### PR TITLE
fix(gui): honor Linux desktop scaling

### DIFF
--- a/jasna/gui/scaling.py
+++ b/jasna/gui/scaling.py
@@ -1,14 +1,10 @@
 """Physical-pixel to CustomTkinter-logical-pixel conversion for window and widget sizing.
 
-On Windows, Jasna owns DPI handling: ``run_gui()`` calls :func:`activate_static_dpi` before
-any CTk window exists. That disables CustomTkinter's automatic per-monitor rescaling (its
-poll loop alpha-blinks the window and re-issues ``geometry()`` mid-drag, which flickered and
-hung at high display scaling), makes the process system-DPI aware, and sets one static CTk
-scaling factor: the system DPI factor, shrunk just enough that the design-minimum window
-plus :data:`SCREEN_MARGIN` fits the primary screen. Windows bitmap-stretches the window on
-monitors with a different DPI. ``winfo_*`` stays physical while ``geometry()``/``minsize()``
-multiply their width/height arguments by the factor and pass the ``+x+y`` offset through
-untouched.
+``run_gui()`` calls :func:`activate_static_dpi` before any CTk window exists. On Windows,
+Jasna disables CustomTkinter's problematic per-monitor rescaling and uses one static system
+DPI factor. On Linux, where CustomTkinter does not apply desktop scaling itself, Jasna reads
+the Xft desktop DPI (falling back to the GDK scale environment) and applies it to both CTk
+windows and widgets.
 
 Three rules follow, and every helper here exists to keep them straight:
 
@@ -16,11 +12,14 @@ Three rules follow, and every helper here exists to keep them straight:
 - Width/height handed to ``geometry()``/``minsize()`` are logical.
 - CTk widget options are logical; raw ``tkinter`` pixel options are physical.
 
-Off Windows the factor is exactly 1 and every function here is the identity.
+At factor 1 every conversion helper here is the identity.
 """
 
 import logging
 import math
+import os
+import re
+import subprocess
 import sys
 
 import customtkinter as ctk
@@ -28,10 +27,19 @@ import customtkinter as ctk
 logger = logging.getLogger(__name__)
 
 SCREEN_MARGIN = (40, 80)
+_BASE_DPI = 96.0
+_MIN_SCALE = 0.5
+_MAX_SCALE = 4.0
 
 
 def activate_static_dpi(design_min: tuple[int, int]) -> None:
     """Fix process DPI awareness and one static CTk scaling factor, before any window exists."""
+    if sys.platform.startswith("linux"):
+        factor = _linux_desktop_scaling()
+        ctk.set_widget_scaling(factor)
+        ctk.set_window_scaling(factor)
+        logger.info("Linux desktop UI scale factor %.2f", factor)
+        return
     if sys.platform != "win32":
         return
     ctk.deactivate_automatic_dpi_awareness()
@@ -45,6 +53,42 @@ def activate_static_dpi(design_min: tuple[int, int]) -> None:
         "Display %dx%d at %d%% scaling, UI scale factor %.2f",
         screen[0], screen[1], round(dpi * 100), factor,
     )
