### PR TITLE
perf(amd): add native rocDecode backend

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -87,8 +87,11 @@ For Nvidia library builds, you also need:
 uv pip install cmake ninja
 ```
 
-Linux AMD source builds use rocDecode for large HEVC/AV1 inputs. Install the
-development package matching the active ROCm release (for example
+Linux AMD source builds use rocDecode for large HEVC/AV1 inputs and for every
+Main10 HEVC input. AMF can open Main10 HEVC on Linux, but its P010 surface
+cannot be transferred through PyAV; when rocDecode is unavailable this case
+uses explicit FFmpeg software decoding instead of the incompatible AMF path.
+Install the development package matching the active ROCm release (for example
 `rocdecode-dev` from the same ROCm 7.2.1 repository). If it is absent or the
 native bridge cannot build, Jasna logs the reason once and permanently falls
 back to its AMF/software reader for that video. A non-root development install
@@ -192,14 +195,15 @@ python jasna/protection/keytool/build_windows_amd.py
 ```
 
 The AMD build uses PyTorch/ROCm for BasicVSR++, YOLO and RF-DETR, rocDecode for
-large HEVC/AV1 decode, and AMF for encode and decode fallback. RF-DETR runs the trained checkpoint through the
+large HEVC/AV1 decode and every Main10 HEVC input, and AMF for encode and
+compatible decode fallback. RF-DETR runs the trained checkpoint through the
 `rfdetr` torch model (`rfdetr==1.8.3` on `transformers==5.1.0`, bundled as
 `rfdetr-v6.pt`) — no ONNX Runtime/MIGraphX, so no
 per-model engine precompile step. NVIDIA builds keep the ONNX → TensorRT path
 (`rfdetr-v6.onnx`). rocDecode keeps PyAV demux timestamps and copies each internal
 surface device-to-device into Torch-owned NV12/P010 memory before release. Small
-inputs and unsupported codecs remain on PyAV; failures fall back to AMF or FFmpeg
-software decoding. Secondary restoration and segment smart rendering remain
+8-bit and AV1 inputs and unsupported codecs remain on PyAV; failures fall back
+to AMF or FFmpeg software decoding. Secondary restoration and segment smart rendering remain
 NVIDIA-only.
 
 `--device cuda:N` selects the PyTorch GPU (ROCm reuses the CUDA device API).

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -87,6 +87,14 @@ For Nvidia library builds, you also need:
 uv pip install cmake ninja
 ```
 
+Linux AMD source builds use rocDecode for large HEVC/AV1 inputs. Install the
+development package matching the active ROCm release (for example
+`rocdecode-dev` from the same ROCm 7.2.1 repository). If it is absent or the
+native bridge cannot build, Jasna logs the reason once and permanently falls
+back to its AMF/software reader for that video. A non-root development install
+may instead place `include/rocdecode` and `share/rocdecode/utils/rocvideodecode`
+under `$XDG_DATA_HOME/jasna/rocdecode-sdk`.
+
 Developer setup also requires:
 
 - `ffmpeg` and `ffprobe` on `PATH`; `ffmpeg` major version must be **8**.
@@ -183,13 +191,15 @@ jasna/protection/keytool/validate_amd_ssh.sh user@amd-host
 python jasna/protection/keytool/build_windows_amd.py
 ```
 
-The AMD build uses PyTorch/ROCm for BasicVSR++, YOLO and RF-DETR, and AMF for
-H.264/HEVC/AV1 decode and encode. RF-DETR runs the trained checkpoint through the
+The AMD build uses PyTorch/ROCm for BasicVSR++, YOLO and RF-DETR, rocDecode for
+large HEVC/AV1 decode, and AMF for encode and decode fallback. RF-DETR runs the trained checkpoint through the
 `rfdetr` torch model (`rfdetr==1.8.3` on `transformers==5.1.0`, bundled as
 `rfdetr-v6.pt`) — no ONNX Runtime/MIGraphX, so no
 per-model engine precompile step. NVIDIA builds keep the ONNX → TensorRT path
-(`rfdetr-v6.onnx`). Decode falls back to FFmpeg software decoding when AMF cannot
-handle the source. Secondary restoration and segment smart rendering remain
+(`rfdetr-v6.onnx`). rocDecode keeps PyAV demux timestamps and copies each internal
+surface device-to-device into Torch-owned NV12/P010 memory before release. Small
+inputs and unsupported codecs remain on PyAV; failures fall back to AMF or FFmpeg
+software decoding. Secondary restoration and segment smart rendering remain
 NVIDIA-only.
 
 `--device cuda:N` selects the PyTorch GPU (ROCm reuses the CUDA device API).

