### PR TITLE
fix: keep public source checkout runnable

### DIFF
--- a/jasna/engine_compiler.py
+++ b/jasna/engine_compiler.py
@@ -142,7 +142,7 @@ def ensure_engines_compiled(
 
     if need_unet4x:
         from jasna.engine_paths import unet4x_plaintext_available
-        from jasna.protection import license_store
+        from jasna.license_api import license_store
         if not unet4x_plaintext_available() and not license_store.is_licensed():
             raise RuntimeError("unet-4x is a supporter feature. Enter your license to enable it.")
 

--- a/jasna/gui/app.py
+++ b/jasna/gui/app.py
@@ -432,7 +432,7 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
             self.destroy()
         
     def _refresh_license_chip(self):
-        from jasna.protection import license_store
+        from jasna.license_api import license_store
         licensed = license_store.is_licensed()
         self._license_chip.configure(
             text=t("license_chip_active") if licensed else t("license_chip_inactive"),

--- a/jasna/gui/components.py
+++ b/jasna/gui/components.py
@@ -223,7 +223,7 @@ class LicenseDialog(ctk.CTkToplevel):
         self._status = ctk.CTkLabel(action, text="", text_color=Colors.TEXT_PRIMARY)
         self._status.pack(side="left", padx=10)
 
-        from jasna.protection import license_store
+        from jasna.license_api import license_store
         stored = license_store.load_license()
         if stored:
             self._email.insert(0, stored[0])
@@ -241,7 +241,7 @@ class LicenseDialog(ctk.CTkToplevel):
         )
 
     def _activate(self):
-        from jasna.protection import ProtectionError, license_store
+        from jasna.license_api import ProtectionError, license_store
         email = self._email.get().strip()
         key = self._key.get().strip()
         try:

--- a/jasna/image_restore.py
+++ b/jasna/image_restore.py
@@ -279,7 +279,7 @@ def _run_image_jobs(args, jobs: list[tuple[Path, Path]], progress_callback=None)
     batch_size = int(args.batch_size)
 
     if args.license_email and args.license_key:
-        from jasna.protection import license_store
+        from jasna.license_api import license_store
         license_store.set_license(args.license_email, args.license_key)
 
     ensure_sd15_bundle(SD15_DIR)

--- a/jasna/license_api.py
+++ b/jasna/license_api.py
@@ -1,0 +1,45 @@
+"""Safe access to the optional private license implementation.
+
+Public source checkouts intentionally do not contain ``jasna.protection``.
+Keep free-model workflows usable without pretending that supporter features
+are licensed. Release builds that include the private package keep using its
+real store and exception type unchanged.
+"""
+
+from __future__ import annotations
+
+
+try:
+    from jasna.protection import ProtectionError, license_store
+except ImportError as exc:
+    # Do not hide a missing dependency inside an installed protection package.
+    # The public checkout is represented either by no package or by the empty
+    # gitlink directory, both of which report ``jasna.protection`` here.
+    if exc.name != "jasna.protection":
+        raise
+
+    class ProtectionError(RuntimeError):
+        """Raised when supporter activation is unavailable or invalid."""
+
+
+    class _PublicSourceLicenseStore:
+        @staticmethod
+        def load_license() -> None:
+            return None
+
+        @staticmethod
+        def is_licensed() -> bool:
+            return False
+
+        @staticmethod
+        def set_license(email: str, key: str) -> None:
+            del email, key
+            raise ProtectionError(
+                "Supporter activation is unavailable in the public source checkout"
+            )
+
+
+    license_store = _PublicSourceLicenseStore()
+
+
+__all__ = ["ProtectionError", "license_store"]

--- a/jasna/main.py
+++ b/jasna/main.py
@@ -832,7 +832,7 @@ def main() -> None:
         raise ValueError(f"Unsupported restoration model: {restoration_model_name}")
 
     if args.license_email and args.license_key:
-        from jasna.protection import license_store
+        from jasna.license_api import license_store
         license_store.set_license(args.license_email, args.license_key)
 
     lut_arg = str(args.lut).strip()

--- a/tests/test_license_api.py
+++ b/tests/test_license_api.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+from jasna.license_api import ProtectionError, license_store
+
+
+def test_public_source_checkout_is_unlicensed_but_usable() -> None:
+    assert license_store.load_license() is None
+    assert license_store.is_licensed() is False
+
+    with pytest.raises(ProtectionError, match="unavailable in the public source checkout"):
+        license_store.set_license("supporter@example.com", "not-a-real-key")
+
+
+def test_private_protection_exports_pass_through_unchanged(monkeypatch) -> None:
+    fake_protection = ModuleType("jasna.protection")
+
+    class PrivateProtectionError(RuntimeError):
+        pass
+
+    private_store = object()
+    fake_protection.ProtectionError = PrivateProtectionError
+    fake_protection.license_store = private_store
+    monkeypatch.setitem(sys.modules, "jasna.protection", fake_protection)
+
+    source = Path(__file__).parents[1] / "jasna" / "license_api.py"
+    spec = importlib.util.spec_from_file_location("_license_api_private_test", source)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.ProtectionError is PrivateProtectionError
+    assert module.license_store is private_store
+
+
+def test_broken_private_dependency_is_not_silently_treated_as_public(monkeypatch) -> None:
+    fake_protection = ModuleType("jasna.protection")
+
+    def _missing_dependency(_name: str):
+        raise ModuleNotFoundError(
+            "No module named 'private_runtime_dependency'",
+            name="private_runtime_dependency",
+        )
+
+    fake_protection.__getattr__ = _missing_dependency
+    monkeypatch.setitem(sys.modules, "jasna.protection", fake_protection)
+
+    source = Path(__file__).parents[1] / "jasna" / "license_api.py"
+    spec = importlib.util.spec_from_file_location("_license_api_broken_test", source)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+
+    with pytest.raises(ModuleNotFoundError, match="private_runtime_dependency"):
+        spec.loader.exec_module(module)


### PR DESCRIPTION
# Keep public source checkouts runnable without the private protection module

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/307#issuecomment-5312164516).

## Summary

The development guide says the public source checkout can run free models, but
the GUI and several CLI entry points import `license_store` directly from the
private `jasna.protection` gitlink. That private repository is intentionally not
available in a public checkout, so the GUI currently aborts during startup.

This candidate adds one narrow license API boundary. Release builds containing
the private module keep using its real objects unchanged. A public checkout is
reported as unlicensed, cannot activate supporter features and remains usable
with free models.

## Changes and security boundary

- add `jasna.license_api` as the only entry point for `license_store` and
  `ProtectionError` used by GUI/CLI activation checks;
- pass through the real private store and exception class when they exist;
- when `jasna.protection` itself is absent, return no stored license, report
  `is_licensed() == False`, and reject activation with a clear error;
- re-raise missing dependencies inside an installed private protection module
  instead of silently treating a broken release build as a public checkout;
- leave protected-model decryption imports unchanged, so no supporter model is
  exposed or bypassed;
- change no codec, encoder, decoder, detector, restoration, scan, Smart Render,
  queue, logging or native implementation.

## Scope and compatibility

- Public branch: `fix/public-source-license-boundary` (`71b88c5`).
- Base: `upstream/main`; independently mergeable.
- Cross-platform source-startup fix. It does not depend on AMD, NVIDIA, Linux
  or Windows behavior.
- Private release builds must still be tested because this PR deliberately
  preserves their real license implementation rather than replacing it.

## Validation

- Focused fallback/pass-through/broken-private-dependency tests: **3 passed**.
- `compileall` and `git diff --check`: passed.
- A real public-checkout GUI startup remained running for an 8-second bounded
  smoke test with no traceback; the test harness then terminated it by timeout.
- The original public-checkout failure was reproduced first: the repository's
  relative submodule URL resolves to a non-public GitHub path and cannot clone.

## Test request

1. Run the GUI from a clean public source checkout without initializing the
   private submodule; the GUI should open and show inactive licensing.
2. In an official Windows and Linux release build containing the private
   module, verify stored-license display and one valid activation still use the
   real implementation.
3. Confirm unet-4x/SD 1.5 remain unavailable in the public checkout.