### PR TITLE
fix(amd): stop ROCm YUV↔RGB frame corruption under full pipeline (#252)

### DIFF
--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -596,14 +596,17 @@ class NvidiaVideoReader:
         color_range = AvColorRange.JPEG if self._full_range else AvColorRange.MPEG
         H, W = self.height, self.width
 
-        # Pinned host batch is shared. Device staging strategy is vendor-gated:
-        # NVIDIA keeps one staging frame on a private stream (H2D+convert ordered
-        # so the next overwrite starts only after the prior kernel consumed it).
-        # AMD (issue #252 / Phase 0): allocate device YUV for the full batch and
-        # convert on current_stream. Isolated D1 was clean; residual glitches are
-        # pipeline-contended. Per-frame staging reuse under multi-thread load can
-        # race; batch staging removes overwrite races. Extra VRAM ≈
-        # (batch_size - 1) × (1.5 × H × W × bytes) — a few MiB at batch 4 @ 1080p8.
+        # Pinned host batch is shared. Device staging is gated on
+        # AcceleratorVendor.AMD (not "if not NVIDIA") so Intel/CPU keep the
+        # historical single-staging private-stream fallback unless AMD-specific.
+        # NVIDIA: one staging frame on a private stream (H2D+convert ordered so
+        # the next overwrite starts only after the prior kernel consumed it).
+        # AMD (issue #252): batch device YUV on current_stream. Isolated D1 was
+        # clean; residual glitches are pipeline-contended (Phase 0). Per-frame
+        # staging reuse under multi-thread load can race; batch staging removes
+        # overwrite races. Phase 4 on gfx1201 cleared full-pipeline static.
+        # Extra VRAM ≈ (batch_size - 1) × (1.5 × H × W × bytes) — a few MiB at
+        # batch 4 @ 1080p8.
         pinned = torch.empty((self.batch_size, H + H // 2, W), dtype=dtype, pin_memory=True)
         amd_path = self.vendor is AcceleratorVendor.AMD
         if amd_path:

--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -596,13 +596,24 @@ class NvidiaVideoReader:
         color_range = AvColorRange.JPEG if self._full_range else AvColorRange.MPEG
         H, W = self.height, self.width
 
-        # One packed pinned host batch and one packed device staging frame bound
-        # the fallback's extra memory: H2D copies and conversion kernels are
-        # ordered on the same stream, so the next H2D overwrite of the staging
-        # frame starts only after the prior conversion kernel consumed it.
+        # Pinned host batch is shared. Device staging strategy is vendor-gated:
+        # NVIDIA keeps one staging frame on a private stream (H2D+convert ordered
+        # so the next overwrite starts only after the prior kernel consumed it).
+        # AMD (issue #252 / Phase 0): allocate device YUV for the full batch and
+        # convert on current_stream. Isolated D1 was clean; residual glitches are
+        # pipeline-contended. Per-frame staging reuse under multi-thread load can
+        # race; batch staging removes overwrite races. Extra VRAM ≈
+        # (batch_size - 1) × (1.5 × H × W × bytes) — a few MiB at batch 4 @ 1080p8.
         pinned = torch.empty((self.batch_size, H + H // 2, W), dtype=dtype, pin_memory=True)
-        staging = torch.empty((H + H // 2, W), dtype=dtype, device=self.device)
-        stream = new_stream(self.device)
+        amd_path = self.vendor is AcceleratorVendor.AMD
+        if amd_path:
+            device_yuv = torch.empty(
+                (self.batch_size, H + H // 2, W), dtype=dtype, device=self.device
+            )
+            stream = current_stream(self.device)
+        else:
+            staging = torch.empty((H + H // 2, W), dtype=dtype, device=self.device)
+            stream = new_stream(self.device)
 
         while group:
             batch = torch.empty((len(group), 3, H, W), device=self.device, dtype=torch.uint8)
@@ -632,13 +643,25 @@ class NvidiaVideoReader:
                 pinned[i, H:].copy_(uv)
 
             with stream_context(stream):
-                for i in range(len(group)):
-                    staging.copy_(pinned[i], non_blocking=True)
-                    converter.convert_into(
-                        staging[:H], staging[H:].view(H // 2, W // 2, 2), batch[i]
-                    )
+                if amd_path:
+                    for i in range(len(group)):
+                        device_yuv[i].copy_(pinned[i], non_blocking=True)
+                    for i in range(len(group)):
+                        plane = device_yuv[i]
+                        converter.convert_into(
+                            plane[:H],
+                            plane[H:].view(H // 2, W // 2, 2),
+                            batch[i],
+                        )
+                else:
+                    for i in range(len(group)):
+                        staging.copy_(pinned[i], non_blocking=True)
+                        converter.convert_into(
+                            staging[:H], staging[H:].view(H // 2, W // 2, 2), batch[i]
+                        )
 
             next_group = self._read_group(decoded)
+            # Sync before yield so other pipeline threads never see in-flight planes.
             stream.synchronize()
             group = next_group
             yield batch, pts

--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -608,13 +608,14 @@ class NvidiaVideoReader:
         # Extra VRAM ≈ (batch_size - 1) × (1.5 × H × W × bytes) — a few MiB at
         # batch 4 @ 1080p8.
         pinned = torch.empty((self.batch_size, H + H // 2, W), dtype=dtype, pin_memory=True)
-        amd_path = self.vendor is AcceleratorVendor.AMD
-        if amd_path:
+        if self.vendor is AcceleratorVendor.AMD:
             device_yuv = torch.empty(
                 (self.batch_size, H + H // 2, W), dtype=dtype, device=self.device
             )
+            staging = None
             stream = current_stream(self.device)
         else:
+            device_yuv = None
             staging = torch.empty((H + H // 2, W), dtype=dtype, device=self.device)
             stream = new_stream(self.device)
 
@@ -646,22 +647,18 @@ class NvidiaVideoReader:
                 pinned[i, H:].copy_(uv)
 
             with stream_context(stream):
-                if amd_path:
-                    for i in range(len(group)):
-                        device_yuv[i].copy_(pinned[i], non_blocking=True)
-                    for i in range(len(group)):
-                        plane = device_yuv[i]
-                        converter.convert_into(
-                            plane[:H],
-                            plane[H:].view(H // 2, W // 2, 2),
-                            batch[i],
-                        )
-                else:
-                    for i in range(len(group)):
-                        staging.copy_(pinned[i], non_blocking=True)
-                        converter.convert_into(
-                            staging[:H], staging[H:].view(H // 2, W // 2, 2), batch[i]
-                        )
+                # Shared copy/convert loop: AMD uses a per-frame plane from the
+                # batch device buffer; NVIDIA reuses the single staging frame
+                # (H2D + convert ordered on the private stream so the next
+                # overwrite starts only after the prior kernel consumed it).
+                for i in range(len(group)):
+                    plane = staging if staging is not None else device_yuv[i]
+                    plane.copy_(pinned[i], non_blocking=True)
+                    converter.convert_into(
+                        plane[:H],
+                        plane[H:].view(H // 2, W // 2, 2),
+                        batch[i],
+                    )
 
             next_group = self._read_group(decoded)
             # Sync before yield so other pipeline threads never see in-flight planes.

--- a/jasna/media/video_encoder.py
+++ b/jasna/media/video_encoder.py
@@ -815,12 +815,12 @@ class NvidiaVideoEncoder:
                 )
 
         if self.vendor is AcceleratorVendor.AMD:
-            # Issue #252 / Phase 0: isolated E1/E2 were clean; residual glitches
-            # under full pipeline load matched AMF reading host planes while a
-            # non-blocking D2H was still in flight. Finish convert on the stream,
-            # then blocking-copy into pinned host so from_dlpack sees complete
-            # planes. Prefer stream sync over full device.synchronize(); escalate
-            # only if post-fix P1 still glitches.
+            # Issue #252: isolated E1/E2 were clean; residual glitches under full
+            # pipeline load matched AMF reading host planes while a non-blocking
+            # D2H was still in flight. Finish convert on the stream, then
+            # blocking-copy into pinned host so from_dlpack sees complete planes.
+            # Phase 4 (gfx1201): stream.synchronize() + blocking copy cleared P1;
+            # do not escalate to full device.synchronize() unless field reports return.
             self.stream.synchronize()
             self._host_yuv.copy_(
                 _amf_host_input(packed, ten_bit=self.spec.ten_bit),

--- a/jasna/media/video_encoder.py
+++ b/jasna/media/video_encoder.py
@@ -764,8 +764,8 @@ class NvidiaVideoEncoder:
     def _packed_frame(self, height: int, width: int) -> torch.Tensor:
         # NVENC takes the device frame by pointer and still owns it after
         # encode() returns, so NVIDIA hands it a fresh one every time. AMF has
-        # no zero-copy path: the AMD branch below copies this buffer into pinned
-        # host memory and synchronizes, so one buffer can serve every frame.
+        # no zero-copy path: the AMD branch synchronizes then blocking-copies
+        # this buffer into pinned host memory, so one buffer can serve every frame.
         if self._packed is not None:
             return self._packed
         return torch.empty(
@@ -813,14 +813,19 @@ class NvidiaVideoEncoder:
                     stream=self.stream.cuda_stream,
                     cuda_context=self._cuda_ctx,
                 )
-            else:
-                self._host_yuv.copy_(
-                    _amf_host_input(packed, ten_bit=self.spec.ten_bit),
-                    non_blocking=True,
-                )
 
         if self.vendor is AcceleratorVendor.AMD:
+            # Issue #252 / Phase 0: isolated E1/E2 were clean; residual glitches
+            # under full pipeline load matched AMF reading host planes while a
+            # non-blocking D2H was still in flight. Finish convert on the stream,
+            # then blocking-copy into pinned host so from_dlpack sees complete
+            # planes. Prefer stream sync over full device.synchronize(); escalate
+            # only if post-fix P1 still glitches.
             self.stream.synchronize()
+            self._host_yuv.copy_(
+                _amf_host_input(packed, ten_bit=self.spec.ten_bit),
+                non_blocking=False,
+            )
             planes = [self._host_yuv[:height], self._host_yuv[height:]]
             hw_frame = av.VideoFrame.from_dlpack(
                 planes,

--- a/tests/test_video_decoder_amd_path.py
+++ b/tests/test_video_decoder_amd_path.py
@@ -1,0 +1,191 @@
+"""Structural contracts for the AMD software-decode color path (issue #252).
+
+These tests do not prove bit-perfect ROCm correctness under full pipeline load
+(see Phase 0 / Phase 4). They lock vendor segregation: batch device YUV +
+current_stream + sync-before-yield on AMD; single staging + private stream on
+NVIDIA software fallback.
+"""
+from __future__ import annotations
+
+from contextlib import nullcontext
+from fractions import Fraction
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import av
+import numpy as np
+import torch
+from av.video.reformatter import Colorspace as AvColorspace, ColorRange as AvColorRange
+
+import jasna.media.video_decoder as module
+from jasna.accelerator import AcceleratorVendor
+from jasna.media import VideoMetadata
+
+H, W = 8, 8
+BATCH = 3
+
+
+def _metadata() -> VideoMetadata:
+    return VideoMetadata(
+        video_file="soft.mkv",
+        video_height=H,
+        video_width=W,
+        video_fps=12.0,
+        average_fps=12.0,
+        video_fps_exact=Fraction(12, 1),
+        codec_name="ffv1",
+        duration=1.0,
+        time_base=Fraction(1, 12),
+        start_pts=0,
+        color_range=AvColorRange.MPEG,
+        color_space=AvColorspace.ITU709,
+        num_frames=BATCH,
+        is_10bit=False,
+    )
+
+
+class _Plane:
+    """Minimal plane stand-in for torch.frombuffer + line_size."""
+
+    def __init__(self, rows: int, cols: int):
+        self.line_size = cols
+        self._buf = bytearray(rows * cols)
+
+    def __buffer__(self, flags):
+        return memoryview(self._buf)
+
+
+def _fake_normalized_frame():
+    y = _Plane(H, W)
+    uv = _Plane(H // 2, W)  # NV12 interleaved UV rows
+    return SimpleNamespace(planes=(y, uv))
+
+
+def _cpu_group(n: int = BATCH) -> list:
+    """Lightweight av frames; reformatter is mocked so content is unused."""
+    frames = []
+    for i in range(n):
+        data = np.zeros((H * 3 // 2, W), dtype=np.uint8)
+        frame = av.VideoFrame.from_ndarray(data, format="yuv420p")
+        frame.pts = i
+        frames.append(frame)
+    return frames
+
+
+def _reader(vendor: AcceleratorVendor) -> module.NvidiaVideoReader:
+    reader = module.NvidiaVideoReader(
+        "soft.mkv",
+        BATCH,
+        torch.device("cpu"),
+        _metadata(),
+    )
+    reader.vendor = vendor
+    reader.height = H
+    reader.width = W
+    reader._full_range = False
+    return reader
+
+
+def _run_software_batch(
+    monkeypatch,
+    vendor: AcceleratorVendor,
+    *,
+    events: list,
+    luma_ptrs: list,
+):
+    reader = _reader(vendor)
+
+    def convert_into(y, uv, out):
+        events.append("convert")
+        luma_ptrs.append(y.data_ptr())
+
+    monkeypatch.setattr(
+        module,
+        "YuvToRgbConverter",
+        lambda *args, **kwargs: SimpleNamespace(convert_into=convert_into),
+    )
+    monkeypatch.setattr(
+        module,
+        "VideoReformatter",
+        lambda: SimpleNamespace(reformat=lambda *a, **k: _fake_normalized_frame()),
+    )
+
+    stream = MagicMock(name=f"{vendor.value}_stream")
+    stream.synchronize.side_effect = lambda: events.append("sync")
+
+    current_calls: list = []
+    new_calls: list = []
+
+    def current_stream(_device):
+        current_calls.append(True)
+        return stream
+
+    def new_stream(_device):
+        new_calls.append(True)
+        return stream
+
+    monkeypatch.setattr(module, "current_stream", current_stream)
+    monkeypatch.setattr(module, "new_stream", new_stream)
+    monkeypatch.setattr(module, "stream_context", lambda _s: nullcontext())
+    monkeypatch.setattr(reader, "_read_group", lambda _decoded: [])
+
+    # Avoid pin_memory hard requirements on exotic hosts.
+    real_empty = torch.empty
+
+    def empty_no_pin(*args, **kwargs):
+        kwargs.pop("pin_memory", None)
+        return real_empty(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "empty", empty_no_pin)
+
+    group = _cpu_group(BATCH)
+    batches = list(reader._frames_software(None, group))
+    return batches, stream, current_calls, new_calls
+
+
+def test_amd_software_path_uses_batch_device_yuv_and_current_stream(monkeypatch):
+    events: list = []
+    luma_ptrs: list = []
+    batches, stream, current_calls, new_calls = _run_software_batch(
+        monkeypatch,
+        AcceleratorVendor.AMD,
+        events=events,
+        luma_ptrs=luma_ptrs,
+    )
+
+    assert len(batches) == 1
+    batch, pts = batches[0]
+    assert batch.shape == (BATCH, 3, H, W)
+    assert pts == list(range(BATCH))
+
+    # Distinct device planes per frame index (not one overwritten staging buffer).
+    assert len(luma_ptrs) == BATCH
+    assert len(set(luma_ptrs)) == BATCH
+
+    assert current_calls, "AMD software path must use current_stream"
+    assert not new_calls, "AMD software path must not open a private new_stream"
+
+    # Sync before yield: all converts complete, then one synchronize, then yield.
+    assert events == ["convert"] * BATCH + ["sync"]
+    stream.synchronize.assert_called_once_with()
+
+
+def test_nvidia_software_path_reuses_single_staging_on_private_stream(monkeypatch):
+    events: list = []
+    luma_ptrs: list = []
+    batches, stream, current_calls, new_calls = _run_software_batch(
+        monkeypatch,
+        AcceleratorVendor.NVIDIA,
+        events=events,
+        luma_ptrs=luma_ptrs,
+    )
+
+    assert len(batches) == 1
+    assert len(luma_ptrs) == BATCH
+    # Same staging object reused for every frame index.
+    assert len(set(luma_ptrs)) == 1
+
+    assert new_calls, "NVIDIA software fallback must use a private new_stream"
+    assert not current_calls, "NVIDIA software fallback must not switch to current_stream"
+    assert events == ["convert"] * BATCH + ["sync"]
+    stream.synchronize.assert_called_once_with()

--- a/tests/test_video_encoder_unit.py
+++ b/tests/test_video_encoder_unit.py
@@ -535,6 +535,8 @@ class TestEncodeBuffer:
         self, tmp_path, monkeypatch
     ):
         enc = _make_encoder(tmp_path, codec="hevc", video_width=2, video_height=2)
+        # Force NVIDIA contracts even when the host GPU is AMD/ROCm.
+        enc.vendor = video_encoder_module.AcceleratorVendor.NVIDIA
         enc.stream = MagicMock()
         enc.stream.cuda_stream = 1234
         enc._cuda_ctx = object()
@@ -553,7 +555,10 @@ class TestEncodeBuffer:
             "VideoFrame",
             SimpleNamespace(from_dlpack=from_dlpack),
         )
-        monkeypatch.setattr(video_encoder_module.torch.cuda, "stream", lambda stream: nullcontext())
+        monkeypatch.setattr(
+            video_encoder_module, "stream_context", lambda _stream: nullcontext()
+        )
+        monkeypatch.setattr(video_encoder_module, "_align_yuv_pitch", lambda p: p)
 
         enc._encode_frame(torch.zeros((3, 2, 2), dtype=torch.uint8), 7)
 
@@ -571,7 +576,14 @@ class TestEncodeBuffer:
         enc = _make_encoder(tmp_path, codec="h264", video_width=2, video_height=2)
         enc.vendor = video_encoder_module.AcceleratorVendor.AMD
         enc.stream = MagicMock()
-        enc._host_yuv = torch.empty((3, 2), dtype=torch.uint8)
+        order: list = []
+        enc.stream.synchronize = MagicMock(side_effect=lambda: order.append("sync"))
+        enc._host_yuv = MagicMock(name="host_yuv")
+
+        def _track_copy(*args, **kwargs):
+            order.append(("copy", kwargs.get("non_blocking")))
+
+        enc._host_yuv.copy_ = MagicMock(side_effect=_track_copy)
         enc._packed = torch.zeros((3, 2), dtype=torch.uint8)
         enc._lut_applier = None
         enc._converter = SimpleNamespace(
@@ -595,6 +607,11 @@ class TestEncodeBuffer:
         enc._encode_frame(torch.zeros((3, 2, 2), dtype=torch.uint8), 7)
 
         enc.stream.synchronize.assert_called_once_with()
+        enc._host_yuv.copy_.assert_called_once()
+        _, copy_kwargs = enc._host_yuv.copy_.call_args
+        assert copy_kwargs.get("non_blocking") is False
+        # Finish device work before filling host planes AMF will read (issue #252).
+        assert order == ["sync", ("copy", False)]
         _, kwargs = from_dlpack.call_args
         assert kwargs == {"format": "nv12"}
 


### PR DESCRIPTION
# fix(amd): stop ROCm YUV↔RGB frame corruption under full pipeline (#252)

## Summary

Residual colored-static / torn-block corruption on AMD ROCm (gfx1201 and similar) after the v0.9.1 partial fix (`YuvScratch` reuse + `expandable_segments:False`). Isolated convert paths were already bit-clean; the failure was **pipeline-contended** (decode staging reuse + AMF host read racing non-blocking D2H).

This PR hardens **only AMD** GPU color paths. NVIDIA fused kernels, private streams, and NVENC/dlpack behavior stay unchanged.

Closes #252 (glitch residual). AMF HEVC open-option quirks, if any remain, are out of scope.

## Changes

### Decode (`jasna/media/video_decoder.py`) — AMD software path only

- Allocate **device YUV for the full batch** instead of one reused staging frame.
- Run H2D + `convert_into` on **`current_stream`** (match encode/restorer).
- Keep **stream.synchronize()** before yielding RGB.
- NVIDIA software fallback: single staging + private `new_stream` unchanged.

### Encode (`jasna/media/video_encoder.py`) — AMD AMF path only

- After RGB→YUV on `current_stream`: **`stream.synchronize()`**, then **blocking** `copy_(..., non_blocking=False)` into pinned `_host_yuv`, then `from_dlpack`.
- Prefer stream sync over full `device.synchronize()` — Phase 4 P1 cleared without escalation.
- NVIDIA: device dlpack with stream/context, no host YUV, no pre-encode sync.

### Tests

- `tests/test_video_decoder_amd_path.py` — distinct batch planes + current_stream on AMD; single staging + private stream on NVIDIA; sync-before-yield.
- `tests/test_video_encoder_unit.py` — AMD order `sync → blocking copy → from_dlpack`; NVIDIA no host sync (vendor forced for multi-vendor CI).

### Tooling / evidence (not required to run product)

- `scripts/amd_color_isolation.py` — D1/D2/E1/E2/M1/A1/P1 isolation harness.
- `PHASE_0.md` — pre-fix residual confirmed on gfx1201.
- `PHASE_4.md` — post-fix P1 clean on same box.
- `FIX_AMD.md` — plan + decisions.

## Validation matrix (Windows 11 + RX 9070 XT / gfx1201)

| Case | Phase 0 (pre-fix) | Phase 4 (this PR) |
|------|---------------------|-------------------|
| D1 decode vs CPU ref | PASS (diff 0) | PASS |
| D2 staging vs batch YUV | PASS both | PASS |
| E1 encode host transfer | PASS | PASS |
| E2 sync/copy modes | PASS all | PASS |
| M1 multi-thread convert | PASS | PASS |
| A1 empty_cache defaults | PASS | PASS |
| **P1 full restore** `test_clip1_1080p` h264 AMF | **FAIL** ~22/300 hard static | **PASS** 0 hard static / 0 HF outliers |
| Throughput (steady-state) | ~1.1–2.3 fps | ~1.1–2.8 fps (no large drop) |
| Page-not-present faults | none | none |
| NVIDIA hardware | n/a this box | n/a; unit contracts green |

## Explicit non-goals

- No CPU YUV↔RGB product path.
- No HIP fused-kernel port.
- No force-overwrite of user `PYTORCH_*_ALLOC_CONF` (still `setdefault`).
- No HEVC AMF option rework.

## Test plan

- [x] Unit: `tests/test_video_decoder_amd_path.py` + encoder AMD/NVIDIA contracts + `test_yuv_scratch_reuse.py`
- [x] Hardware Phase 4 P1 on gfx1201 (see `PHASE_4.md`)
- [ ] Optional: Linux ROCm re-run when available
- [ ] Optional: NVIDIA smoke of same clip if a green box is free


[amd_color_isolation.py](https://github.com/user-attachments/files/30506975/amd_color_isolation.py)
[FIX_AMD.md](https://github.com/user-attachments/files/30506977/FIX_AMD.md)
[PHASE_0.md](https://github.com/user-attachments/files/30506978/PHASE_0.md)
[PHASE_4.md](https://github.com/user-attachments/files/30506980/PHASE_4.md)

Before Fix
<img width="1920" height="1080" alt="suspect_0004" src="https://github.com/user-attachments/assets/af85433a-e5ba-4095-9bf7-9f4a2dd60b23" />
<img width="1920" height="1080" alt="suspect_0006" src="https://github.com/user-attachments/assets/9f266670-848c-438c-8179-fda423b84ba1" />

After Fix
<img width="1920" height="1080" alt="frame_0004" src="https://github.com/user-attachments/assets/25dcc45f-fdde-4e20-b0e0-6bac2b837458" />
<img width="1920" height="1080" alt="frame_0122" src="https://github.com/user-attachments/assets/9891ee6b-f157-4070-a32c-0d8796d879d7" />
