### PR TITLE
fix: propagate pipeline worker failures

### DIFF
--- a/jasna/gui/restoration_preview.py
+++ b/jasna/gui/restoration_preview.py
@@ -383,7 +383,7 @@ class RestorationPreviewWorker:
         session: RestorationSession,
         detection_model,
     ) -> RestorationFrame | RestorationClip | None:
-        from queue import Empty, Queue
+        from queue import Queue
 
         from jasna.blend_buffer import BlendBuffer
         from jasna.crop_buffer import CropBuffer
@@ -393,6 +393,7 @@ class RestorationPreviewWorker:
             decode_detect_loop,
             primary_restore_loop,
             secondary_restore_loop,
+            wait_for_worker_threads,
         )
         from jasna.vram_offloader import VramOffloader
 
@@ -558,20 +559,11 @@ class RestorationPreviewWorker:
                 break
             time.sleep(0.05)
 
-        all_queues = [clip_queue, secondary_queue, encode_queue, metadata_queue]
-
-        def _drain_all_queues():
-            for q in all_queues:
-                try:
-                    while True:
-                        q.get_nowait()
-                except Empty:
-                    pass
-
-        for t in threads:
-            while t.is_alive():
-                _drain_all_queues()
-                t.join(timeout=0.02)
+        wait_for_worker_threads(
+            threads,
+            (clip_queue, secondary_queue, encode_queue, metadata_queue),
+            cancel_event,
+        )
         vram_offloader.stop()
 
         with self._cancel_lock:

--- a/jasna/pipeline.py
+++ b/jasna/pipeline.py
@@ -34,7 +34,14 @@ from jasna.media.splice import (
 from jasna.mosaic.detection_registry import build_detection_model
 from jasna.pipeline_debug_logging import PipelineDebugMemoryLogger
 from jasna.pipeline_items import FrameMeta, PrimaryRestoreResult, SecondaryLoopStats, _SENTINEL
-from jasna.pipeline_threads import decode_detect_loop, primary_restore_loop, secondary_restore_loop, blend_encode_loop
+from jasna.pipeline_threads import (
+    blend_encode_loop,
+    decode_detect_loop,
+    primary_restore_loop,
+    record_worker_error,
+    secondary_restore_loop,
+    wait_for_worker_threads,
+)
 from jasna.progressbar import Progressbar
 from jasna.restorer import RestorationPipeline
 from jasna.restorer.secondary_restorer import AsyncSecondaryRestorer
@@ -205,6 +212,7 @@ class Pipeline:
         debug_memory: PipelineDebugMemoryLogger | None = None,
         clip_queue: FrameQueue | None = None,
         primary_idle_event: threading.Event | None = None,
+        cancel_event: threading.Event | None = None,
     ) -> SecondaryLoopStats:
         restorer: AsyncSecondaryRestorer = self.restoration_pipeline.secondary_restorer  # type: ignore[assignment]
         pending_prs: dict[int, PrimaryRestoreResult] = {}
@@ -220,7 +228,12 @@ class Pipeline:
             nonlocal last_push_time, flushed_since_last_push, pusher_stall_seconds, clips_pushed
             try:
                 while True:
-                    item = secondary_queue.get()
+                    if cancel_event is not None and cancel_event.is_set():
+                        break
+                    try:
+                        item = secondary_queue.get(timeout=self._ASYNC_POLL_TIMEOUT)
+                    except Empty:
+                        continue
                     if item is _SENTINEL:
                         break
                     pr: PrimaryRestoreResult = item  # type: ignore[assignment]
@@ -279,6 +292,8 @@ class Pipeline:
         starvation_start: float | None = None
 
         while not push_done.is_set():
+            if cancel_event is not None and cancel_event.is_set():
+                break
             if pusher_error:
                 raise pusher_error[0]
 
@@ -323,6 +338,14 @@ class Pipeline:
         pusher_thread.join()
         if pusher_error:
             raise pusher_error[0]
