### PR TITLE
fix: make final video completion durable

### DIFF
--- a/jasna/gui/processor.py
+++ b/jasna/gui/processor.py
@@ -17,6 +17,8 @@ from jasna.session_factory import RestorationSession, build_pipeline
 
 logger = logging.getLogger(__name__)
 
+_OutputFingerprint = tuple[int, int, int, int, int, int]
+
 
 @dataclass
 class ProgressUpdate:
@@ -140,6 +142,64 @@ class Processor:
                 return job
         return None
 
+    def _validate_completed_video_output(
+        self,
+        input_path: Path,
+        output_path: Path,
+        *,
+        codec: str,
+        smart_render: bool,
+        previous_fingerprint: _OutputFingerprint | None,
+    ) -> None:
+        from jasna.media.splice import (
+            sync_and_validate_final_output,
+            validate_video_output,
+        )
+
+        self._require_completed_output_changed(output_path, previous_fingerprint)
+        if smart_render:
+            # Smart-render muxing commits through _commit_smart_output, which
+            # already validates and syncs the final output before returning.
+            validate_video_output(output_path, source=input_path)
+        else:
+            sync_and_validate_final_output(
+                output_path,
+                source=input_path,
+                expected_codec=codec,
+            )
+
+    @staticmethod
+    def _output_fingerprint(path: Path) -> _OutputFingerprint | None:
+        try:
+            info = path.stat()
+        except FileNotFoundError:
+            return None
+        return (
+            int(info.st_mode),
+            int(info.st_dev),
+            int(info.st_ino),
+            int(info.st_size),
+            int(info.st_mtime_ns),
+            int(info.st_ctime_ns),
+        )
+
+    @classmethod
+    def _require_completed_output_changed(
+        cls,
+        output_path: Path,
+        previous_fingerprint: _OutputFingerprint | None,
+    ) -> None:
+        current_fingerprint = cls._output_fingerprint(output_path)
+        if current_fingerprint is None:
+            raise ValueError(f"completed output is missing: {output_path}")
+        if (
+            previous_fingerprint is not None
+            and current_fingerprint == previous_fingerprint
+        ):
+            raise ValueError(
+                f"completed output was not created or changed by this job: {output_path}"
+            )
+
     def _run(self):
         self._log("INFO", "Processing started")
 
@@ -239,9 +299,11 @@ class Processor:
                 self._log("INFO", f"Renamed output to {output_path.name} to avoid overwrite")
             # "overwrite" - just proceed and let the file be replaced
         
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
         try:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            previous_output_fingerprint = (
+                self._output_fingerprint(output_path) if not is_image else None
+            )
             if is_image:
                 self._close_video_session()
             else:
@@ -258,9 +320,17 @@ class Processor:
                 **pipeline_options,
             )
             if not is_image:
-                self._run_post_export_video_command(input_path, output_path)
+                self._validate_completed_video_output(
+                    input_path,
+                    output_path,
+                    codec=job_settings.codec,
+                    smart_render=bool(segments),
+                    previous_fingerprint=previous_output_fingerprint,
+                )
 
             job.output_path = output_path
