### PR TITLE
perf(amd): optimize ROCm preprocessing

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -192,6 +192,12 @@ per-model engine precompile step. NVIDIA builds keep the ONNX → TensorRT path
 handle the source. Secondary restoration and segment smart rendering remain
 NVIDIA-only.
 
+On ROCm, detector resize/letterbox/normalization uses a fused Triton kernel and
+falls back to the equivalent Torch expression if Triton is unavailable. Equal,
+long BasicVSR++ clips may also share a model batch; an out-of-memory retry runs
+the clips individually. Both optimizations are AMD-gated, so CUDA/TensorRT
+behavior and batch sizes are unchanged.
+
 `--device cuda:N` selects the PyTorch GPU (ROCm reuses the CUDA device API).
 FFmpeg 8's Linux AMF device context currently ignores its adapter
 argument, so AMF decode/encode can use the default Vulkan adapter on a multi-GPU

--- a/jasna/media/resize_normalize.py
+++ b/jasna/media/resize_normalize.py
@@ -132,7 +132,17 @@ class ResizeNormalizer:
 
                 self._kernel = TritonResizeNormalizeKernel()
                 self._backend = "triton-rocm"
-            except (ImportError, RuntimeError):
+            except ImportError as exc:
+                logger.warning(
+                    "ROCm fused resize-normalize is unavailable; using Torch (%s)",
+                    exc,
+                )
+                logger.debug(
+                    "ROCm fused resize-normalize import failure",
+                    exc_info=True,
+                )
+                self._kernel = None
+            except RuntimeError:
                 logger.warning(
                     "ROCm fused resize-normalize is unavailable; using Torch",
                     exc_info=True,

--- a/jasna/media/resize_normalize.py
+++ b/jasna/media/resize_normalize.py
@@ -10,11 +10,15 @@ caller already had, which is also what the kernel is tested against.
 from __future__ import annotations
 
 import ctypes
+import logging
 
 import torch
+import torch.nn.functional as F
 
-from jasna.accelerator import is_nvidia_device
+from jasna.accelerator import is_amd_device, is_nvidia_device
 from jasna.media.cuda_kernel import check_cuda, cuda_driver, resolve_function
+
+logger = logging.getLogger(__name__)
 
 _FATBIN = "resize_normalize.fatbin"
 _BLOCK_WIDTH = 16
@@ -116,15 +120,34 @@ class ResizeNormalizer:
         self._std = torch.tensor(std, dtype=torch.float32, device=device)
         self._fill = torch.tensor(fill, dtype=torch.float32, device=device)
         function = _FUNCTIONS.get(dtype)
-        self._kernel = (
-            _ResizeNormalizeKernel(function)
-            if function is not None and is_nvidia_device(device)
-            else None
-        )
+        self._backend = "torch"
+        if function is not None and is_nvidia_device(device):
+            self._kernel = _ResizeNormalizeKernel(function)
+            self._backend = "cuda"
+        elif function is not None and is_amd_device(device):
+            try:
+                from jasna.media.triton_resize_normalize import (
+                    TritonResizeNormalizeKernel,
+                )
+
+                self._kernel = TritonResizeNormalizeKernel()
+                self._backend = "triton-rocm"
+            except (ImportError, RuntimeError):
+                logger.warning(
+                    "ROCm fused resize-normalize is unavailable; using Torch",
+                    exc_info=True,
+                )
+                self._kernel = None
+        else:
+            self._kernel = None
 
     @property
     def available(self) -> bool:
         return self._kernel is not None
+
+    @property
+    def backend(self) -> str:
+        return self._backend
 
     def run(
         self,
@@ -133,8 +156,6 @@ class ResizeNormalizer:
         out_hw: tuple[int, int],
         content: tuple[int, int, int, int],
     ) -> torch.Tensor:
-        if self._kernel is None:
-            raise RuntimeError("The fused preprocess requires the CUDA kernel")
         if frames_uint8_bchw.dtype is not torch.uint8:
             raise ValueError(f"Expected a uint8 batch, got {frames_uint8_bchw.dtype}")
         if frames_uint8_bchw.ndim != 4 or frames_uint8_bchw.shape[1] != 3:
@@ -145,9 +166,58 @@ class ResizeNormalizer:
         frames = frames_uint8_bchw
         if frames.device != self.device:
             frames = frames.to(self.device, non_blocking=True)
+        if self._kernel is None:
+            if self._backend == "torch":
+                return self._run_torch(frames, out_hw=out_hw, content=content)
+            raise RuntimeError("The fused preprocess requires the CUDA kernel")
 
         out = torch.empty(
             (frames.shape[0], 3, out_hw[0], out_hw[1]), dtype=self.dtype, device=self.device
         )
-        self._kernel.launch(frames, out, content, self._mean, self._std, self._fill)
+        try:
+            self._kernel.launch(frames, out, content, self._mean, self._std, self._fill)
+        except Exception:
+            if self._backend != "triton-rocm":
+                raise
+            logger.warning(
+                "ROCm fused resize-normalize failed; disabling it for this instance",
+                exc_info=True,
+            )
+            self._kernel = None
+            self._backend = "torch"
+            return self._run_torch(frames, out_hw=out_hw, content=content)
         return out
+
+    def _run_torch(
+        self,
+        frames: torch.Tensor,
+        *,
+        out_hw: tuple[int, int],
+        content: tuple[int, int, int, int],
+    ) -> torch.Tensor:
+        left, top, content_width, content_height = content
+        values = frames.to(device=self.device, dtype=self.dtype).div_(255.0)
+        values = F.interpolate(
+            values,
+            size=(content_height, content_width),
+            mode="bilinear",
+            align_corners=False,
+        )
+        mean = self._mean.to(dtype=self.dtype)[:, None, None]
+        std = self._std.to(dtype=self.dtype)[:, None, None]
+        values = (values - mean) / std
+        if content == (0, 0, out_hw[1], out_hw[0]):
+            return values
+        output = torch.empty(
+            (frames.shape[0], 3, out_hw[0], out_hw[1]),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        output[:] = self._fill.to(dtype=self.dtype)[None, :, None, None]
+        output[
+            :,
+            :,
+            top : top + content_height,
+            left : left + content_width,
+        ] = values
+        return output

--- a/jasna/media/triton_resize_normalize.py
+++ b/jasna/media/triton_resize_normalize.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _resize_normalize_kernel(
+    source,
+    destination,
+    mean,
+    standard_deviation,
+    fill,
+    source_batch_stride: tl.constexpr,
+    source_channel_stride: tl.constexpr,
+    source_row_stride: tl.constexpr,
+    destination_batch_stride: tl.constexpr,
+    destination_channel_stride: tl.constexpr,
+    destination_row_stride: tl.constexpr,
+    batch: tl.constexpr,
+    source_height: tl.constexpr,
+    source_width: tl.constexpr,
+    output_height: tl.constexpr,
+    output_width: tl.constexpr,
+    content_left: tl.constexpr,
+    content_top: tl.constexpr,
+    content_width: tl.constexpr,
+    content_height: tl.constexpr,
+    output_fp16: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    offsets = tl.program_id(0) * block_size + tl.arange(0, block_size)
+    element_count = batch * 3 * output_height * output_width
+    valid = offsets < element_count
+
+    x = offsets % output_width
+    remaining = offsets // output_width
+    y = remaining % output_height
+    remaining = remaining // output_height
+    channel = remaining % 3
+    batch_index = remaining // 3
+
+    local_x = x - content_left
+    local_y = y - content_top
+    inside = (
+        valid
+        & (local_x >= 0)
+        & (local_x < content_width)
+        & (local_y >= 0)
+        & (local_y < content_height)
+    )
+
+    source_x = tl.maximum(
+        (local_x.to(tl.float32) + 0.5) * (source_width / content_width) - 0.5,
+        0.0,
+    )
+    source_y = tl.maximum(
+        (local_y.to(tl.float32) + 0.5) * (source_height / content_height) - 0.5,
+        0.0,
+    )
+    x0 = tl.minimum(tl.floor(source_x).to(tl.int64), source_width - 1)
+    y0 = tl.minimum(tl.floor(source_y).to(tl.int64), source_height - 1)
+    x1 = tl.minimum(x0 + 1, source_width - 1)
+    y1 = tl.minimum(y0 + 1, source_height - 1)
+    wx = source_x - x0.to(tl.float32)
+    wy = source_y - y0.to(tl.float32)
+
+    source_base = (
+        batch_index * source_batch_stride
+        + channel * source_channel_stride
+    )
+    offset00 = source_base + y0 * source_row_stride + x0
+    offset01 = source_base + y0 * source_row_stride + x1
+    offset10 = source_base + y1 * source_row_stride + x0
+    offset11 = source_base + y1 * source_row_stride + x1
+    value00 = tl.load(source + offset00, mask=inside, other=0.0).to(tl.float32) / 255.0
+    value01 = tl.load(source + offset01, mask=inside, other=0.0).to(tl.float32) / 255.0
+    value10 = tl.load(source + offset10, mask=inside, other=0.0).to(tl.float32) / 255.0
+    value11 = tl.load(source + offset11, mask=inside, other=0.0).to(tl.float32) / 255.0
+    if output_fp16:
+        value00 = value00.to(tl.float16).to(tl.float32)
+        value01 = value01.to(tl.float16).to(tl.float32)
+        value10 = value10.to(tl.float16).to(tl.float32)
+        value11 = value11.to(tl.float16).to(tl.float32)
+
+    interpolated = (
+        (1.0 - wy) * ((1.0 - wx) * value00 + wx * value01)
+        + wy * ((1.0 - wx) * value10 + wx * value11)
+    )
+    channel_mean = tl.load(mean + channel, mask=valid, other=0.0)
+    channel_std = tl.load(standard_deviation + channel, mask=valid, other=1.0)
+    if output_fp16:
+        interpolated = interpolated.to(tl.float16).to(tl.float32)
+        channel_mean = channel_mean.to(tl.float16).to(tl.float32)
+        channel_std = channel_std.to(tl.float16).to(tl.float32)
+        normalized = (interpolated - channel_mean).to(tl.float16).to(tl.float32)
+        normalized = (normalized / channel_std).to(tl.float16)
+    else:
+        normalized = (interpolated - channel_mean) / channel_std
+    fill_value = tl.load(fill + channel, mask=valid, other=0.0)
+    result = tl.where(inside, normalized, fill_value)
+
+    destination_offset = (
+        batch_index * destination_batch_stride
+        + channel * destination_channel_stride
+        + y * destination_row_stride
+        + x
+    )
+    tl.store(destination + destination_offset, result, mask=valid)
+
+
+class TritonResizeNormalizeKernel:
+    def launch(
+        self,
+        frames: torch.Tensor,
+        out: torch.Tensor,
+        content: tuple[int, int, int, int],
+        mean: torch.Tensor,
+        std: torch.Tensor,
+        fill: torch.Tensor,
+    ) -> None:
+        batch, _, source_height, source_width = frames.shape
+        output_height, output_width = out.shape[2:]
+        left, top, content_width, content_height = content
+        block_size = 256
+        grid = (triton.cdiv(out.numel(), block_size),)
+        _resize_normalize_kernel[grid](
+            frames,
+            out,
+            mean,
+            std,
+            fill,
+            frames.stride(0),
+            frames.stride(1),
+            frames.stride(2),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            batch,
+            source_height,
+            source_width,
+            output_height,
+            output_width,
+            left,
+            top,
+            content_width,
+            content_height,
+            out.dtype is torch.float16,
+            block_size,
+            num_warps=4,
+        )

--- a/jasna/pipeline_threads.py
+++ b/jasna/pipeline_threads.py
@@ -239,6 +239,11 @@ def primary_restore_loop(
     debug_memory: PipelineDebugMemoryLogger | None = None,
 ) -> None:
     timer = LoopTimer("primary")
+    restored_track_ids: set[int] = set()
+    restoration_clips = 0
+    batched_invocations = 0
+    pending_item: ClipRestoreItem | object | None = None
+    reached_sentinel = False
     try:
         torch.cuda.set_device(device)
         log.debug("[primary] thread starting")
@@ -246,7 +251,10 @@ def primary_restore_loop(
             if cancel_event is not None and cancel_event.is_set():
                 break
             primary_idle_event.set()
-            if cancel_event is not None:
+            if pending_item is not None:
+                item = pending_item
+                pending_item = None
+            elif cancel_event is not None:
                 try:
                     with timer.measure("queue-wait"):
                         item = clip_queue.get(timeout=0.1)
@@ -258,31 +266,101 @@ def primary_restore_loop(
             primary_idle_event.clear()
             if item is _SENTINEL:
                 break
-            clip_item: ClipRestoreItem = item
+
+            clip_items: list[ClipRestoreItem] = [item]
+            batch_limit = getattr(
+                restoration_pipeline, "independent_clip_batch_size", 1
+            )
+            batch_limit = batch_limit if isinstance(batch_limit, int) else 1
+            batch_min_frames = getattr(
+                restoration_pipeline, "independent_clip_batch_min_frames", 0
+            )
+            batch_min_frames = (
+                batch_min_frames if isinstance(batch_min_frames, int) else 0
+            )
+            while (
+                len(clip_items[0].raw_crops) >= max(0, batch_min_frames)
+                and len(clip_items) < max(1, batch_limit)
+            ):
+                try:
+                    candidate = clip_queue.get_nowait()
+                except Empty:
+                    break
+                if candidate is _SENTINEL:
+                    reached_sentinel = True
+                    break
+                if len(candidate.raw_crops) != len(clip_items[0].raw_crops):
+                    pending_item = candidate
+                    break
+                clip_items.append(candidate)
+
+            for clip_item in clip_items:
+                restored_track_ids.add(int(clip_item.clip.track_id))
+            restoration_clips += len(clip_items)
             with timer.measure("restore"):
-                result = restoration_pipeline.prepare_and_run_primary(
-                    clip_item.clip,
-                    clip_item.raw_crops,
-                    clip_item.frame_shape,
-                    clip_item.keep_start,
-                    clip_item.keep_end,
-                    clip_item.crossfade_weights,
-                )
+                if len(clip_items) > 1:
+                    try:
+                        results = restoration_pipeline.prepare_and_run_primary_batch(
+                            clip_items
+                        )
+                        batched_invocations += 1
+                    except torch.cuda.OutOfMemoryError:
+                        log.warning(
+                            "Primary clip batch of %d exceeded VRAM; retrying individually",
+                            len(clip_items),
+                        )
+                        torch.cuda.empty_cache()
+                        results = [
+                            restoration_pipeline.prepare_and_run_primary(
+                                clip_item.clip,
+                                clip_item.raw_crops,
+                                clip_item.frame_shape,
+                                clip_item.keep_start,
+                                clip_item.keep_end,
+                                clip_item.crossfade_weights,
+                            )
+                            for clip_item in clip_items
+                        ]
+                else:
+                    clip_item = clip_items[0]
+                    results = [
+                        restoration_pipeline.prepare_and_run_primary(
+                            clip_item.clip,
+                            clip_item.raw_crops,
+                            clip_item.frame_shape,
+                            clip_item.keep_start,
+                            clip_item.keep_end,
+                            clip_item.crossfade_weights,
+                        )
+                    ]
                 if restoration_pipeline.secondary_prefers_cpu_input:
-                    result.primary_raw = result.primary_raw.cpu()
+                    for result in results:
+                        result.primary_raw = result.primary_raw.cpu()
             with timer.measure("queue-put"):
-                secondary_queue.put(result, frame_count=result.keep_end - result.keep_start)
+                for result in results:
+                    secondary_queue.put(
+                        result, frame_count=result.keep_end - result.keep_start
+                    )
             if debug_memory is not None:
-                debug_memory.snapshot(
-                    "primary",
-                    f"clip={clip_item.clip.track_id} frames={len(clip_item.raw_crops)}",
-                )
+                for clip_item in clip_items:
+                    debug_memory.snapshot(
+                        "primary",
+                        f"clip={clip_item.clip.track_id} frames={len(clip_item.raw_crops)}",
+                    )
+            if reached_sentinel:
+                break
     except BaseException as e:
         if cancel_event is None or not cancel_event.is_set():
             log.exception("[primary] thread crashed")
             error_holder.append(e)
     finally:
         log.info(timer.summary())
+        log.info(
+            "[activity] restoration_clips=%d unique_tracks=%d batched_invocations=%d",
+            restoration_clips,
+            len(restored_track_ids),
+            batched_invocations,
+        )
         log.debug("[primary] thread exiting")
         secondary_queue.put(_SENTINEL)
 

--- a/jasna/restorer/basicvsrpp_mosaic_restorer.py
+++ b/jasna/restorer/basicvsrpp_mosaic_restorer.py
@@ -5,10 +5,12 @@ import torch
 logger = logging.getLogger(__name__)
 from torch import Tensor
 
-from jasna.accelerator import is_nvidia_device
+from jasna.accelerator import is_amd_device, is_nvidia_device
 from jasna.models.basicvsrpp.inference import load_model
 
 INFERENCE_SIZE = 256
+AMD_INDEPENDENT_CLIP_BATCH_SIZE = 2
+AMD_INDEPENDENT_CLIP_BATCH_MIN_FRAMES = 60
 
 
 class BasicvsrppMosaicRestorer:
@@ -50,6 +52,18 @@ class BasicvsrppMosaicRestorer:
             self.model = load_model(config, checkpoint_path, self.device, fp16)
             logger.info("BasicVSR++ loaded from checkpoint: %s (fp16=%s)", checkpoint_path, fp16)
 
+        # Independent long clips can share the model batch dimension on ROCm.
+        # Short one-off shapes are slower because of MIOpen setup overhead. The
+        # TensorRT split path has batch-1 loop-body engines and stays unchanged.
+        if is_amd_device(self.device):
+            self.independent_clip_batch_size = AMD_INDEPENDENT_CLIP_BATCH_SIZE
+            self.independent_clip_batch_min_frames = (
+                AMD_INDEPENDENT_CLIP_BATCH_MIN_FRAMES
+            )
+        else:
+            self.independent_clip_batch_size = 1
+            self.independent_clip_batch_min_frames = 0
+
     def close(self) -> None:
         if self._split_forward is not None:
             self._split_forward.close()
@@ -71,6 +85,27 @@ class BasicvsrppMosaicRestorer:
             else:
                 result = self.model(inputs=stacked.unsqueeze(0))
             return result.squeeze(0)
+
+    def raw_process_batch(self, videos: list[list[Tensor]]) -> list[torch.Tensor]:
+        """Restore equal-length, independent clips in one model invocation."""
+        if not videos:
+            return []
+        frame_count = len(videos[0])
+        if frame_count <= 0 or any(len(video) != frame_count for video in videos):
+            raise ValueError("batched restoration requires equal non-empty clip lengths")
+        if len(videos) == 1 or self._split_forward is not None:
+            return [self.raw_process(video) for video in videos]
+
+        with torch.inference_mode():
+            stacked = torch.stack(
+                [torch.stack(video) for video in videos]
+            ).to(
+                device=self.device,
+                dtype=self.input_dtype,
+                memory_format=torch.contiguous_format,
+            ).div_(255.0)
+            result = self.model(inputs=stacked)
+            return list(result.unbind(0))
 
     def restore(self, video: list[Tensor]) -> list[Tensor]:
         """

--- a/jasna/restorer/restoration_pipeline.py
+++ b/jasna/restorer/restoration_pipeline.py
@@ -9,7 +9,7 @@ from jasna.crop_buffer import (
     RawCrop,
     prepare_crops_for_restoration,
 )
-from jasna.pipeline_items import PrimaryRestoreResult, SecondaryRestoreResult
+from jasna.pipeline_items import ClipRestoreItem, PrimaryRestoreResult, SecondaryRestoreResult
 from jasna.restorer.basicvsrpp_mosaic_restorer import BasicvsrppMosaicRestorer
 from jasna.restorer.denoise import DenoiseStep, DenoiseStrength, apply_denoise, apply_denoise_u8
 from jasna.restorer.secondary_restorer import SecondaryRestorer
@@ -49,6 +49,17 @@ class RestorationPipeline:
         if self.secondary_restorer is not None:
             return bool(getattr(self.secondary_restorer, "prefers_cpu_input", False))
         return False
+
+    @property
+    def independent_clip_batch_size(self) -> int:
+        return max(1, int(getattr(self.restorer, "independent_clip_batch_size", 1)))
+
+    @property
+    def independent_clip_batch_min_frames(self) -> int:
+        return max(
+            0,
+            int(getattr(self.restorer, "independent_clip_batch_min_frames", 0)),
+        )
 
     def _apply_denoise(self, frames: torch.Tensor) -> torch.Tensor:
         return apply_denoise(frames, self._denoise_strength)
@@ -118,6 +129,51 @@ class RestorationPipeline:
             pad_offsets=pad_offsets,
             resize_shapes=resize_shapes,
         )
+
+    def prepare_and_run_primary_batch(
+        self,
+        items: list[ClipRestoreItem],
+    ) -> list[PrimaryRestoreResult]:
+        if not items:
+            return []
+        frame_count = len(items[0].raw_crops)
+        if frame_count <= 0 or any(
+            len(item.raw_crops) != frame_count for item in items
+        ):
+            raise ValueError("primary restoration batches require equal clip lengths")
+
+        prepared = [
+            self._prepare_from_raw_crops(item.raw_crops) for item in items
+        ]
+        primary_batches = self.restorer.raw_process_batch(
+            [entry[0] for entry in prepared]
+        )
+        results: list[PrimaryRestoreResult] = []
+        for item, primary_raw, metadata in zip(
+            items, primary_batches, prepared, strict=True
+        ):
+            _resized, enlarged_bboxes, crop_shapes, pad_offsets, resize_shapes = metadata
+            if self._denoise_step is DenoiseStep.AFTER_PRIMARY:
+                primary_raw = self._apply_denoise(primary_raw)
+            results.append(
+                PrimaryRestoreResult(
+                    track_id=item.clip.track_id,
+                    start_frame=item.clip.start_frame,
+                    frame_count=len(item.raw_crops),
+                    frame_shape=item.frame_shape,
+                    frame_device=item.raw_crops[0].crop.device,
+                    masks=item.clip.masks,
+                    primary_raw=primary_raw,
+                    keep_start=item.keep_start,
+                    keep_end=item.keep_end,
+                    crossfade_weights=item.crossfade_weights,
+                    enlarged_bboxes=enlarged_bboxes,
+                    crop_shapes=crop_shapes,
+                    pad_offsets=pad_offsets,
+                    resize_shapes=resize_shapes,
+                )
+            )
+        return results
 
     def build_secondary_result(
         self,

--- a/tests/test_resize_normalize_logging.py
+++ b/tests/test_resize_normalize_logging.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import logging
+import sys
+
+import torch
+
+from jasna.media.resize_normalize import ResizeNormalizer
+
+
+def test_missing_triton_warns_without_a_traceback(monkeypatch, caplog) -> None:
+    monkeypatch.setattr("jasna.media.resize_normalize.is_nvidia_device", lambda _device: False)
+    monkeypatch.setattr("jasna.media.resize_normalize.is_amd_device", lambda _device: True)
+    monkeypatch.setitem(sys.modules, "jasna.media.triton_resize_normalize", None)
+
+    with caplog.at_level(logging.DEBUG, logger="jasna.media.resize_normalize"):
+        normalizer = ResizeNormalizer(
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+            mean=(0.0, 0.0, 0.0),
+            std=(1.0, 1.0, 1.0),
+            fill=(0.0, 0.0, 0.0),
+        )
+
+    warning = next(record for record in caplog.records if record.levelno == logging.WARNING)
+    diagnostic = next(record for record in caplog.records if record.levelno == logging.DEBUG)
+    assert normalizer.backend == "torch"
+    assert not normalizer.available
+    assert "unavailable; using Torch (" in warning.getMessage()
+    assert warning.exc_info is None
+    assert diagnostic.exc_info is not None
+    assert diagnostic.exc_info[0] is ModuleNotFoundError


### PR DESCRIPTION
# ROCm detector preprocessing and restoration batching

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/301#issuecomment-5312155433).

## Summary

This candidate contains two AMD-gated throughput optimizations: a fused ROCm
Triton resize/letterbox/normalize kernel for detection, and conservative batch-2
processing for adjacent equal-length BasicVSR++ clips of at least 60 frames.
CUDA/TensorRT behavior and batch sizes are unchanged.

## Changes

- fuse detector preprocessing into one ROCm Triton kernel;
- permanently fall back to the equivalent Torch expression after the first
  Triton build/runtime failure;
- keep an expected missing-Triton warning to one line at normal log levels while
  retaining the traceback at debug level;
- batch only adjacent compatible restoration clips with equal lengths and a
  minimum of 60 frames;
- preserve output order and retry clips individually after OOM;
- keep short, unequal, NVIDIA and TensorRT clips on the original path.

## Scope and compatibility

- Public branch: `perf/amd-rocm-preprocessing` (`e55a5ea`).
- Base: `upstream/main`; independently mergeable.
- NVIDIA risk: low because both policies are AMD-gated, but shared pipeline
  scheduling is touched; run the NVIDIA restoration suite and one short clip.
- No decoder, encoder, scan policy, GUI setting, or native C++ change.

## Validation evidence

- On an RX 7900 XTX 8K half-eye, fused preprocessing measured 0.106 ms versus
  3.976 ms and reduced temporary allocation from 799 MiB to 16 MiB.
- A real 368-frame RF-DETR path improved from 9.748 s to 9.139 s (6.25%) while
  retaining 129/129 detections and 7/7 restoration items.
- Synthetic equal-clip batch 2 measured about 1.92–1.93x throughput at T=60/90;
  the bounded part of a real 480-frame window improved 7.705 s to 4.737 s.
- Real short clips were slower, which is why the 60-frame minimum remains.
- Windows missing-Triton logging probe: warning `exc_info=False`, Torch fallback
  active, debug diagnostic `exc_info=True`.
- New CPU-only logging regression: `1 passed`, exit 0.
- Combined logging + GPU resize suite reached `14 passed`; the Windows ROCm
  interpreter then remained in shutdown past 30 seconds, so that combined run
  is recorded as assertion-complete but not a clean process-exit result.

## Test request

Run one NVIDIA BasicVSR++ clip and the normal NVIDIA pipeline tests to confirm
the guard has not affected CUDA scheduling.