+        if cancel_event is not None and cancel_event.is_set():
+            return SecondaryLoopStats(
+                starvation_flushes=starvation_count,
+                starvation_seconds=starvation_seconds,
+                pusher_stall_seconds=pusher_stall_seconds,
+                clips_pushed=clips_pushed,
+                clips_popped=clips_popped,
+            )
         restorer.flush_all()
         for _ in range(100):
             if not pending_prs:
@@ -396,10 +419,21 @@ class Pipeline:
             nonlocal starvation_stats
             try:
                 torch.cuda.set_device(device)
-                starvation_stats = self._run_secondary_loop(secondary_queue, encode_queue, debug_memory, clip_queue, primary_idle_event)
+                starvation_stats = self._run_secondary_loop(
+                    secondary_queue,
+                    encode_queue,
+                    debug_memory,
+                    clip_queue,
+                    primary_idle_event,
+                    self._cancel_event,
+                )
             except BaseException as e:
-                log.exception("[secondary-async] thread crashed")
-                error_holder.append(e)
+                record_worker_error(
+                    "secondary-async",
+                    e,
+                    error_holder,
+                    self._cancel_event,
+                )
             finally:
                 encode_queue.put(_SENTINEL)
 
@@ -489,8 +523,11 @@ class Pipeline:
         vram_offloader.start()
         for t in threads:
             t.start()
-        for t in threads:
-            t.join()
+        wait_for_worker_threads(
+            threads,
+            (clip_queue, secondary_queue, encode_queue, metadata_queue),
+            self._cancel_event,
+        )
         vram_offloader.stop()
         frame_writer.close()
 

--- a/jasna/pipeline_threads.py
+++ b/jasna/pipeline_threads.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections.abc import Iterable, Sequence
 from queue import Empty, Queue
-from typing import Protocol
+from typing import Any, Protocol
 
 import torch
 
@@ -22,6 +23,49 @@ from jasna.tracking import ClipTracker
 from jasna.tracking.scene_detector import SceneCutDetector
 
 log = logging.getLogger(__name__)
+
+
+def record_worker_error(
+    label: str,
+    error: BaseException,
+    error_holder: list[BaseException],
+    cancel_event: threading.Event | None,
+) -> None:
+    """Record the first worker failure and ask the other workers to stop."""
+    if cancel_event is not None and cancel_event.is_set():
+        return
+    log.exception("[%s] thread crashed", label)
+    error_holder.append(error)
+    if cancel_event is not None:
+        cancel_event.set()
+
+
+def _drain_pipeline_queues(queues: Iterable[Any]) -> None:
+    for pipeline_queue in queues:
+        while True:
+            try:
+                pipeline_queue.get_nowait()
+            except Empty:
+                break
+
+
+def wait_for_worker_threads(
+    threads: Sequence[threading.Thread],
+    queues: Iterable[Any],
+    cancel_event: threading.Event,
+    *,
+    poll_interval: float = 0.02,
+) -> None:
+    """Join workers while releasing blocked producers during cancellation."""
+    pipeline_queues = tuple(queues)
+    while True:
+        alive = [thread for thread in threads if thread.is_alive()]
+        if not alive:
+            return
+        if cancel_event.is_set():
+            _drain_pipeline_queues(pipeline_queues)
+        for thread in alive:
+            thread.join(timeout=poll_interval)
 
 
 class FrameWriter(Protocol):