--- a/jasna/media/rocdecode.py
+++ b/jasna/media/rocdecode.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+
+_CODECS = {"h264": 3, "hevc": 4, "av1": 5, "vp9": 7}
+_BUILD_LOCK = threading.Lock()
+_LIBRARY: ctypes.CDLL | None = None
+_LOAD_ERROR: Exception | None = None
+_HELPER_PATCH_VERSION = "jasna-rocdecode-parse-errors-v1"
+_HELPER_PARSE_ERROR_BLOCK = """    if (rocDecParseVideoData(rocdec_parser_, &packet) != ROCDEC_SUCCESS) {
+        ROCDEC_ERR(\"Error occurred in rocDecParseVideoData().\");
+    }"""
+_HELPER_PARSE_EXCEPTION_BLOCK = """    const rocDecStatus parse_status = rocDecParseVideoData(rocdec_parser_, &packet);
+    if (parse_status != ROCDEC_SUCCESS) {
+        std::ostringstream error_log;
+        error_log << \"rocDecParseVideoData() returned \"
+                  << rocDecGetErrorName(parse_status);
+        ROCDEC_THROW(error_log.str(), parse_status);
+    }"""
+_TERMINAL_STATUS_NAMES = (
+    "ROCDEC_DEVICE_INVALID",
+    "ROCDEC_CONTEXT_INVALID",
+    "ROCDEC_RUNTIME_ERROR",
+    "ROCDEC_OUTOF_MEMORY",
+)
+
+
+class RocDecodeError(RuntimeError):
+    pass
+
+
+def is_terminal_rocdecode_error(error: BaseException) -> bool:
+    """Return whether continuing in the current GPU context is unsafe."""
+    message = str(error).upper()
+    if any(status in message for status in _TERMINAL_STATUS_NAMES):
+        return True
+    return "HIP" in message and (
+        "HIPERROROUTOFMEMORY" in message or "OUT OF MEMORY" in message
+    )
+
+
+def _patch_helper_source(source: str) -> str:
+    if source.count(_HELPER_PARSE_ERROR_BLOCK) != 1:
+        raise RocDecodeError(
+            "unsupported rocDecode helper source: expected the log-only "
+            "rocDecParseVideoData() failure block exactly once"
+        )
+    return source.replace(
+        _HELPER_PARSE_ERROR_BLOCK,
+        _HELPER_PARSE_EXCEPTION_BLOCK,
+        1,
+    )
+
+
+def _library_cache_key(root: Path, paths: tuple[Path, ...]) -> str:
+    digest = hashlib.sha256()
+    digest.update(_HELPER_PATCH_VERSION.encode())
+    for path in paths:
+        digest.update(path.read_bytes())
+    digest.update(str(root).encode())
+    return digest.hexdigest()[:16]
+
+
+def _sdk_root() -> Path:
+    override = os.environ.get("JASNA_ROCDECODE_SDK_PATH")
+    user_data = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local/share"))
+    candidates = (
+        [Path(override)]
+        if override
+        else [Path("/opt/rocm"), user_data / "jasna/rocdecode-sdk"]
+    )
+    for root in candidates:
+        root = root.resolve()
+        if (
+            (root / "include/rocdecode/rocdecode.h").is_file()
+            and (root / "share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp").is_file()
+        ):
+            return root
+    raise RocDecodeError(
+        "rocDecode development files are unavailable; install the rocdecode-dev "
+        "package matching the active ROCm version or provide a local SDK at "
+        "$XDG_DATA_HOME/jasna/rocdecode-sdk"
+    )
+
+
+def _build_library() -> Path:
+    root = _sdk_root()
+    source = Path(__file__).with_name("rocdecode_bridge.cpp")
+    helper_dir = root / "share/rocdecode/utils/rocvideodecode"
+    helper_source = helper_dir / "roc_video_dec.cpp"
+    runtime_root = Path(os.environ.get("ROCM_PATH", "/opt/rocm")).resolve()
+    compiler = runtime_root / "lib/llvm/bin/amdclang++"
+    if not compiler.is_file():
+        raise RocDecodeError(f"ROCm C++ compiler is unavailable: {compiler}")
+
+    helper_header = helper_dir / "roc_video_dec.h"
+    key = _library_cache_key(root, (source, helper_source, helper_header))
+    cache = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "jasna/native"
+    output = cache / f"rocdecode_bridge_{key}.so"
+    if output.is_file():
+        return output
+
+    cache.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="jasna-rocdecode-", dir=cache) as temporary:
+        temporary_path = Path(temporary)
+        staged = temporary_path / output.name
+        patched_helper_source = temporary_path / "roc_video_dec.cpp"
+        patched_helper_source.write_text(
+            _patch_helper_source(helper_source.read_text(encoding="utf-8")),
+            encoding="utf-8",
+        )
+        command = [
+            str(compiler),
+            "-std=c++17",
+            "-O3",
+            "-DNDEBUG",
+            "-D__HIP_PLATFORM_AMD__=1",
+            "-include",
+            "cmath",
+            "-fPIC",
+            "-shared",
+            str(source),
+            str(patched_helper_source),
+            f"-I{root / 'include'}",
+            f"-I{runtime_root / 'include'}",
+            f"-I{helper_dir}",
+            f"-L{runtime_root / 'lib'}",
+            f"-Wl,-rpath,{runtime_root / 'lib'}",
+            "-l:librocdecode.so.1",
+            "-lamdhip64",
+            "-pthread",
+            "-o",
+            str(staged),
+        ]
+        completed = subprocess.run(command, text=True, capture_output=True, check=False)
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout).strip()
+            raise RocDecodeError(f"failed to build rocDecode bridge: {detail}")
+        os.replace(staged, output)
+    return output
+
+
+def _configure_library(library: ctypes.CDLL) -> None:
+    library.jasna_rocdecode_create.argtypes = [ctypes.c_int, ctypes.c_int]
+    library.jasna_rocdecode_create.restype = ctypes.c_void_p
+    library.jasna_rocdecode_destroy.argtypes = [ctypes.c_void_p]
+    library.jasna_rocdecode_destroy.restype = None
+    library.jasna_rocdecode_error.argtypes = [ctypes.c_void_p]
+    library.jasna_rocdecode_error.restype = ctypes.c_char_p
+    library.jasna_rocdecode_decode.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_uint8),
+        ctypes.c_size_t,
+        ctypes.c_int64,
+        ctypes.c_int,
+        ctypes.POINTER(ctypes.c_int),
+    ]
+    library.jasna_rocdecode_decode.restype = ctypes.c_int
+    library.jasna_rocdecode_copy_frame.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_int64),
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+    library.jasna_rocdecode_copy_frame.restype = ctypes.c_int
+    library.jasna_rocdecode_drop_frame.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_int64),
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+    library.jasna_rocdecode_drop_frame.restype = ctypes.c_int
+
+
+def load_rocdecode_bridge() -> ctypes.CDLL:
+    global _LIBRARY, _LOAD_ERROR
+    if _LIBRARY is not None:
+        return _LIBRARY
+    if _LOAD_ERROR is not None:
+        raise RocDecodeError(str(_LOAD_ERROR)) from _LOAD_ERROR
+    with _BUILD_LOCK:
+        if _LIBRARY is not None:
+            return _LIBRARY
+        try:
+            library = ctypes.CDLL(str(_build_library()))
+            _configure_library(library)
+            _LIBRARY = library
+        except Exception as error:
+            _LOAD_ERROR = error
+            raise RocDecodeError(str(error)) from error
+    return _LIBRARY
+
+
+class RocDecoder:
+    def __init__(self, device_id: int, codec_name: str):
+        self._handle = None
+        codec = _CODECS.get(codec_name.lower())
+        if codec is None:
+            raise RocDecodeError(f"rocDecode does not support codec {codec_name!r}")
+        self._library = load_rocdecode_bridge()
+        self._handle = self._library.jasna_rocdecode_create(device_id, codec)
+        if not self._handle:
+            raise RocDecodeError(self._error(None))
+
+    def _error(self, handle=None) -> str:
+        raw = self._library.jasna_rocdecode_error(
+            self._handle if handle is None and hasattr(self, "_handle") else handle
+        )
+        return raw.decode(errors="replace") if raw else "unknown rocDecode error"
+
+    def decode(self, packet=None, pts: int = 0) -> int:
+        if self._handle is None:
+            raise RocDecodeError("rocDecode decoder is closed")
+        available = ctypes.c_int()
+        owner = None
+        pointer = None
+        size = 0
+        if packet is not None:
+            view = memoryview(packet)
+            size = view.nbytes
+            owner = (
+                (ctypes.c_uint8 * size).from_buffer(view)
+                if view.contiguous and not view.readonly
+                else (ctypes.c_uint8 * size).from_buffer_copy(view)
+            )
+            pointer = ctypes.cast(owner, ctypes.POINTER(ctypes.c_uint8))
+        status = self._library.jasna_rocdecode_decode(
+            self._handle,
+            pointer,
+            size,
+            int(pts),
+            int(packet is None),
+            ctypes.byref(available),
+        )
+        if status != 0:
+            raise RocDecodeError(self._error())
+        return available.value
+
+    def copy_frame_into(self, destination) -> tuple[int, int, int, int]:
+        if self._handle is None:
+            raise RocDecodeError("rocDecode decoder is closed")
+        pts = ctypes.c_int64()
+        width = ctypes.c_uint32()
+        height = ctypes.c_uint32()
+        bit_depth = ctypes.c_uint32()
+        status = self._library.jasna_rocdecode_copy_frame(
+            self._handle,
+            ctypes.c_void_p(destination.data_ptr()),
+            destination.numel() * destination.element_size(),
+            ctypes.byref(pts),
+            ctypes.byref(width),
+            ctypes.byref(height),
+            ctypes.byref(bit_depth),
+        )
+        if status != 0:
+            raise RocDecodeError(self._error())
+        return pts.value, width.value, height.value, bit_depth.value
+
+    def drop_frame(self) -> tuple[int, int, int, int]:
+        if self._handle is None:
+            raise RocDecodeError("rocDecode decoder is closed")
+        pts = ctypes.c_int64()
+        width = ctypes.c_uint32()
+        height = ctypes.c_uint32()
+        bit_depth = ctypes.c_uint32()
+        status = self._library.jasna_rocdecode_drop_frame(
+            self._handle,
+            ctypes.byref(pts),
+            ctypes.byref(width),
+            ctypes.byref(height),
+            ctypes.byref(bit_depth),
+        )
+        if status != 0:
+            raise RocDecodeError(self._error())
+        return pts.value, width.value, height.value, bit_depth.value
+
+    def close(self) -> None:
+        if getattr(self, "_handle", None) is not None:
+            self._library.jasna_rocdecode_destroy(self._handle)
+            self._handle = None
+
+    def __del__(self):
+        self.close()
+
+
+def rocdecode_supported_codec(codec_name: str) -> bool:
+    return sys.platform.startswith("linux") and codec_name.lower() in _CODECS