+
+
+def _linux_desktop_scaling() -> float:
+    try:
+        result = subprocess.run(
+            ["xrdb", "-query"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        result = None
+
+    if result is not None and result.returncode == 0:
+        match = re.search(r"(?mi)^Xft\.dpi:\s*([0-9]+(?:\.[0-9]+)?)\s*$", result.stdout)
+        if match is not None:
+            return _clamp_scaling(float(match.group(1)) / _BASE_DPI)
+
+    gdk_scale = _positive_env_float("GDK_SCALE")
+    gdk_dpi_scale = _positive_env_float("GDK_DPI_SCALE")
+    if gdk_scale is not None or gdk_dpi_scale is not None:
+        return _clamp_scaling((gdk_scale or 1.0) * (gdk_dpi_scale or 1.0))
+    return 1.0
+
+
+def _positive_env_float(name: str) -> float | None:
+    try:
+        value = float(os.environ[name])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _clamp_scaling(value: float) -> float:
+    return max(_MIN_SCALE, min(value, _MAX_SCALE))
 
 
 def _static_scaling(

--- a/tests/test_gui_hidpi_scaling.py
+++ b/tests/test_gui_hidpi_scaling.py
@@ -130,7 +130,9 @@ def test_main_window_keeps_design_minimum_at_high_dpi_on_1440p(dpi, monkeypatch)
     assert minimum[-1][0] >= 899 and minimum[-1][1] >= 579
 
 
-def test_activate_static_dpi_is_a_no_op_off_windows() -> None:
+def test_activate_static_dpi_is_a_no_op_off_windows_and_linux(monkeypatch) -> None:
+    monkeypatch.setattr(scaling.sys, "platform", "darwin")
+
     scaling.activate_static_dpi((900, 580))
 
     assert not ctk.ScalingTracker.deactivate_automatic_dpi_awareness
@@ -158,6 +160,69 @@ def test_activate_static_dpi_windows_path(monkeypatch) -> None:
         ctk.ScalingTracker.deactivate_automatic_dpi_awareness = False
         ctk.set_widget_scaling(1.0)
         ctk.set_window_scaling(1.0)
+
+
+def test_linux_desktop_scaling_uses_xft_dpi(monkeypatch) -> None:
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(returncode=0, stdout="Xft.dpi: 192\n")
+
+    monkeypatch.setattr(scaling.subprocess, "run", fake_run)
+    monkeypatch.delenv("GDK_SCALE", raising=False)
+    monkeypatch.delenv("GDK_DPI_SCALE", raising=False)
+
+    assert scaling._linux_desktop_scaling() == 2.0
+    assert calls == [
+        ((["xrdb", "-query"],), {
+            "capture_output": True,
+            "check": False,
+            "text": True,
+            "timeout": 2,
+        }),
+    ]
+
+
+def test_linux_desktop_scaling_falls_back_to_gdk_environment(monkeypatch) -> None:
+    def unavailable(*args, **kwargs):
+        raise OSError("xrdb unavailable")
+
+    monkeypatch.setattr(scaling.subprocess, "run", unavailable)
+    monkeypatch.setenv("GDK_SCALE", "2")
+    monkeypatch.setenv("GDK_DPI_SCALE", "1.25")
+
+    assert scaling._linux_desktop_scaling() == 2.5
+
+
+@pytest.mark.parametrize(
+    ("xft_dpi", "expected"),
+    [("24", 0.5), ("768", 4.0)],
+)
+def test_linux_desktop_scaling_clamps_xft_dpi(monkeypatch, xft_dpi, expected) -> None:
+    monkeypatch.setattr(
+        scaling.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0, stdout=f"Xft.dpi: {xft_dpi}\n"
+        ),
+    )
+    monkeypatch.delenv("GDK_SCALE", raising=False)
+    monkeypatch.delenv("GDK_DPI_SCALE", raising=False)
+
+    assert scaling._linux_desktop_scaling() == expected
+
+
+def test_activate_static_dpi_linux_applies_widget_and_window_scaling(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(scaling.sys, "platform", "linux")
+    monkeypatch.setattr(scaling, "_linux_desktop_scaling", lambda: 2.0)
+    monkeypatch.setattr(ctk, "set_widget_scaling", lambda value: calls.append(("widget", value)))
+    monkeypatch.setattr(ctk, "set_window_scaling", lambda value: calls.append(("window", value)))
+
+    scaling.activate_static_dpi((900, 580))
+
+    assert calls == [("widget", 2.0), ("window", 2.0)]
 
 
 def test_scaling_helpers_are_identity_without_scaling():


### PR DESCRIPTION
## Summary

This candidate extracts the Linux desktop-scaling part of the validated GUI
HiDPI implementation onto `upstream/main`. CustomTkinter does not apply the
desktop scale automatically on Linux, so the GUI previously stayed at a 1.0
factor even when the X11 desktop reported 200% scaling.

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/309#issuecomment-5312162532).

## Changes

- read `Xft.dpi` from `xrdb -query` before the first CustomTkinter window;
- fall back to `GDK_SCALE * GDK_DPI_SCALE` when Xft DPI is unavailable;
- clamp the resulting factor to `0.5..4.0` and use `1.0` when no source is
  available or valid;
- apply the same factor to both CustomTkinter widget and window scaling;
- preserve the existing Windows DPI path exactly and keep other platforms as
  no-ops;
- add platform, subprocess, environment, fallback, clamp, and activation tests
  without requiring a live desktop.

## Scope and compatibility

- Public branch: `fix/linux-desktop-scaling`.
- Base: `upstream/main` (`592472bda8aeb1fc0d5cea3d3ff6607add0ab0a7`).
- Changed repository files: `jasna/gui/scaling.py` and
  `tests/test_gui_hidpi_scaling.py`.
- No GUI layout, executable lookup, Windows behavior, packaging specification,
  or unrelated test is changed. Source and packaged runs share the same
  `activate_static_dpi` entry point.

## Validation

- `tests/test_gui_hidpi_scaling.py`: **48 passed**;
- `compileall`: passed for `jasna` and the focused test;
- `git diff --check upstream/main...HEAD`: passed;
- worktree status: clean after the single candidate commit.

The Linux activation test mocks the platform, `xrdb`, environment, and CTk
setters. With an X11 `Xft.dpi: 192` value, the expected factor is `2.0`.

## Follow-up test request

Run one packaged Linux GUI smoke test under an X11 desktop configured with
`Xft.dpi: 192` (or equivalent 200% desktop scaling) and confirm that both
widget dimensions and top-level window dimensions are visibly scaled.