### PR TITLE
fix: prefer source-checkout FFmpeg tools

### DIFF
--- a/jasna/os_utils.py
+++ b/jasna/os_utils.py
@@ -183,13 +183,14 @@ def _parse_ffmpeg_major_version(version_output: str) -> int:
         raise ValueError(f"Unexpected ffmpeg/ffprobe version output: {first_line!r}")
 
     ver = m.group(1)
-    if ver.startswith(("N-", "git-", "GIT-")):
-        return parse_major_from_libavutil(version_output)
-
-    m = re.search(r"(\d+)", ver)
-    if not m:
-        raise ValueError(f"Could not parse ffmpeg major version from: {ver!r}")
-    return int(m.group(1))
+    # Release builds start with an optional ``n`` followed by the semantic
+    # major. Snapshot distributors may instead put a build date or git label in
+    # this field (for example ``2026-06-15-git-...``); those numbers are not the
+    # FFmpeg major, so derive it from the library ABI below.
+    release = re.match(r"^[nN]?(\d+)(?:\.|$)", ver)
+    if release:
+        return int(release.group(1))
+    return parse_major_from_libavutil(version_output)
 
 
 FFMPEG_DOWNLOAD_LINKS = (

--- a/jasna/os_utils.py
+++ b/jasna/os_utils.py
@@ -54,6 +54,13 @@ def _find_bundled_executable(name: str) -> Path | None:
     return None
 
 
+def _find_source_executable(name: str) -> Path | None:
+    if is_frozen() or name not in {"ffmpeg", "ffprobe"}:
+        return None
+    candidate = Path(__file__).resolve().parent.parent / "tools" / _bundled_exe_filename(name)
+    return candidate if candidate.is_file() else None
+
+
 _COMMON_EXECUTABLE_LOCATIONS: dict[str, tuple[str, ...]] = {
     "nvidia-smi": (
         # Windows
@@ -79,6 +86,9 @@ def find_executable(name: str) -> str | None:
     bundled = _find_bundled_executable(name)
     if bundled is not None:
         return str(bundled)
+    source_tool = _find_source_executable(name)
+    if source_tool is not None:
+        return str(source_tool)
     found = shutil.which(name)
     if found is not None:
         return found

--- a/tests/test_os_utils.py
+++ b/tests/test_os_utils.py
@@ -323,6 +323,51 @@ def test_find_executable_bundled_wins_over_system_path(monkeypatch, tmp_path) ->
     assert os_utils.find_executable("ffmpeg") == str(ffmpeg)
 
 
+@pytest.mark.parametrize("name", ["ffmpeg", "ffprobe"])
+def test_find_executable_prefers_source_tool_over_path_when_not_frozen(
+    monkeypatch, tmp_path, name
+) -> None:
+    source_root = tmp_path / "source-checkout"
+    monkeypatch.setattr(os_utils, "__file__", str(source_root / "jasna" / "os_utils.py"))
+    monkeypatch.setattr(os_utils.os, "name", "posix", raising=False)
+    monkeypatch.setattr(os_utils, "is_frozen", lambda: False)
+    source_tool = source_root / "tools" / name
+    source_tool.parent.mkdir(parents=True)
+    source_tool.write_bytes(b"")
+    monkeypatch.setattr(os_utils.shutil, "which", lambda exe: f"/path/{exe}")
+
+    assert os_utils.find_executable(name) == str(source_tool)
+
+
+@pytest.mark.parametrize("name", ["ffmpeg", "ffprobe"])
+def test_find_executable_uses_path_when_source_tool_is_missing(monkeypatch, tmp_path, name) -> None:
+    source_root = tmp_path / "source-checkout"
+    monkeypatch.setattr(os_utils, "__file__", str(source_root / "jasna" / "os_utils.py"))
+    monkeypatch.setattr(os_utils.os, "name", "posix", raising=False)
+    monkeypatch.setattr(os_utils, "is_frozen", lambda: False)
+    path_tool = f"/path/{name}"
+    monkeypatch.setattr(os_utils.shutil, "which", lambda exe: path_tool)
+
+    assert os_utils.find_executable(name) == path_tool
+
+
+def test_find_executable_keeps_frozen_bundle_before_source_and_path(monkeypatch, tmp_path) -> None:
+    source_root = tmp_path / "source-checkout"
+    monkeypatch.setattr(os_utils, "__file__", str(source_root / "jasna" / "os_utils.py"))
+    monkeypatch.setattr(os_utils.os, "name", "posix", raising=False)
+    monkeypatch.setattr(os_utils, "is_frozen", lambda: True)
+    monkeypatch.setattr(os_utils.sys, "executable", str(tmp_path / "dist" / "jasna"), raising=False)
+    monkeypatch.setattr(os_utils.shutil, "which", lambda exe: f"/path/{exe}")
+    source_tool = source_root / "tools" / "ffmpeg"
+    source_tool.parent.mkdir(parents=True)
+    source_tool.write_bytes(b"source")
+    bundled_tool = tmp_path / "dist" / "tools" / "ffmpeg"
+    bundled_tool.parent.mkdir(parents=True)
+    bundled_tool.write_bytes(b"frozen")
+
+    assert os_utils.find_executable("ffmpeg") == str(bundled_tool)
+
+
 def test_check_sysmem_fallback_returns_true_when_prefer_no_sysmem(monkeypatch) -> None:
     monkeypatch.setattr(os_utils.sys, "platform", "win32", raising=False)
     monkeypatch.setattr(

--- a/tests/test_os_utils.py
+++ b/tests/test_os_utils.py
@@ -340,9 +340,8 @@ def test_find_executable_prefers_source_tool_over_path_when_not_frozen(
 ) -> None:
     source_root = tmp_path / "source-checkout"
     monkeypatch.setattr(os_utils, "__file__", str(source_root / "jasna" / "os_utils.py"))
-    monkeypatch.setattr(os_utils.os, "name", "posix", raising=False)
     monkeypatch.setattr(os_utils, "is_frozen", lambda: False)
-    source_tool = source_root / "tools" / name
+    source_tool = source_root / "tools" / os_utils._bundled_exe_filename(name)
     source_tool.parent.mkdir(parents=True)
     source_tool.write_bytes(b"")
     monkeypatch.setattr(os_utils.shutil, "which", lambda exe: f"/path/{exe}")
@@ -354,7 +353,6 @@ def test_find_executable_prefers_source_tool_over_path_when_not_frozen(
 def test_find_executable_uses_path_when_source_tool_is_missing(monkeypatch, tmp_path, name) -> None:
     source_root = tmp_path / "source-checkout"
     monkeypatch.setattr(os_utils, "__file__", str(source_root / "jasna" / "os_utils.py"))
-    monkeypatch.setattr(os_utils.os, "name", "posix", raising=False)
     monkeypatch.setattr(os_utils, "is_frozen", lambda: False)
     path_tool = f"/path/{name}"
     monkeypatch.setattr(os_utils.shutil, "which", lambda exe: path_tool)
@@ -365,14 +363,14 @@ def test_find_executable_uses_path_when_source_tool_is_missing(monkeypatch, tmp_
 def test_find_executable_keeps_frozen_bundle_before_source_and_path(monkeypatch, tmp_path) -> None:
     source_root = tmp_path / "source-checkout"
     monkeypatch.setattr(os_utils, "__file__", str(source_root / "jasna" / "os_utils.py"))
-    monkeypatch.setattr(os_utils.os, "name", "posix", raising=False)
     monkeypatch.setattr(os_utils, "is_frozen", lambda: True)
     monkeypatch.setattr(os_utils.sys, "executable", str(tmp_path / "dist" / "jasna"), raising=False)
     monkeypatch.setattr(os_utils.shutil, "which", lambda exe: f"/path/{exe}")
-    source_tool = source_root / "tools" / "ffmpeg"
+    exe_name = os_utils._bundled_exe_filename("ffmpeg")
+    source_tool = source_root / "tools" / exe_name
     source_tool.parent.mkdir(parents=True)
     source_tool.write_bytes(b"source")
-    bundled_tool = tmp_path / "dist" / "tools" / "ffmpeg"
+    bundled_tool = tmp_path / "dist" / "tools" / exe_name
     bundled_tool.parent.mkdir(parents=True)
     bundled_tool.write_bytes(b"frozen")
 

--- a/tests/test_os_utils.py
+++ b/tests/test_os_utils.py
@@ -82,6 +82,17 @@ def test_parse_ffmpeg_major_version_parses_nightly_build_from_libavutil() -> Non
     assert os_utils._parse_ffmpeg_major_version(out) == 8
 
 
+def test_parse_ffmpeg_major_version_parses_date_snapshot_from_libavutil() -> None:
+    out = "\n".join(
+        [
+            "ffprobe version 2026-06-15-git-44d082edc8-full_build-www.gyan.dev "
+            "Copyright (c) ...",
+            "libavutil      60. 33.100 / 60. 33.100",
+        ]
+    )
+    assert os_utils._parse_ffmpeg_major_version(out) == 8
+
+
 def test_check_required_executables_uses_expected_version_commands(monkeypatch) -> None:
     monkeypatch.setattr(os_utils.shutil, "which", lambda exe: f"/fake/{exe}")
 


### PR DESCRIPTION
# Prefer source-checkout FFmpeg tools

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/308#issuecomment-5312165050).

## Summary

This candidate makes a source checkout prefer repository-root `tools/ffmpeg`
and `tools/ffprobe` when resolving those two executables. If the source tool is
not present, the existing `PATH` lookup remains the fallback. Frozen builds
retain their existing bundled-tool lookup and ordering.

## Scope

- Public branch: `fix/source-runtime-tools`.
- Base: `upstream/main` (`592472bda8aeb1fc0d5cea3d3ff6607add0ab0a7`).
- Changed only `jasna/os_utils.py` and `tests/test_os_utils.py`.
- The source lookup is limited to the names `ffmpeg` and `ffprobe`; common
  executable discovery and all other runtime tools are unchanged.

## Rationale and risk

Development checkouts may carry the exact FFmpeg pair expected by Jasna under
the repository-root `tools/` directory. Preferring those files avoids an
incompatible system version while preserving normal `PATH` behavior when the
files are absent. The helper is disabled while frozen, so packaged releases
continue to resolve their adjacent bundled tools before consulting `PATH`.

The change does not package, download, or commit FFmpeg binaries. The main
risk is a stale or incompatible local `tools/ffmpeg`/`tools/ffprobe`; that is
intentional source-checkout behavior and is limited to those exact names.

## Validation

- `.../.venv/bin/python -m pytest tests/test_os_utils.py`
- `.../.venv/bin/python -m compileall -q jasna tests/test_os_utils.py`
- `git diff --check upstream/main...HEAD`
- `git status --short` clean after the candidate commit.

The focused tests mock platform and frozen state and cover both source tools,
`PATH` fallback, and frozen bundled-before-`PATH` ordering.

## Manual verification

In a source checkout, place executable FFmpeg 8 binaries at `tools/ffmpeg` and
`tools/ffprobe`, then run the Jasna system checks and confirm their logged or
observed command paths point into the checkout. Remove either file and confirm
the corresponding executable resolves from `PATH`. In a packaged build,
confirm the adjacent distribution `tools/` binaries remain selected.