--- a/jasna/media/rocdecode_bridge.cpp
+++ b/jasna/media/rocdecode_bridge.cpp
@@ -1,0 +1,258 @@
+/*
+Copyright (c) 2026 Jasna contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <hip/hip_runtime.h>
+#include "roc_video_dec.h"
+
+namespace {
+
+struct Bridge {
+    explicit Bridge(int device_id, rocDecVideoCodec codec)
+        : decoder(std::make_unique<RocVideoDecoder>(
+              device_id, OUT_SURFACE_MEM_DEV_INTERNAL, codec)) {
+        const hipError_t status =
+            hipStreamCreateWithFlags(&copy_stream, hipStreamNonBlocking);
+        if (status != hipSuccess) {
+            throw std::runtime_error(
+                std::string("HIP copy stream creation failed: ") +
+                hipGetErrorString(status));
+        }
+    }
+
+    ~Bridge() {
+        if (copy_stream) {
+            (void)hipStreamDestroy(copy_stream);
+        }
+    }
+
+    std::unique_ptr<RocVideoDecoder> decoder;
+    hipStream_t copy_stream = nullptr;
+    std::string error;
+};
+
+thread_local std::string construction_error;
+
+void set_error(Bridge *bridge, const char *message) {
+    if (bridge) {
+        bridge->error = message ? message : "unknown rocDecode bridge error";
+    } else {
+        construction_error = message ? message : "unknown rocDecode bridge error";
+    }
+}
+
+template <typename Function>
+int guarded(Bridge *bridge, Function &&function) {
+    try {
+        if (bridge) {
+            bridge->error.clear();
+        }
+        function();
+        return 0;
+    } catch (const std::exception &error) {
+        set_error(bridge, error.what());
+    } catch (...) {
+        set_error(bridge, "unknown C++ exception");
+    }
+    return -1;
+}
+
+}  // namespace
+
+extern "C" {
+
+void *jasna_rocdecode_create(int device_id, int codec) {
+    construction_error.clear();
+    try {
+        return new Bridge(device_id, static_cast<rocDecVideoCodec>(codec));
+    } catch (const std::exception &error) {
+        set_error(nullptr, error.what());
+    } catch (...) {
+        set_error(nullptr, "unknown C++ exception while creating rocDecode");
+    }
+    return nullptr;
+}
+
+void jasna_rocdecode_destroy(void *opaque) {
+    delete static_cast<Bridge *>(opaque);
+}
+
+const char *jasna_rocdecode_error(void *opaque) {
+    auto *bridge = static_cast<Bridge *>(opaque);
+    return bridge ? bridge->error.c_str() : construction_error.c_str();
+}
+
+int jasna_rocdecode_decode(
+    void *opaque,
+    const uint8_t *data,
+    size_t size,
+    int64_t pts,
+    int end_of_stream,
+    int *frames_available
+) {
+    auto *bridge = static_cast<Bridge *>(opaque);
+    if (!bridge || !frames_available) {
+        set_error(bridge, "invalid decode arguments");
+        return -1;
+    }
+    return guarded(bridge, [&] {
+        *frames_available = bridge->decoder->DecodeFrame(
+            end_of_stream ? nullptr : data,
+            end_of_stream ? 0 : size,
+            0,
+            pts
+        );
+    });
+}
+
+int jasna_rocdecode_copy_frame(
+    void *opaque,
+    uint8_t *destination,
+    size_t destination_size,
+    int64_t *pts,
+    uint32_t *width,
+    uint32_t *height,
+    uint32_t *bit_depth
+) {
+    auto *bridge = static_cast<Bridge *>(opaque);
+    if (!bridge || !destination || !pts || !width || !height || !bit_depth) {
+        set_error(bridge, "invalid frame-copy arguments");
+        return -1;
+    }
+    return guarded(bridge, [&] {
+        int64_t frame_pts = 0;
+        uint8_t *source = bridge->decoder->GetFrame(&frame_pts);
+        if (!source) {
+            throw std::runtime_error("rocDecode returned no frame surface");
+        }
+
+        OutputSurfaceInfo *info = nullptr;
+        if (!bridge->decoder->GetOutputSurfaceInfo(&info) || !info) {
+            bridge->decoder->ReleaseFrame(frame_pts);
+            throw std::runtime_error("rocDecode returned no surface metadata");
+        }
+        if (info->surface_format != rocDecVideoSurfaceFormat_NV12 &&
+            info->surface_format != rocDecVideoSurfaceFormat_P016) {
+            bridge->decoder->ReleaseFrame(frame_pts);
+            throw std::runtime_error("rocDecode output is not NV12/P016");
+        }
+
+        const size_t row_bytes =
+            static_cast<size_t>(info->output_width) * info->bytes_per_pixel;
+        const size_t packed_size = row_bytes *
+            (static_cast<size_t>(info->output_height) + info->chroma_height);
+        if (destination_size < packed_size) {
+            bridge->decoder->ReleaseFrame(frame_pts);
+            throw std::runtime_error("Torch destination is smaller than rocDecode output");
+        }
+
+        hipError_t status = hipMemcpy2DAsync(
+            destination,
+            row_bytes,
+            source,
+            info->output_pitch,
+            row_bytes,
+            info->output_height,
+            hipMemcpyDeviceToDevice,
+            bridge->copy_stream
+        );
+        bool copy_queued = status == hipSuccess;
+        if (status == hipSuccess) {
+            const uint8_t *source_uv = source +
+                static_cast<size_t>(info->output_pitch) * info->output_vstride;
+            uint8_t *destination_uv = destination + row_bytes * info->output_height;
+            const hipError_t uv_status = hipMemcpy2DAsync(
+                destination_uv,
+                row_bytes,
+                source_uv,
+                info->output_pitch,
+                row_bytes,
+                info->chroma_height,
+                hipMemcpyDeviceToDevice,
+                bridge->copy_stream
+            );
+            if (uv_status != hipSuccess) {
+                status = uv_status;
+            }
+        }
+        if (copy_queued) {
+            const hipError_t sync_status =
+                hipStreamSynchronize(bridge->copy_stream);
+            if (status == hipSuccess && sync_status != hipSuccess) {
+                status = sync_status;
+            }
+        }
+        const bool released = bridge->decoder->ReleaseFrame(frame_pts);
+        if (status != hipSuccess) {
+            throw std::runtime_error(
+                std::string("HIP surface copy failed: ") + hipGetErrorString(status));
+        }
+        if (!released) {
+            throw std::runtime_error("rocDecode surface release failed");
+        }
+
+        *pts = frame_pts;
+        *width = info->output_width;
+        *height = info->output_height;
+        *bit_depth = info->bit_depth;
+    });
+}
+
+int jasna_rocdecode_drop_frame(
+    void *opaque,
+    int64_t *pts,
+    uint32_t *width,
+    uint32_t *height,
+    uint32_t *bit_depth
+) {
+    auto *bridge = static_cast<Bridge *>(opaque);
+    if (!bridge || !pts || !width || !height || !bit_depth) {
+        set_error(bridge, "invalid frame-drop arguments");
+        return -1;
+    }
+    return guarded(bridge, [&] {
+        int64_t frame_pts = 0;
+        uint8_t *source = bridge->decoder->GetFrame(&frame_pts);
+        if (!source) {
+            throw std::runtime_error("rocDecode returned no frame surface");
+        }
+        OutputSurfaceInfo *info = nullptr;
+        if (!bridge->decoder->GetOutputSurfaceInfo(&info) || !info) {
+            bridge->decoder->ReleaseFrame(frame_pts);
+            throw std::runtime_error("rocDecode returned no surface metadata");
+        }
+        if (!bridge->decoder->ReleaseFrame(frame_pts)) {
+            throw std::runtime_error("rocDecode surface release failed");
+        }
+        *pts = frame_pts;
+        *width = info->output_width;
+        *height = info->output_height;
+        *bit_depth = info->bit_depth;
+    });
+}
+
+}  // extern "C"

--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -61,6 +61,44 @@ class VideoDecodeError(RuntimeError):
     pass
 
 
+def _requires_software_pyav_fallback(
+    metadata: VideoMetadata,
+    vendor: AcceleratorVendor,
+) -> bool:
+    """Return whether AMF cannot safely replace a failed native decoder."""
+
+    return (
+        sys.platform == "linux"
+        and vendor is AcceleratorVendor.AMD
+        and str(metadata.codec_name).lower() == "hevc"
+        and bool(metadata.is_10bit)
+    )
+
+
+def _should_auto_rocdecode(
+    metadata: VideoMetadata,
+    vendor: AcceleratorVendor,
+) -> bool:
+    if (
+        not ROCDECODE_AUTO_ENABLED
+        or sys.platform != "linux"
+        or vendor is not AcceleratorVendor.AMD
+    ):
+        return False
+    codec_name = str(metadata.codec_name).lower()
+    if codec_name not in _ROCDECODE_AUTO_CODECS:
+        return False
+    if _requires_software_pyav_fallback(metadata, vendor):
+        # Linux AMF can open Main10 HEVC, but PyAV cannot transfer the P010
+        # surface to host memory. Prefer rocDecode even below the normal
+        # performance threshold so this route remains functional.
+        return True
+    return (
+        int(metadata.video_width) * int(metadata.video_height)
+        >= _ROCDECODE_AUTO_MIN_PIXELS
+    )
+
+
 def _decode_backend() -> str:
     backend = os.environ.get(DECODE_BACKEND_ENV, DECODE_BACKEND)
     if backend not in _DECODE_BACKENDS:
@@ -461,11 +499,7 @@ class NvidiaVideoReader:
                 raise VideoDecodeError("The VALI decode backend requires an NVIDIA device")
         if backend == "rocdecode" or (
             backend == "auto"
-            and ROCDECODE_AUTO_ENABLED
-            and self.vendor is AcceleratorVendor.AMD
-            and str(self.metadata.codec_name).lower() in _ROCDECODE_AUTO_CODECS
-            and int(self.metadata.video_width) * int(self.metadata.video_height)
-            >= _ROCDECODE_AUTO_MIN_PIXELS
+            and _should_auto_rocdecode(self.metadata, self.vendor)
         ):
             if self.vendor is not AcceleratorVendor.AMD:
                 raise VideoDecodeError("The rocDecode backend requires an AMD device")
@@ -490,18 +524,33 @@ class NvidiaVideoReader:
                         ) from exc
                     if backend == "rocdecode":
                         raise VideoDecodeError(f"rocDecode cannot open {self.file}: {exc}") from exc
+                    fallback_name = (
+                        "FFmpeg software decoding"
+                        if _requires_software_pyav_fallback(
+                            self.metadata,
+                            self.vendor,
+                        )
+                        else "PyAV"
+                    )
                     log.warning(
-                        "rocDecode cannot open %s (codec %s): %s; falling back to PyAV",
+                        "rocDecode cannot open %s (codec %s): %s; falling back to %s",
                         self.file,
                         self.metadata.codec_name,
                         exc,
+                        fallback_name,
                     )
                 else:
                     self.width = self._rocdecode_source.width
                     self.height = self._rocdecode_source.height
                     log.info("Using rocDecode hardware decoder for %s", self.file)
                     return self
-        self._open_pyav(backend)
+        pyav_backend = (
+            "pyav-sw"
+            if backend == "auto"
+            and _requires_software_pyav_fallback(self.metadata, self.vendor)
+            else backend
+        )
+        self._open_pyav(pyav_backend)
         return self
 
     def _open_pyav(self, backend: str) -> None:
@@ -764,7 +813,12 @@ class NvidiaVideoReader:
                 )
                 source.close()
                 self._rocdecode_source = None
-                self._open_pyav("auto")
+                fallback_backend = (
+                    "pyav-sw"
+                    if _requires_software_pyav_fallback(self.metadata, self.vendor)
+                    else "auto"
+                )
+                self._open_pyav(fallback_backend)
                 yield from self._frames_pyav(seek_ts, after_pts=last_pts)
                 return
         yield from self._frames_pyav(seek_ts)

--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -17,6 +17,12 @@ from jasna.accelerator import (
     vendor_for_device,
 )
 from jasna.media import VideoMetadata, resolve_video_start_pts
+from jasna.media.rocdecode import (
+    RocDecodeError,
+    RocDecoder,
+    is_terminal_rocdecode_error,
+    rocdecode_supported_codec,
+)
 from jasna.media.yuv_to_rgb import YuvToRgbConverter
 
 log = logging.getLogger(__name__)
@@ -27,13 +33,21 @@ _libcuda: ctypes.CDLL | None = None
 # Decode backend selection (`JASNA_DECODE_BACKEND` overrides the default):
 # - "auto":    NVIDIA tries VALI first and falls back to PyAV hwaccel, then PyAV
 #              software, when VALI cannot open or decode the first frame. AMD
-#              keeps its AMF -> software escalation.
+#              tries rocDecode when enabled, then keeps its AMF -> software
+#              escalation.
 # - "vali":    VALI only; any failure raises (NVIDIA only).
+# - "rocdecode": rocDecode only; any failure raises (Linux AMD only).
 # - "pyav-hw": skip VALI, use the PyAV hwaccel path with its software fallback.
 # - "pyav-sw": force FFmpeg software decoding with GPU upload on every vendor.
 DECODE_BACKEND = "auto"
 DECODE_BACKEND_ENV = "JASNA_DECODE_BACKEND"
-_DECODE_BACKENDS = ("auto", "vali", "pyav-hw", "pyav-sw")
+_DECODE_BACKENDS = ("auto", "vali", "rocdecode", "pyav-hw", "pyav-sw")
+
+# Enabled after bounded 8/10-bit pixel, PTS and wall-clock acceptance. The
+# explicit backend remains available for evaluating codecs outside auto routing.
+ROCDECODE_AUTO_ENABLED = True
+_ROCDECODE_AUTO_CODECS = frozenset({"hevc", "av1"})
+_ROCDECODE_AUTO_MIN_PIXELS = 30_000_000
 
 # PyAV's avcodec_find_decoder returns libdav1d for AV1, which carries no NVDEC
 # hwaccel config, so av.open silently decodes AV1 in software. Force the native
@@ -230,6 +244,162 @@ class _ValiFrameSource:
             raise RuntimeError(f"cuStreamDestroy failed (CUDA error {result})")
 
 
+class _RocDecodeFrameSource:
+    """PyAV demux with rocDecode surfaces copied into Torch-owned GPU memory."""
+
+    _BITSTREAM_FILTERS = {
+        "h264": "h264_mp4toannexb",
+        "hevc": "hevc_mp4toannexb",
+    }
+
+    def __init__(
+        self,
+        file: str,
+        batch_size: int,
+        device: torch.device,
+        metadata: VideoMetadata,
+        frame_stride: int,
+    ):
+        self.file = file
+        self.batch_size = batch_size
+        self.device = device
+        self.metadata = metadata
+        self.frame_stride = frame_stride
+        self.container = None
+        self.decoder = None
+        self._used = False
+        try:
+            self.container = av.open(file)
+            self.video_stream = self.container.streams.video[0]
+            codec = str(metadata.codec_name).lower()
+            filter_name = self._BITSTREAM_FILTERS.get(codec)
+            self.bitstream_filter = (
+                av.BitStreamFilterContext(filter_name, self.video_stream)
+                if filter_name is not None
+                else None
+            )
+            self.decoder = RocDecoder(device.index or 0, codec)
+            self.width = int(metadata.video_width)
+            self.height = int(metadata.video_height)
+            self._full_range = (
+                self.video_stream.codec_context.color_range == int(AvColorRange.JPEG)
+                or metadata.color_range == AvColorRange.JPEG
+            )
+        except BaseException:
+            self.close()
+            raise
+
+    @property
+    def start_pts(self) -> int:
+        return resolve_video_start_pts(self.video_stream.start_time, self.metadata.start_pts)
+
+    def _packets(self):
+        for packet in self.container.demux(self.video_stream):
+            if packet.size <= 0:
+                continue
+            if self.bitstream_filter is None:
+                yield packet
+            else:
+                yield from self.bitstream_filter.filter(packet)
+        if self.bitstream_filter is not None:
+            yield from self.bitstream_filter.filter(None)
+
+    def _decode_counts(self):
+        for packet in self._packets():
+            packet_pts = packet.pts if packet.pts is not None else packet.dts
+            yield self.decoder.decode(packet, 0 if packet_pts is None else packet_pts)
+        yield self.decoder.decode(None)
+
+    def frames(self, seek_ts: float | None) -> Iterator[tuple[torch.Tensor, list[int]]]:
+        if self._used:
+            raise RocDecodeError("a rocDecode frame source can only be consumed once")
+        self._used = True
+        if seek_ts is not None:
+            target_pts = self.start_pts + round(seek_ts / self.video_stream.time_base)
+            self.container.seek(target_pts, stream=self.video_stream, backward=True)
+            if self.bitstream_filter is not None:
+                self.bitstream_filter.flush()
+        else:
+            target_pts = None
+
+        dtype = torch.uint16 if self.metadata.is_10bit else torch.uint8
+        packed = torch.empty(
+            (self.batch_size + 1, self.height + self.height // 2, self.width),
+            dtype=dtype,
+            device=self.device,
+        )
+        converter = YuvToRgbConverter(
+            self.height,
+            self.width,
+            self.metadata.color_space,
+            self._full_range,
+            self.metadata.is_10bit,
+            self.device,
+        )
+        frame_index = 0
+        selected_pts: list[int] = []
+
+        for available in self._decode_counts():
+            for _ in range(available):
+                waiting_for_target = target_pts is not None
+                selected = not waiting_for_target and frame_index % self.frame_stride == 0
+                if not waiting_for_target and not selected:
+                    pts, width, height, bit_depth = self.decoder.drop_frame()
+                else:
+                    destination = packed[0] if waiting_for_target else packed[len(selected_pts)]
+                    pts, width, height, bit_depth = self.decoder.copy_frame_into(destination)
+                if (width, height) != (self.width, self.height):
+                    raise RocDecodeError(
+                        f"rocDecode dimensions changed to {width}x{height}; "
+                        f"expected {self.width}x{self.height}"
+                    )
+                expected_depth = 10 if self.metadata.is_10bit else 8
+                if bit_depth != expected_depth:
+                    raise RocDecodeError(
+                        f"rocDecode bit depth changed to {bit_depth}; expected {expected_depth}"
+                    )
+                if target_pts is not None and pts < target_pts:
+                    continue
+                if target_pts is not None:
+                    target_pts = None
+                    frame_index = 0
+                    selected = True
+                frame_index += 1
+                if not selected:
+                    continue
+                selected_pts.append(pts)
+                if len(selected_pts) == self.batch_size:
+                    yield self._convert_group(packed, converter, selected_pts)
+                    selected_pts = []
+
+        if selected_pts:
+            yield self._convert_group(packed, converter, selected_pts)
+
+    def _convert_group(self, packed, converter, pts):
+        batch = torch.empty(
+            (len(pts), 3, self.height, self.width),
+            dtype=torch.uint8,
+            device=self.device,
+        )
+        for index in range(len(pts)):
+            surface = packed[index]
+            y = surface[: self.height]
+            uv = surface[self.height :].view(self.height // 2, self.width // 2, 2)
+            converter.convert_into(y, uv, batch[index])
+        # Conversion kernels are asynchronous; synchronize before the batch
+        # crosses the producer/consumer thread boundary.
+        current_stream(self.device).synchronize()
+        return batch, list(pts)
+
+    def close(self) -> None:
+        if self.decoder is not None:
+            decoder, self.decoder = self.decoder, None
+            decoder.close()
+        if self.container is not None:
+            container, self.container = self.container, None
+            container.close()
+
+
 class NvidiaVideoReader:
     def __init__(
         self,
@@ -252,14 +422,17 @@ class NvidiaVideoReader:
         self._decoder_ctx = None
         self._amd_hardware_decode = False
         self._vali_source: _ValiFrameSource | None = None
+        self._rocdecode_source: _RocDecodeFrameSource | None = None
         self._software_only = False
 
     def __enter__(self):
         self._decoder_ctx = None
         self._amd_hardware_decode = False
         self._vali_source = None
+        self._rocdecode_source = None
         current_stream(self.device)
         backend = _decode_backend()
+        self._decode_backend = backend
         if backend in ("auto", "vali"):
             if self.vendor is AcceleratorVendor.NVIDIA:
                 try:
@@ -286,6 +459,52 @@ class NvidiaVideoReader:
                     return self
             elif backend == "vali":
                 raise VideoDecodeError("The VALI decode backend requires an NVIDIA device")
+        if backend == "rocdecode" or (
+            backend == "auto"
+            and ROCDECODE_AUTO_ENABLED
+            and self.vendor is AcceleratorVendor.AMD
+            and str(self.metadata.codec_name).lower() in _ROCDECODE_AUTO_CODECS
+            and int(self.metadata.video_width) * int(self.metadata.video_height)
+            >= _ROCDECODE_AUTO_MIN_PIXELS
+        ):
+            if self.vendor is not AcceleratorVendor.AMD:
+                raise VideoDecodeError("The rocDecode backend requires an AMD device")
+            if not rocdecode_supported_codec(str(self.metadata.codec_name)):
+                if backend == "rocdecode":
+                    raise VideoDecodeError(
+                        f"rocDecode does not support codec {self.metadata.codec_name}"
+                    )
+            else:
+                try:
+                    self._rocdecode_source = _RocDecodeFrameSource(
+                        self.file,
+                        self.batch_size,
+                        self.device,
+                        self.metadata,
+                        self.frame_stride,
+                    )
+                except (OSError, RuntimeError, ValueError, RocDecodeError) as exc:
+                    if is_terminal_rocdecode_error(exc):
+                        raise VideoDecodeError(
+                            f"rocDecode entered a fatal runtime state for {self.file}: {exc}"
+                        ) from exc
+                    if backend == "rocdecode":
+                        raise VideoDecodeError(f"rocDecode cannot open {self.file}: {exc}") from exc
+                    log.warning(
+                        "rocDecode cannot open %s (codec %s): %s; falling back to PyAV",
+                        self.file,
+                        self.metadata.codec_name,
+                        exc,
+                    )
+                else:
+                    self.width = self._rocdecode_source.width
+                    self.height = self._rocdecode_source.height
+                    log.info("Using rocDecode hardware decoder for %s", self.file)
+                    return self
+        self._open_pyav(backend)
+        return self
+
+    def _open_pyav(self, backend: str) -> None:
         software_only = backend == "pyav-sw"
         self._software_only = software_only
         try:
@@ -326,12 +545,13 @@ class NvidiaVideoReader:
             or self.metadata.color_range == AvColorRange.JPEG
         )
         self._raw_stream: int | None = None
-        return self
 
     @property
     def start_pts(self) -> int:
-        if self._vali_source is not None:
+        if getattr(self, "_vali_source", None) is not None:
             return resolve_video_start_pts(None, self.metadata.start_pts)
+        if getattr(self, "_rocdecode_source", None) is not None:
+            return self._rocdecode_source.start_pts
         return resolve_video_start_pts(
             self.video_stream.start_time,
             self.metadata.start_pts,
@@ -364,7 +584,8 @@ class NvidiaVideoReader:
             # PyAV 18 rejects assigning time_base on a decoder ("Cannot access
             # 'time_base' as a decoder"); decoders take timing from packets.
             decoder.framerate = source_ctx.framerate
-            decoder.sample_aspect_ratio = source_ctx.sample_aspect_ratio
+            if source_ctx.sample_aspect_ratio is not None:
+                decoder.sample_aspect_ratio = source_ctx.sample_aspect_ratio
             decoder.open(strict=False)
             self._decoder_ctx = decoder
             self._amd_hardware_decode = True
@@ -434,6 +655,10 @@ class NvidiaVideoReader:
     def __exit__(self, exc_type, exc_value, traceback):
         if self._vali_source is not None:
             source, self._vali_source = self._vali_source, None
+            source.close()
+            return
+        if self._rocdecode_source is not None:
+            source, self._rocdecode_source = self._rocdecode_source, None
             source.close()
             return
         self.container.close()
@@ -511,14 +736,64 @@ class NvidiaVideoReader:
         # With seek_ts, strided selection re-anchors at the first decoded frame
         # after the seek instead of the start of the file: sample phase is only
         # stable relative to the seek target.
-        if self._vali_source is not None:
+        if getattr(self, "_vali_source", None) is not None:
             yield from self._vali_source.frames(seek_ts)
             return
+        if getattr(self, "_rocdecode_source", None) is not None:
+            source = self._rocdecode_source
+            last_pts = None
+            try:
+                for batch, pts in source.frames(seek_ts):
+                    yield batch, pts
+                    if pts:
+                        last_pts = pts[-1]
+                return
+            except (OSError, RuntimeError, ValueError, RocDecodeError) as exc:
+                if is_terminal_rocdecode_error(exc):
+                    source.close()
+                    self._rocdecode_source = None
+                    raise VideoDecodeError(
+                        f"rocDecode entered a fatal runtime state for {self.file}: {exc}"
+                    ) from exc
+                if getattr(self, "_decode_backend", DECODE_BACKEND) == "rocdecode":
+                    raise VideoDecodeError(f"rocDecode failed for {self.file}: {exc}") from exc
+                log.warning(
+                    "rocDecode failed while decoding %s: %s; permanently falling back to PyAV",
+                    self.file,
+                    exc,
+                )
+                source.close()
+                self._rocdecode_source = None
+                self._open_pyav("auto")
+                yield from self._frames_pyav(seek_ts, after_pts=last_pts)
+                return
+        yield from self._frames_pyav(seek_ts)
+
+    def _frames_pyav(
+        self,
+        seek_ts: float | None,
+        *,
+        after_pts: int | None = None,
+    ) -> Iterator[tuple[torch.Tensor, list[int]]]:
         # The first decoded frame's format is the final backend decision: a codec
         # can advertise a CUDA config and still fall back to software when
         # hardware initialization rejects a profile or pixel format. Dispatch
         # once here so neither per-frame loop carries a backend branch.
-        decoded = self._selected_frames(self._decoded_frames(seek_ts))
+        decoded_frames = self._decoded_frames(seek_ts)
+        if after_pts is not None:
+            decoded_frames = (
+                frame
+                for frame in decoded_frames
+                if frame.pts is None or frame.pts > after_pts
+            )
+        if after_pts is not None and self.frame_stride > 1:
+            decoded = (
+                frame
+                for index, frame in enumerate(decoded_frames, start=1)
+                if index % self.frame_stride == 0
+            )
+        else:
+            decoded = self._selected_frames(decoded_frames)
         group = self._read_group(decoded)
         if not group:
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,9 @@ dev = [
 [tool.setuptools]
 include-package-data = false
 
+[tool.setuptools.package-data]
+"jasna.media" = ["rocdecode_bridge.cpp"]
+
 [tool.setuptools.packages.find]
 include = ["jasna*"]
 exclude = ["jasna.protection.keytool*", "jasna.protection.tests*"]

--- a/tests/test_rocdecode.py
+++ b/tests/test_rocdecode.py
@@ -1,7 +1,9 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from jasna.accelerator import AcceleratorVendor
 from jasna.media.rocdecode import (
     RocDecodeError,
     _HELPER_PARSE_ERROR_BLOCK,
@@ -10,6 +12,10 @@ from jasna.media.rocdecode import (
     _patch_helper_source,
     is_terminal_rocdecode_error,
     rocdecode_supported_codec,
+)
+from jasna.media.video_decoder import (
+    _requires_software_pyav_fallback,
+    _should_auto_rocdecode,
 )
 
 
@@ -60,3 +66,57 @@ def test_codec_support_is_linux_only(monkeypatch) -> None:
 
     monkeypatch.setattr("jasna.media.rocdecode.sys.platform", "win32")
     assert not rocdecode_supported_codec("hevc")
+
+
+def _metadata(
+    *,
+    codec_name: str = "hevc",
+    is_10bit: bool = False,
+    width: int = 1920,
+    height: int = 1080,
+):
+    return SimpleNamespace(
+        codec_name=codec_name,
+        is_10bit=is_10bit,
+        video_width=width,
+        video_height=height,
+    )
+
+
+def test_auto_rocdecode_covers_small_linux_amd_main10_hevc(monkeypatch) -> None:
+    monkeypatch.setattr("jasna.media.video_decoder.sys.platform", "linux")
+
+    metadata = _metadata(is_10bit=True)
+
+    assert _should_auto_rocdecode(metadata, AcceleratorVendor.AMD)
+    assert _requires_software_pyav_fallback(metadata, AcceleratorVendor.AMD)
+
+
+@pytest.mark.parametrize(
+    ("metadata", "vendor", "expected"),
+    [
+        (_metadata(), AcceleratorVendor.AMD, False),
+        (_metadata(width=8192, height=4096), AcceleratorVendor.AMD, True),
+        (_metadata(codec_name="av1", is_10bit=True), AcceleratorVendor.AMD, False),
+        (_metadata(codec_name="av1", width=8192, height=4096), AcceleratorVendor.AMD, True),
+        (_metadata(is_10bit=True), AcceleratorVendor.NVIDIA, False),
+    ],
+)
+def test_auto_rocdecode_keeps_existing_threshold_for_other_inputs(
+    monkeypatch,
+    metadata,
+    vendor,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr("jasna.media.video_decoder.sys.platform", "linux")
+
+    assert _should_auto_rocdecode(metadata, vendor) is expected
+
+
+def test_auto_rocdecode_does_not_change_windows_amd(monkeypatch) -> None:
+    monkeypatch.setattr("jasna.media.video_decoder.sys.platform", "win32")
+
+    metadata = _metadata(is_10bit=True, width=8192, height=4096)
+
+    assert not _should_auto_rocdecode(metadata, AcceleratorVendor.AMD)
+    assert not _requires_software_pyav_fallback(metadata, AcceleratorVendor.AMD)

--- a/tests/test_rocdecode.py
+++ b/tests/test_rocdecode.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import pytest
+
+from jasna.media.rocdecode import (
+    RocDecodeError,
+    _HELPER_PARSE_ERROR_BLOCK,
+    _HELPER_PARSE_EXCEPTION_BLOCK,
+    _library_cache_key,
+    _patch_helper_source,
+    is_terminal_rocdecode_error,
+    rocdecode_supported_codec,
+)
+
+
+def test_helper_patch_turns_log_only_parse_failure_into_exception() -> None:
+    source = f"before\n{_HELPER_PARSE_ERROR_BLOCK}\nafter\n"
+
+    patched = _patch_helper_source(source)
+
+    assert _HELPER_PARSE_ERROR_BLOCK not in patched
+    assert _HELPER_PARSE_EXCEPTION_BLOCK in patched
+
+
+@pytest.mark.parametrize("source", ["", _HELPER_PARSE_ERROR_BLOCK * 2])
+def test_helper_patch_rejects_unknown_or_ambiguous_sdk_source(source: str) -> None:
+    with pytest.raises(RocDecodeError, match="expected the log-only"):
+        _patch_helper_source(source)
+
+
+def test_library_cache_key_tracks_bridge_sdk_and_patch_version(tmp_path: Path) -> None:
+    first = tmp_path / "first.cpp"
+    second = tmp_path / "second.h"
+    first.write_bytes(b"bridge-v1")
+    second.write_bytes(b"sdk-v1")
+    initial = _library_cache_key(tmp_path, (first, second))
+
+    second.write_bytes(b"sdk-v2")
+
+    assert _library_cache_key(tmp_path, (first, second)) != initial
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "ROCDEC_DEVICE_INVALID",
+        "ROCDEC_CONTEXT_INVALID during parse",
+        "HIP error: hipErrorOutOfMemory",
+        "HIP runtime is out of memory",
+    ],
+)
+def test_terminal_runtime_errors_are_not_safe_to_fallback(message: str) -> None:
+    assert is_terminal_rocdecode_error(RuntimeError(message))
+
+
+def test_codec_support_is_linux_only(monkeypatch) -> None:
+    monkeypatch.setattr("jasna.media.rocdecode.sys.platform", "linux")
+    assert rocdecode_supported_codec("HEVC")
+    assert not rocdecode_supported_codec("mpeg2video")
+
+    monkeypatch.setattr("jasna.media.rocdecode.sys.platform", "win32")
+    assert not rocdecode_supported_codec("hevc")


### PR DESCRIPTION
# Native rocDecode backend for Linux AMD

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/300#issuecomment-5312154536).

## Summary

This candidate adds a Linux AMD rocDecode reader while keeping PyAV demux,
source integer PTS and existing fallbacks. Internal decoder surfaces are copied
device-to-device into Torch-owned NV12/P010 memory before release, avoiding the
AMF host-transfer bottleneck and lifetime ambiguity.

Large HEVC/AV1 inputs use rocDecode automatically. Main10 HEVC also uses it at
smaller resolutions because Linux AMF opens that stream but PyAV cannot transfer
the P010 surface. If rocDecode is unavailable for Main10 HEVC, the code selects
explicit FFmpeg software decoding instead of retrying the incompatible AMF path.

## Changes

- add a small C++ bridge built against the installed rocDecode SDK;
- retain PyAV packet demux and exact PTS while rocDecode owns video surfaces;
- support 8/10-bit HEVC and AV1, seek, stride and bounded non-terminal fallback;
- classify device/context/OOM failures as terminal rather than continuing in a
  damaged native runtime;
- package the bridge source for source/release builds;
- route every Linux AMD Main10 HEVC input through rocDecode.

## Scope and compatibility

- Public branch: `perf/linux-amd-rocdecode` (`a6af248`, after `9a1b967`).
- Base: `upstream/main`; independently mergeable.
- NVIDIA and Windows do not enter the Linux AMD routing guard.
- Requires matching rocDecode development files at build/run time; the code
  documents the system and per-user SDK locations.
- Smart-span decoder reuse is a separate dependent follow-up.

## Validation

- Focused rocDecode/backend tests: 36 passed, 1 hardware-dependent skip.
- New real regression: 3840x1920 Main10 HEVC, 480/480 frames. Automatic routing
  selected rocDecode and preserved first/last PTS; forcing a missing SDK selected
  explicit software decoding and produced a valid first batch.
- Integrated 8192x4096 HEVC Smart Render selected two rocDecode readers, retained
  1200/1200 video and 940/940 AAC packets and passed strict complete decode.
- Earlier bounded RX 7900 XTX comparisons measured 61.20 vs 23.03 fps for 8-bit
  HEVC, 57.80 vs 14.79 fps for Main10 HEVC and 65.88 vs 34.99 fps for 8K AV1,
  with compared PTS/RGB values equal.

## Test request

No NVIDIA hardware behavior should change, but the maintainer should run the
normal NVIDIA decoder suite because this PR touches the shared reader class.