@@ -217,9 +261,7 @@ def decode_detect_loop(
                 if progress is not None and close_progress:
                     progress.close(ensure_completed_bar=True)
     except BaseException as e:
-        if cancel_event is None or not cancel_event.is_set():
-            log.exception("[decode] thread crashed")
-            error_holder.append(e)
+        record_worker_error("decode", e, error_holder, cancel_event)
     finally:
         log.info(timer.summary())
         log.debug("[decode] thread exiting")
@@ -278,9 +320,7 @@ def primary_restore_loop(
                     f"clip={clip_item.clip.track_id} frames={len(clip_item.raw_crops)}",
                 )
     except BaseException as e:
-        if cancel_event is None or not cancel_event.is_set():
-            log.exception("[primary] thread crashed")
-            error_holder.append(e)
+        record_worker_error("primary", e, error_holder, cancel_event)
     finally:
         log.info(timer.summary())
         log.debug("[primary] thread exiting")
@@ -332,9 +372,7 @@ def secondary_restore_loop(
                     f"clip={pr.track_id} frames={sr.frame_count}",
                 )
     except BaseException as e:
-        if cancel_event is None or not cancel_event.is_set():
-            log.exception("[secondary] thread crashed")
-            error_holder.append(e)
+        record_worker_error("secondary", e, error_holder, cancel_event)
     finally:
         log.info(timer.summary())
         log.debug("[secondary] thread exiting")
@@ -442,9 +480,7 @@ def blend_encode_loop(
                 vram_offloader.pause_stall_check()
 
     except BaseException as e:
-        if cancel_event is None or not cancel_event.is_set():
-            log.exception("[blend-encode] thread crashed")
-            error_holder.append(e)
+        record_worker_error("blend-encode", e, error_holder, cancel_event)
     finally:
         log.info(timer.summary())
 

--- a/tests/test_pipeline_run.py
+++ b/tests/test_pipeline_run.py
@@ -1,5 +1,6 @@
 from fractions import Fraction
 from pathlib import Path
+import threading
 from unittest.mock import MagicMock, patch, call
 
 from jasna.crop_buffer import RawCrop
@@ -525,6 +526,89 @@ class TestPipelineRun:
         ):
             with pytest.raises(RuntimeError, match="secondary boom"):
                 p.run()
+        assert p.cancel_requested
+
+    def test_run_secondary_failure_releases_bounded_queues_without_hanging(self):
+        """A secondary failure must unblock a primary producer before Pipeline returns."""
+        p = _make_pipeline()
+        p.max_clip_size = 1
+        p.temporal_overlap = 0
+        p.restoration_pipeline.secondary_restorer = None
+        p.restoration_pipeline.secondary_num_workers = 1
+
+        frames_t = torch.zeros((1, 3, 8, 8), dtype=torch.uint8)
+
+        def _reader_for_pipeline_worker(*_args, **_kwargs):
+            reader = MagicMock()
+            reader.__enter__ = MagicMock(return_value=reader)
+            reader.__exit__ = MagicMock(return_value=False)
+            if threading.current_thread().name == "DecodeDetect":
+                reader.frames.return_value = iter([(frames_t, [0])])
+            else:
+                reader.frames.return_value = iter([])
+            return reader
+
+        def _primary_result():
+            result = MagicMock()
+            result.keep_start = 0
+            result.keep_end = 1
+            result.primary_raw = torch.zeros((1, 3, 8, 8))
+            return result
+
+        p.restoration_pipeline.prepare_and_run_primary.side_effect = [
+            _primary_result(),
+            _primary_result(),
+            _primary_result(),
+        ]
+        p.restoration_pipeline._run_secondary.side_effect = RuntimeError("secondary failure")
+
+        from jasna.pipeline_processing import BatchProcessResult
+
+        def _emit_three_clips(**kwargs):
+            for _ in range(3):
+                kwargs["clip_queue"].put(MagicMock(), frame_count=1)
+            return BatchProcessResult(next_frame_idx=1, clips_emitted=3)
+
+        mock_encoder = MagicMock()
+        mock_encoder.__enter__ = MagicMock(return_value=mock_encoder)
+        mock_encoder.__exit__ = MagicMock(return_value=False)
+        errors: list[BaseException] = []
+        finished = threading.Event()
+
+        def _run_pipeline():
+            try:
+                p.run()
+            except BaseException as error:
+                errors.append(error)
+            finally:
+                finished.set()
+
+        with (
+            patch("jasna.pipeline.get_video_meta_data", return_value=_fake_metadata()),
+            patch("jasna.pipeline.NvidiaVideoEncoder", return_value=mock_encoder),
+            patch("jasna.pipeline.VramOffloader"),
+            patch("jasna.pipeline_threads.NvidiaVideoReader", side_effect=_reader_for_pipeline_worker),
+            patch("jasna.pipeline_threads.process_frame_batch", side_effect=_emit_three_clips),
+            patch("jasna.pipeline_threads.finalize_processing"),
+            patch("jasna.pipeline_threads.torch.cuda.set_device"),
+            patch(
+                "jasna.pipeline_threads.torch.inference_mode",
+                return_value=MagicMock(
+                    __enter__=MagicMock(),
+                    __exit__=MagicMock(return_value=False),
+                ),
+            ),
+        ):
+            runner = threading.Thread(target=_run_pipeline, daemon=True)
+            runner.start()
+            assert finished.wait(timeout=3), "Pipeline did not return after the secondary failure"
+            runner.join(timeout=0.2)
+
+        assert not runner.is_alive()
+        assert len(errors) == 1
+        assert isinstance(errors[0], RuntimeError)
+        assert str(errors[0]) == "secondary failure"
+        assert p.cancel_requested
 
     def test_run_secondary_loop(self):
         """Cover _run_secondary_loop: push_clip → flush → pop_completed → build_secondary_result."""

--- a/tests/test_pipeline_threads.py
+++ b/tests/test_pipeline_threads.py
@@ -22,9 +22,11 @@ from jasna.pipeline_threads import (
     FrameWriter,
     decode_detect_loop,
     primary_restore_loop,
+    record_worker_error,
     secondary_restore_loop,
     blend_encode_loop,
     _estimate_start_frame,
+    wait_for_worker_threads,
 )
 from jasna.tracking.clip_tracker import TrackedClip
 
@@ -84,6 +86,128 @@ class TestEstimateStartFrame:
     def test_zero(self):
         meta = _fake_metadata(fps=24.0)
         assert _estimate_start_frame(meta, 0.0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Worker failure shutdown
+# ---------------------------------------------------------------------------
+
+class TestWorkerFailureShutdown:
+    def test_record_worker_error_keeps_first_failure_and_cancels_peers(self):
+        cancel_event = threading.Event()
+        error_holder: list[BaseException] = []
+        first_error = RuntimeError("first worker failure")
+
+        try:
+            raise first_error
+        except RuntimeError as error:
+            record_worker_error("primary", error, error_holder, cancel_event)
+
+        try:
+            raise RuntimeError("second worker failure")
+        except RuntimeError as error:
+            record_worker_error("secondary", error, error_holder, cancel_event)
+
+        assert error_holder == [first_error]
+        assert cancel_event.is_set()
+
+    def test_record_worker_error_ignores_user_initiated_cancellation(self):
+        cancel_event = threading.Event()
+        cancel_event.set()
+        error_holder: list[BaseException] = []
+
+        try:
+            raise RuntimeError("cancelled worker")
+        except RuntimeError as error:
+            record_worker_error("decode", error, error_holder, cancel_event)
+
+        assert not error_holder
+
+    def test_wait_for_worker_threads_drains_queue_and_joins_cancelled_workers(self):
+        class TrackingFrameQueue:
+            def __init__(self):
+                self._queue = FrameQueue(max_frames=1)
+                self.drain_calls = 0
+
+            def put(self, item, frame_count=0):
+                self._queue.put(item, frame_count=frame_count)
+
+            def get_nowait(self):
+                self.drain_calls += 1
+                return self._queue.get_nowait()
+
+        cancel_event = threading.Event()
+        pipeline_queue = TrackingFrameQueue()
+        pipeline_queue.put("occupied", frame_count=1)
+        producer_entered = threading.Event()
+        producer_released = threading.Event()
+        peer_entered = threading.Event()
+        peer_released = threading.Event()
+
+        def blocked_producer():
+            producer_entered.set()
+            pipeline_queue.put("released", frame_count=1)
+            producer_released.set()
+
+        def peer_worker():
+            peer_entered.set()
+            cancel_event.wait(timeout=2)
+            peer_released.set()
+
+        threads = [
+            threading.Thread(target=blocked_producer),
+            threading.Thread(target=peer_worker),
+        ]
+        for thread in threads:
+            thread.start()
+
+        assert producer_entered.wait(timeout=1)
+        assert peer_entered.wait(timeout=1)
+        cancel_event.set()
+        wait_for_worker_threads(
+            threads,
+            (pipeline_queue,),
+            cancel_event,
+            poll_interval=0.001,
+        )
+
+        assert pipeline_queue.drain_calls >= 1
+        assert producer_released.is_set()
+        assert peer_released.is_set()
+        assert all(not thread.is_alive() for thread in threads)
+
+    def test_wait_for_worker_threads_does_not_drain_healthy_workers(self):
+        class NoDrainQueue:
+            def __init__(self):
+                self.drain_calls = 0
+
+            def get_nowait(self):
+                self.drain_calls += 1
+                raise AssertionError("healthy queues must not be drained")
+
+        worker_started = threading.Event()
+        worker_finished = threading.Event()
+
+        def healthy_worker():
+            worker_started.set()
+            time.sleep(0.03)
+            worker_finished.set()
+
+        thread = threading.Thread(target=healthy_worker)
+        thread.start()
+        assert worker_started.wait(timeout=1)
+
+        pipeline_queue = NoDrainQueue()
+        wait_for_worker_threads(
+            [thread],
+            (pipeline_queue,),
+            threading.Event(),
+            poll_interval=0.001,
+        )
+
+        assert worker_finished.is_set()
+        assert pipeline_queue.drain_calls == 0
+        assert not thread.is_alive()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Pipeline worker failure propagation

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/311#issuecomment-5312164325).

## Scope

This independently mergeable candidate is based on `upstream/main` at
`592472bda8aeb1fc0d5cea3d3ff6607add0ab0a7`. It prevents the restoration
pipeline from deadlocking when a worker fails while another worker is blocked
on a bounded pipeline queue.

Candidate commit: `e80946c6621241928a4a1797d5a1cb8efede8001`
(`fix: propagate pipeline worker failures`).

It deliberately does not include exact-PTS recovery, rocDecode reuse/backend
changes, VR/fisheye preview geometry, restoration batching policy, encoder
changes, GUI layout work, or integration-branch changes.

## Behavior

- `record_worker_error()` keeps the first worker failure, sets the shared
  cancellation event, and ignores later failures after cancellation has
  started. A pre-existing user cancellation is not reported as a worker
  failure.
- Decode, primary restore, secondary restore, blend/encode, and the async
  secondary wrapper all use that common error path.
- `wait_for_worker_threads()` joins every supplied worker. Only after the
  cancellation event is set, it drains the supplied bounded queues between
  timed joins, releasing producers blocked in queue `put()` calls. Healthy
  runs never drain queues, so their normal ordering is unchanged.
- The async-secondary pusher polls its input queue while cancellation-aware,
  then joins before the async worker exits. Cancellation skips its normal
  flush/finalization path rather than treating it as a new error.
- Preview now shares the same wait helper instead of unconditionally draining
  queues during ordinary completion.

Sentinel puts and the existing final cleanup remain in place. A cancelled run
may discard pending intermediate queue items, which is intentional because it
cannot produce a valid completed output after cancellation/failure.

## Validation

- Focused CPU-mock pytest covers first-error retention, cancellation,
  cancellation-only queue draining, release of a blocked bounded producer,
  joining every worker, and a secondary worker error propagating out of
  `Pipeline` without hanging.
- Existing pipeline-thread, pipeline-run, and restoration-preview tests are
  run together to check normal completion and preview cancellation behavior.
- Python compilation and whitespace/diff checks are run before handoff.

## Runtime smoke requested

This changes the shared restoration-thread lifecycle, so run a short real
video smoke on both NVIDIA and AMD. Exercise normal completion, user cancel,
and a deliberately invalid restoration/model input if practical; confirm the
GUI returns to idle without a stuck worker or a later batch item starting.
Cover available 8-bit and 10-bit inputs on each runtime. No GPU/native media
smoke is claimed by the CPU-mock tests above.

## Important paths

- `jasna/pipeline_threads.py`
- `jasna/pipeline.py`
- `jasna/gui/restoration_preview.py`
- `tests/test_pipeline_threads.py`
- `tests/test_pipeline_run.py`