+            if not is_image:
+                self._run_post_export_video_command(input_path, output_path)
             job.status = JobStatus.COMPLETED
             self._progress(ProgressUpdate(
                 job_id=job.id,

--- a/jasna/gui/processor.py
+++ b/jasna/gui/processor.py
@@ -66,6 +66,7 @@ class Processor:
         
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
+        self._completion_lock = threading.Lock()
         self._pause_event = threading.Event()
         self._pause_event.set()  # Not paused by default
         
@@ -99,7 +100,8 @@ class Processor:
         self._output_pattern = output_pattern
         self._disable_basicvsrpp_tensorrt_for_run = bool(disable_basicvsrpp_tensorrt)
         
-        self._stop_event.clear()
+        with self._completion_lock:
+            self._stop_event.clear()
         self._pause_event.set()
         
         self._thread = threading.Thread(target=self._run, daemon=True)
@@ -115,7 +117,11 @@ class Processor:
         return not self._pause_event.is_set()
         
     def stop(self):
-        self._stop_event.set()
+        # Linearize Stop against the final job-state commit. If Stop wins this
+        # lock after output validation, the current job remains pending; if the
+        # completion commit wins, the completed job remains authoritative.
+        with self._completion_lock:
+            self._stop_event.set()
         self._pause_event.set()  # Unpause to allow thread to exit
         pipeline = self._current_pipeline
         if pipeline is not None:
@@ -199,6 +205,15 @@ class Processor:
             raise ValueError(
                 f"completed output was not created or changed by this job: {output_path}"
             )
+
+    def _commit_completed_job(self, job: JobItem, output_path: Path) -> None:
+        """Commit terminal job fields atomically with respect to ``stop()``."""
+
+        with self._completion_lock:
+            if self._stop_event.is_set():
+                raise ProcessingStopped("Processing stopped")
+            job.output_path = output_path
+            job.status = JobStatus.COMPLETED
 
     def _run(self):
         self._log("INFO", "Processing started")
@@ -328,10 +343,9 @@ class Processor:
                     previous_fingerprint=previous_output_fingerprint,
                 )
 
-            job.output_path = output_path
             if not is_image:
                 self._run_post_export_video_command(input_path, output_path)
-            job.status = JobStatus.COMPLETED
+            self._commit_completed_job(job, output_path)
             self._progress(ProgressUpdate(
                 job_id=job.id,
                 status=JobStatus.COMPLETED,

--- a/jasna/media/splice.py
+++ b/jasna/media/splice.py
@@ -4,6 +4,7 @@ import bisect
 import logging
 import os
 import subprocess
+import sys
 from dataclasses import dataclass
 from fractions import Fraction
 from io import BytesIO
@@ -42,6 +43,208 @@ class SmartRenderCompatibilityError(ValueError):
     def __init__(self, message: str, *, reason: str = "generic") -> None:
         super().__init__(message)
         self.reason = reason
+
+
+class OutputValidationError(RuntimeError):
+    """Raised when a completed media file is absent, truncated, or inconsistent."""
+
+
+def _stream_duration_seconds(container, stream) -> float:
+    if stream.duration is not None and stream.time_base is not None:
+        return float(stream.duration * stream.time_base)
+    if container.duration is not None:
+        duration = float(container.duration / av.time_base)
+        start = _stream_start_seconds(container, stream)
+        # Matroska can expose the absolute last timestamp as the container
+        # duration when a stream starts after zero. Normalize that value to the
+        # media span used by FFprobe and by ordinary MP4/TS stream durations.
+        if start > 0.0 and duration > start:
+            duration -= start
+        return duration
+    return 0.0
+
+
+def _stream_start_seconds(container, stream) -> float:
+    if stream.start_time is not None and stream.time_base is not None:
+        return float(stream.start_time * stream.time_base)
+    if container.start_time is not None:
+        return float(container.start_time / av.time_base)
+    return 0.0
+
+
+def _source_video_contract(source: Path) -> tuple[str, float]:
+    try:
+        with av.open(str(source)) as container:
+            if not container.streams.video:
+                raise OutputValidationError(f"Source has no video stream: {source}")
+            stream = container.streams.video[0]
+            duration = _stream_duration_seconds(container, stream)
+            return _canonical_codec(stream.codec_context.name), duration
+    except OutputValidationError:
+        raise
+    except Exception as exc:
+        raise OutputValidationError(
+            f"Could not inspect source video {source}: {exc}"
+        ) from exc
+
+
+def validate_video_output(
+    path: str | Path,
+    *,
+    source: str | Path | None = None,
+    expected_codec: str | None = None,
+    expected_duration: float | None = None,
+) -> None:
+    """Perform a bounded structural and tail-read check of a completed video."""
+
+    output = Path(path)
+    try:
+        size = output.stat().st_size
+    except OSError as exc:
+        raise OutputValidationError(f"Completed output is missing: {output}") from exc
+    if not output.is_file() or size <= 0:
+        raise OutputValidationError(
+            f"Completed output is empty or not a file: {output}"
+        )
+
+    if source is not None:
+        source_codec, source_duration = _source_video_contract(Path(source))
+        if expected_codec is None:
+            expected_codec = source_codec
+        if expected_duration is None:
+            expected_duration = source_duration
+
+    try:
+        with av.open(str(output)) as container:
+            if not container.streams.video:
+                raise OutputValidationError(
+                    f"Completed output has no video stream: {output}"
+                )
+            stream = container.streams.video[0]
+            actual_codec = _canonical_codec(stream.codec_context.name)
+            if expected_codec is not None and actual_codec != _canonical_codec(
+                expected_codec
+            ):
+                raise OutputValidationError(
+                    f"Completed output codec is {actual_codec}, expected "
+                    f"{_canonical_codec(expected_codec)}: {output}"
+                )
+
+            actual_duration = _stream_duration_seconds(container, stream)
+            if actual_duration <= 0:
+                raise OutputValidationError(
+                    f"Completed output has no usable video duration: {output}"
+                )
+            if expected_duration is not None and float(expected_duration) > 0:
+                tolerance = max(0.5, min(2.0, float(expected_duration) * 0.001))
+                if abs(actual_duration - float(expected_duration)) > tolerance:
+                    raise OutputValidationError(
+                        f"Completed output duration is {actual_duration:.6f}s, expected "
+                        f"{float(expected_duration):.6f}s (+/- {tolerance:.3f}s): {output}"
+                    )
+
+            stream_start_seconds = _stream_start_seconds(container, stream)
+            seek_seconds = stream_start_seconds + max(0.0, actual_duration - 2.0)
+            container.seek(
+                int(seek_seconds * av.time_base),
+                backward=True,
+                any_frame=False,
+            )
+            tail_seconds: float | None = None
+            inspected = 0
+            for packet in container.demux(stream):
+                if packet.size <= 0:
+                    continue
+                timestamp = packet.pts if packet.pts is not None else packet.dts
+                if timestamp is None or packet.time_base is None:
+                    continue
+                packet_seconds = (
+                    float(timestamp * packet.time_base) - stream_start_seconds
+                )
+                duration_seconds = float((packet.duration or 0) * packet.time_base)
+                tail_seconds = max(
+                    tail_seconds or packet_seconds,
+                    packet_seconds + duration_seconds,
+                )
+                inspected += 1
+                if inspected >= 4096:
+                    break
+            if tail_seconds is None or tail_seconds < actual_duration - 1.0:
+                raise OutputValidationError(
+                    f"Completed output tail is missing or unreadable: {output}"
+                )
+    except OutputValidationError:
+        raise
+    except Exception as exc:
+        raise OutputValidationError(
+            f"Completed output is unreadable: {output}: {exc}"
+        ) from exc
+
+
+def _fsync_file(path: Path) -> None:
+    # Microsoft CRT _commit() ultimately needs a writable file handle. FFmpeg
+    # just created this output, so reopen it read/write only for the final flush.
+    mode = "r+b" if os.name == "nt" or sys.platform == "win32" else "rb"
+    with path.open(mode) as handle:
+        os.fsync(handle.fileno())
+
+
+def _fsync_directory(path: Path) -> None:
+    # Windows does not expose directory handles through os.open. The file flush
+    # remains mandatory there; POSIX filesystems also receive a metadata barrier.
+    if os.name == "nt" or sys.platform == "win32":
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    directory_fd = os.open(path, flags)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def sync_and_validate_final_output(
+    path: str | Path,
+    *,
+    source: str | Path | None = None,
+    expected_codec: str | None = None,
+    expected_duration: float | None = None,
+) -> None:
+    """Validate an output before and after the filesystem durability barriers."""
+
+    output = Path(path)
+    validate_video_output(
+        output,
+        source=source,
+        expected_codec=expected_codec,
+        expected_duration=expected_duration,
+    )
+    _fsync_file(output)
+    _fsync_directory(output.parent)
+    validate_video_output(
+        output,
+        source=source,
+        expected_codec=expected_codec,
+        expected_duration=expected_duration,
+    )
+
+
+def _commit_smart_output(
+    temporary: Path,
+    destination: Path,
+    *,
+    source: Path,
+    codec: str,
+) -> None:
+    """Durably commit a structurally valid smart-render temporary output."""
+
+    validate_video_output(temporary, source=source, expected_codec=codec)
+    _fsync_file(temporary)
+    os.replace(temporary, destination)
+    # Reopen the committed name as a post-rename barrier. This is especially
+    # important on Windows, where directory fsync is not available.
+    _fsync_file(destination)
+    _fsync_directory(destination.parent)
+    validate_video_output(destination, source=source, expected_codec=codec)
 
 
 @dataclass(frozen=True)
@@ -86,7 +289,7 @@ def _canonical_codec(name: str) -> str:
         return "hevc"
     if value in {"avc", "h.264"}:
         return "h264"
-    if value == "av01":
+    if value in {"av01", "libdav1d"}:
         return "av1"
     return value
 
@@ -657,11 +860,10 @@ def mux_final_output(
         tag = {"h264": "avc3", "hevc": "hev1", "av1": "av01"}[codec]
         args += ["-tag:v:0", tag, "-movflags", "+faststart"]
     args.append(str(temporary))
-    try:
-        _run_ffmpeg(args, purpose=f"mux smart-render output {destination.name}")
-        os.replace(temporary, destination)
-    finally:
-        try:
-            temporary.unlink(missing_ok=True)
-        except OSError:
-            log.warning("Could not remove temporary output %s", temporary)
+    _run_ffmpeg(args, purpose=f"mux smart-render output {destination.name}")
+    _commit_smart_output(
+        temporary,
+        destination,
+        source=source,
+        codec=codec,
+    )

--- a/tests/test_gui_job_ordering.py
+++ b/tests/test_gui_job_ordering.py
@@ -54,6 +54,7 @@ class TestProcessorPullLoop:
     def test_processes_jobs_in_order_by_status(self):
         processed_ids: list[int] = []
         p = Processor()
+        p._validate_completed_video_output = MagicMock()
         jobs = _make_jobs("a.mp4", "b.mp4", "c.mp4")
 
         def fake_pipeline(job_id, inp, out):
@@ -75,6 +76,7 @@ class TestProcessorPullLoop:
     def test_skips_removed_pending_job(self):
         processed_ids: list[int] = []
         p = Processor()
+        p._validate_completed_video_output = MagicMock()
         jobs = _make_jobs("a.mp4", "b.mp4", "c.mp4")
 
         call_count = [0]
@@ -103,6 +105,7 @@ class TestProcessorPullLoop:
     def test_progress_update_carries_job_id(self):
         updates: list[ProgressUpdate] = []
         p = Processor(on_progress=lambda u: updates.append(u))
+        p._validate_completed_video_output = MagicMock()
         jobs = _make_jobs("a.mp4")
 
         with patch.object(p, "_run_pipeline"):
@@ -122,6 +125,7 @@ class TestProcessorPullLoop:
     def test_reorder_during_processing_respects_new_order(self):
         processed_filenames: list[str] = []
         p = Processor()
+        p._validate_completed_video_output = MagicMock()
         jobs = _make_jobs("a.mp4", "b.mp4", "c.mp4")
 
         call_count = [0]
@@ -152,6 +156,7 @@ class TestProcessorPullLoop:
     def test_runs_post_export_action_after_queue_completes(self):
         calls: list[tuple[str, str]] = []
         p = Processor()
+        p._validate_completed_video_output = MagicMock()
         jobs = _make_jobs("a.mp4")
 
         with (
@@ -183,6 +188,7 @@ class TestProcessorPullLoop:
     def test_runs_post_export_video_command_after_each_video(self, tmp_path):
         calls: list[tuple[str, Path, Path]] = []
         p = Processor()
+        p._validate_completed_video_output = MagicMock()
         jobs = _make_jobs(str(tmp_path / "a.mp4"), str(tmp_path / "b.mp4"))
 
         with (
@@ -219,6 +225,7 @@ class TestProcessorPullLoop:
 
     def test_post_export_video_command_failure_marks_job_error_and_continues(self, tmp_path):
         p = Processor()
+        p._validate_completed_video_output = MagicMock()
         jobs = _make_jobs(str(tmp_path / "a.mp4"), str(tmp_path / "b.mp4"))
 
         def run_command(_command, _input_path, output_path, _cancel):
@@ -268,6 +275,7 @@ class TestProcessorPullLoop:
         (tmp_path / "clip_restored.mp4").touch()
         command = MagicMock()
         p = Processor()
+        p._validate_completed_video_output = MagicMock()
         jobs = _make_jobs(str(tmp_path / "clip.mp4"))
 
         with (
@@ -291,6 +299,7 @@ class TestProcessorPullLoop:
     def test_per_video_and_queue_wide_actions_both_run(self, tmp_path):
         calls: list[str] = []
         p = Processor()
+        p._validate_completed_video_output = MagicMock()
         jobs = _make_jobs(str(tmp_path / "clip.mp4"))
 
         with (

--- a/tests/test_gui_processor_stop.py
+++ b/tests/test_gui_processor_stop.py
@@ -152,6 +152,53 @@ def test_video_post_export_runs_after_final_output_validation(tmp_path):
     assert output_paths_during_validation == [None]
 
 
+def test_stop_during_final_validation_prevents_completion_markers(tmp_path):
+    def write_new_output(job_id, input_path, output_path, **kwargs):
+        output_path.write_bytes(b"new completed output")
+
+    processor, job, updates = _processor_with_job(tmp_path, write_new_output)
+    processor._settings.pre_scan_policy = "off"
+
+    def validate(*_args, **_kwargs):
+        processor.stop()
+
+    with patch(
+        "jasna.media.splice.sync_and_validate_final_output",
+        side_effect=validate,
+    ):
+        processor._run()
+
+    assert processor._stop_event.is_set()
+    assert job.status is JobStatus.PENDING
+    assert job.output_path is None
+    assert getattr(processor, "completed_processing_path", lambda _job_id: None)(job.id) is None
+    assert updates[-1].status is JobStatus.PENDING
+
+
+def test_stop_during_post_export_prevents_completion_markers(tmp_path):
+    def write_new_output(job_id, input_path, output_path, **kwargs):
+        output_path.write_bytes(b"new completed output")
+
+    processor, job, updates = _processor_with_job(tmp_path, write_new_output)
+    processor._settings = AppSettings(post_export_video_command="remux {output}")
+    processor._settings.pre_scan_policy = "off"
+
+    with (
+        patch("jasna.media.splice.sync_and_validate_final_output"),
+        patch(
+            "jasna.post_export_action.run_post_export_video_command",
+            side_effect=lambda *_args, **_kwargs: processor.stop(),
+        ),
+    ):
+        processor._run()
+
+    assert processor._stop_event.is_set()
+    assert job.status is JobStatus.PENDING
+    assert job.output_path is None
+    assert getattr(processor, "completed_processing_path", lambda _job_id: None)(job.id) is None
+    assert updates[-1].status is JobStatus.PENDING
+
+
 def test_validation_failure_skips_video_post_export_command(tmp_path):
     def write_new_output(job_id, input_path, output_path, **kwargs):
         output_path.write_bytes(b"new completed output")

--- a/tests/test_gui_processor_stop.py
+++ b/tests/test_gui_processor_stop.py
@@ -1,4 +1,5 @@
 import threading
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -60,12 +61,133 @@ def test_completed_job_stays_completed(tmp_path):
         tmp_path,
         lambda job_id, input_path, output_path, **kwargs: None,
     )
+    processor._validate_completed_video_output = MagicMock()
 
     processor._run()
 
     assert job.status is JobStatus.COMPLETED
     assert job.output_path == tmp_path / "clip_restored.mp4"
     assert updates[-1].status is JobStatus.COMPLETED
+
+
+def test_pipeline_return_without_output_is_not_completed(tmp_path):
+    processor, job, updates = _processor_with_job(
+        tmp_path,
+        lambda job_id, input_path, output_path, **kwargs: None,
+    )
+
+    processor._run()
+
+    assert job.status is JobStatus.ERROR
+    assert updates[-1].status is JobStatus.ERROR
+    assert "completed output is missing" in updates[-1].message
+
+
+def test_overwrite_pipeline_cannot_claim_unchanged_preexisting_output(tmp_path):
+    existing = tmp_path / "clip_restored.mp4"
+    existing.write_bytes(b"old completed output")
+    processor, job, updates = _processor_with_job(
+        tmp_path,
+        lambda job_id, input_path, output_path, **kwargs: None,
+    )
+    processor._settings = AppSettings(file_conflict="overwrite")
+
+    processor._run()
+
+    assert job.status is JobStatus.ERROR
+    assert updates[-1].status is JobStatus.ERROR
+    assert "not created or changed" in updates[-1].message
+
+
+def test_changed_video_output_is_synced_before_completion(tmp_path):
+    existing = tmp_path / "clip_restored.mp4"
+    existing.write_bytes(b"old")
+
+    def write_new_output(job_id, input_path, output_path, **kwargs):
+        output_path.write_bytes(b"new completed output")
+
+    processor, job, updates = _processor_with_job(tmp_path, write_new_output)
+    processor._settings = AppSettings(file_conflict="overwrite", codec="hevc")
+
+    with patch("jasna.media.splice.sync_and_validate_final_output") as validate:
+        processor._run()
+
+    assert job.status is JobStatus.COMPLETED
+    assert updates[-1].status is JobStatus.COMPLETED
+    validate.assert_called_once_with(
+        existing,
+        source=job.path,
+        expected_codec="hevc",
+    )
+
+
+def test_video_post_export_runs_after_final_output_validation(tmp_path):
+    events: list[str] = []
+    output_paths_during_validation = []
+
+    def write_new_output(job_id, input_path, output_path, **kwargs):
+        output_path.write_bytes(b"new completed output")
+
+    processor, job, _updates = _processor_with_job(tmp_path, write_new_output)
+    processor._settings = AppSettings(post_export_video_command="remux {output}")
+
+    def validate(*_args, **_kwargs):
+        events.append("validate")
+        output_paths_during_validation.append(job.output_path)
+
+    with (
+        patch(
+            "jasna.media.splice.sync_and_validate_final_output",
+            side_effect=validate,
+        ),
+        patch(
+            "jasna.post_export_action.run_post_export_video_command",
+            side_effect=lambda *_args, **_kwargs: events.append("post-export"),
+        ),
+    ):
+        processor._run()
+
+    assert job.status is JobStatus.COMPLETED
+    assert events == ["validate", "post-export"]
+    assert output_paths_during_validation == [None]
+
+
+def test_validation_failure_skips_video_post_export_command(tmp_path):
+    def write_new_output(job_id, input_path, output_path, **kwargs):
+        output_path.write_bytes(b"new completed output")
+
+    processor, job, updates = _processor_with_job(tmp_path, write_new_output)
+    processor._settings = AppSettings(post_export_video_command="remux {output}")
+
+    with (
+        patch(
+            "jasna.media.splice.sync_and_validate_final_output",
+            side_effect=RuntimeError("final output invalid"),
+        ),
+        patch("jasna.post_export_action.run_post_export_video_command") as command,
+    ):
+        processor._run()
+
+    assert job.status is JobStatus.ERROR
+    assert updates[-1].status is JobStatus.ERROR
+    command.assert_not_called()
+
+
+def test_image_jobs_do_not_require_video_output_validation(tmp_path):
+    job = JobItem(path=tmp_path / "image.png")
+    processor = Processor()
+    processor._jobs = [job]
+    processor._settings = AppSettings()
+    processor._output_folder = str(tmp_path)
+    processor._output_pattern = "{original}_restored.mp4"
+    processor._run_pipeline = MagicMock()
+    processor._validate_completed_video_output = MagicMock()
+
+    processor._run()
+
+    assert job.status is JobStatus.COMPLETED
+    assert job.output_path == tmp_path / "image_restored.png"
+    processor._validate_completed_video_output.assert_not_called()
 
 
 def test_stop_cancels_the_running_pipeline(tmp_path):

--- a/tests/test_gui_segments.py
+++ b/tests/test_gui_segments.py
@@ -45,6 +45,7 @@ def test_processor_passes_frozen_segments_to_video_job(tmp_path) -> None:
 
     with (
         patch.object(processor, "_run_pipeline") as run_pipeline,
+        patch.object(processor, "_validate_completed_video_output"),
         patch("jasna.gui.processor._cleanup_torch"),
     ):
         processor._process_job(job)
@@ -71,6 +72,7 @@ def test_processor_uses_each_videos_detection_and_projection_overrides(tmp_path)
 
     with (
         patch.object(processor, "_run_pipeline") as run_pipeline,
+        patch.object(processor, "_validate_completed_video_output"),
         patch("jasna.gui.processor._cleanup_torch"),
     ):
         processor._process_job(job)

--- a/tests/test_splice.py
+++ b/tests/test_splice.py
@@ -11,13 +11,19 @@ from jasna.accelerator import AcceleratorVendor
 from jasna.media import VideoMetadata
 from jasna.media.splice import (
     KeyframeIndex,
+    OutputValidationError,
     SpliceSpan,
     SmartRenderCompatibilityError,
     _analyze_packet_reordering,
+    _commit_smart_output,
+    _fsync_directory,
+    _fsync_file,
     _is_safe_random_access_packet,
     build_splice_plan,
     create_copy_fragment,
     resolve_smart_encoder_settings,
+    sync_and_validate_final_output,
+    validate_video_output,
     validate_smart_render,
 )
 from jasna.segments import SegmentRange
@@ -332,3 +338,168 @@ def test_copy_fragment_seeks_before_demux(tmp_path: Path) -> None:
     ]
     assert packet.pts == 5
     assert packet.dts == 3
+
+
+def test_validate_video_output_rejects_missing_output(tmp_path: Path) -> None:
+    with pytest.raises(OutputValidationError, match="missing"):
+        validate_video_output(tmp_path / "missing.mp4")
+
+
+def test_sync_and_validate_final_output_validates_before_and_after_sync(
+    monkeypatch, tmp_path: Path
+) -> None:
+    import jasna.media.splice as module
+
+    output = tmp_path / "output.mp4"
+    source = tmp_path / "source.mp4"
+    events = []
+
+    monkeypatch.setattr(
+        module,
+        "validate_video_output",
+        lambda path, **kwargs: events.append(("validate", Path(path), kwargs)),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fsync_file",
+        lambda path: events.append(("fsync-file", Path(path))),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fsync_directory",
+        lambda path: events.append(("fsync-directory", Path(path))),
+    )
+
+    sync_and_validate_final_output(
+        output,
+        source=source,
+        expected_codec="hevc",
+    )
+
+    assert [event[0] for event in events] == [
+        "validate",
+        "fsync-file",
+        "fsync-directory",
+        "validate",
+    ]
+    assert events[0] == events[-1]
+    assert events[0][1] == output
+    assert events[0][2] == {
+        "source": source,
+        "expected_codec": "hevc",
+        "expected_duration": None,
+    }
+
+
+def test_directory_sync_is_safe_noop_on_windows(monkeypatch, tmp_path: Path) -> None:
+    import jasna.media.splice as module
+
+    open_directory = MagicMock()
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    monkeypatch.setattr(module.os, "open", open_directory)
+
+    _fsync_directory(tmp_path)
+
+    open_directory.assert_not_called()
+
+
+def test_windows_file_sync_reopens_output_with_write_access(
+    monkeypatch, tmp_path: Path
+) -> None:
+    import jasna.media.splice as module
+
+    output = tmp_path / "output.mp4"
+    output.write_bytes(b"completed output")
+    opened_modes = []
+    original_open = Path.open
+
+    def record_open(path, mode="r", *args, **kwargs):
+        opened_modes.append(mode)
+        return original_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    monkeypatch.setattr(Path, "open", record_open)
+    monkeypatch.setattr(module.os, "fsync", lambda _fd: None)
+
+    _fsync_file(output)
+
+    assert opened_modes == ["r+b"]
+
+
+def test_smart_output_commit_orders_validation_sync_replace_and_final_validation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    import jasna.media.splice as module
+
+    temporary = tmp_path / ".output.smart-render.mp4"
+    destination = tmp_path / "output.mp4"
+    source = tmp_path / "source.mp4"
+    events = []
+
+    monkeypatch.setattr(
+        module,
+        "validate_video_output",
+        lambda path, **kwargs: events.append(("validate", Path(path), kwargs)),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fsync_file",
+        lambda path: events.append(("fsync-file", Path(path))),
+    )
+    monkeypatch.setattr(
+        module.os,
+        "replace",
+        lambda src, dst: events.append(("replace", Path(src), Path(dst))),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fsync_directory",
+        lambda path: events.append(("fsync-directory", Path(path))),
+    )
+
+    _commit_smart_output(
+        temporary,
+        destination,
+        source=source,
+        codec="hevc",
+    )
+
+    assert [event[0] for event in events] == [
+        "validate",
+        "fsync-file",
+        "replace",
+        "fsync-file",
+        "fsync-directory",
+        "validate",
+    ]
+    assert events[0][1] == temporary
+    assert events[3][1] == destination
+    assert events[-1][1] == destination
+
+
+def test_smart_output_commit_keeps_temporary_on_precommit_failure(
+    monkeypatch, tmp_path: Path
+) -> None:
+    import jasna.media.splice as module
+
+    temporary = tmp_path / ".output.smart-render.mp4"
+    destination = tmp_path / "output.mp4"
+    source = tmp_path / "source.mp4"
+    temporary.write_bytes(b"recovery artifact")
+
+    def reject_temporary(path, **_kwargs):
+        if Path(path) == temporary:
+            raise OutputValidationError("bad temporary")
+
+    monkeypatch.setattr(module, "validate_video_output", reject_temporary)
+
+    with pytest.raises(OutputValidationError, match="bad temporary"):
+        _commit_smart_output(
+            temporary,
+            destination,
+            source=source,
+            codec="hevc",
+        )
+
+    assert temporary.read_bytes() == b"recovery artifact"
+    assert not destination.exists()


### PR DESCRIPTION
# Final video output durability

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/310#issuecomment-5312163472).

## Scope

This candidate is based on current `upstream/main` at `592472bda8aeb1fc0d5cea3d3ff6607add0ab0a7` and is independently mergeable. It hardens the normal GUI `Processor` video path without changing encoder selection, Smart Render span planning, stream mapping, or layout.

Candidate HEAD: `36901c759596a7d18c93b7f3e5bda89c7f0c40dd`.

## Changes

- snapshot the resolved output fingerprint before processing and reject missing or unchanged completion output;
- validate codec, duration, readable tail, file fsync, and parent-directory fsync before terminal completion;
- keep Smart Render/source-copy temporary-file publication intact;
- use `_completion_lock` for Stop, direct pending-job claim, and terminal completion so Stop cannot be followed by a newly started queued job or a newly created output directory;
- render GUI Full Render jobs to same-directory hidden `.<stem>.jasna-full-<uuid><suffix>` staging;
- after successful pipeline completion, validate and atomically publish staging with `commit_video_output`/`os.replace`;
- remove hidden staging on Stop or failure and preserve any previous final file;
- keep still-image processing outside the video-output validation path.

## Completion contract

If Stop wins before a pending job is claimed, no pipeline starts and no later output directory is created. If Stop wins during validation or the post-export command, output-path, completed-path, and Completed status remain unset. If the terminal commit wins first, the completed state remains authoritative.

## Deferred integration

This upstream-base candidate contains no source-copy/pre-scan route and no isolated child protocol because those paths do not exist on `upstream/main`. The collection composes the same lock with PR #303, PR #304, and PR #305. CLI callers that construct `Pipeline` directly are outside this GUI `Processor` publication change.

## Validation

- Baseline probe: Stop still allowed `pipeline_calls=1` and created the nested output directory; Full Render used the final file name directly with `publish_calls=0`.
- Modified probe: Stop left `pipeline_calls=0` and no nested directory; Full Render used hidden staging, published once, removed staging, and left complete final bytes.
- Baseline focused tests: `50 passed`; modified focused tests: `54 passed`.
- Integrated affected group: `123 passed`.
- Tested reverse patch restored all three modified files and both baseline behaviors.
- Transaction evidence: `D:\jasna_out\verification\final_output_pr310_v2_20260818`.

## Important paths

- `jasna/media/splice.py`
- `jasna/gui/processor.py`
- `tests/test_splice.py`
- `tests/test_gui_processor_stop.py`
