### PR TITLE
fix(encoder): own buffered frames with PTS metadata

### DIFF
--- a/jasna/media/video_encoder.py
+++ b/jasna/media/video_encoder.py
@@ -402,6 +402,16 @@ def _normalized_audio_layout(layout: av.AudioLayout) -> av.AudioLayout:
     return layout
 
 
+@dataclass(order=True, frozen=True)
+class _BufferedEncodeItem:
+    """One encoder input kept together while the bounded PTS window reorders it."""
+
+    pts: int
+    sequence: int
+    frame: torch.Tensor = field(compare=False)
+    apply_lut: bool = field(compare=False)
+
+
 class NvidiaVideoEncoder:
     def __init__(
         self,
@@ -524,7 +534,8 @@ class NvidiaVideoEncoder:
             self.encoder_options.update(spec.smart_fragment_options)
 
         self.BUFFER_MAX_SIZE = 8
-        self._lut_flags: deque[bool] = deque()
+        self.frame_buffer: list[_BufferedEncodeItem] = []
+        self._next_buffer_sequence = 0
         # Set on AMD in __enter__, where the frame size is known; NVIDIA leaves
         # them None and allocates per frame (NVENC outlives encode()).
         self._packed: torch.Tensor | None = None
@@ -631,9 +642,8 @@ class NvidiaVideoEncoder:
                 dtype=dtype,
                 pin_memory=True,
             )
-        self.pts_heap: list[int] = []
-        self.frame_buffer: deque = deque()
-        self._lut_flags.clear()
+        self.frame_buffer = []
+        self._next_buffer_sequence = 0
         self.pts_set: set[int] = set()
         self._last_emitted_pts: int | None = None
         self._video_started = False
@@ -948,15 +958,14 @@ class NvidiaVideoEncoder:
 
     def _process_buffer(self, flush_all=False):
         if len(self.frame_buffer) > (self.BUFFER_MAX_SIZE // 2) or (flush_all and self.frame_buffer):
-            frame_to_encode = self.frame_buffer.popleft()
-            pts_to_assign = heapq.heappop(self.pts_heap)
-            self.pts_set.remove(pts_to_assign)
-            pts_to_assign = self._clamp_pts_monotonic(pts_to_assign)
-            apply_lut = self._lut_flags.popleft() if self._lut_flags else True
-            if apply_lut:
-                item = self._build_encode_item(frame_to_encode, pts_to_assign)
-            else:
-                item = self._build_encode_item(frame_to_encode, pts_to_assign, False)
+            buffered = heapq.heappop(self.frame_buffer)
+            self.pts_set.remove(buffered.pts)
+            pts_to_assign = self._clamp_pts_monotonic(buffered.pts)
+            item = self._build_encode_item(
+                buffered.frame,
+                pts_to_assign,
+                buffered.apply_lut,
+            )
             self._encode_queue.put(item)
 
     def _encoder_open_error(self, exc: Exception) -> RuntimeError:
@@ -1063,8 +1072,23 @@ class NvidiaVideoEncoder:
         pts = int(pts) - self.pts_origin
         while pts in self.pts_set:
             pts += 1
-        heapq.heappush(self.pts_heap, pts)
-        self.frame_buffer.append(frame)
-        self._lut_flags.append(bool(apply_lut))
+        # AMD rocDecode batch views can be reused by subsequent decode batches.
+        # Keep an independent tensor only on that path; NVIDIA retains its
+        # existing no-copy producer/worker storage contract.
+        owned_frame = (
+            frame.clone()
+            if self.vendor is AcceleratorVendor.AMD and isinstance(frame, torch.Tensor)
+            else frame
+        )
+        heapq.heappush(
+            self.frame_buffer,
+            _BufferedEncodeItem(
+                pts=pts,
+                sequence=self._next_buffer_sequence,
+                frame=owned_frame,
+                apply_lut=bool(apply_lut),
+            ),
+        )
+        self._next_buffer_sequence += 1
         self.pts_set.add(pts)
         self._process_buffer()

--- a/tests/test_video_encoder_unit.py
+++ b/tests/test_video_encoder_unit.py
@@ -1,6 +1,7 @@
 """Unit tests for NvidiaVideoEncoder internals (options, color guard, buffer, worker, audio pump)."""
 from __future__ import annotations
 
+import heapq
 import queue
 import threading
 from contextlib import nullcontext
@@ -771,17 +772,59 @@ class TestColorHandling:
 
 def _buffered_encoder(tmp_path) -> NvidiaVideoEncoder:
     enc = _make_encoder(tmp_path)
-    enc.pts_heap = []
-    enc.frame_buffer = deque()
+    enc.frame_buffer = []
+    enc._next_buffer_sequence = 0
     enc.pts_set = set()
     enc._last_emitted_pts = None
     enc._worker_error = None
     enc._encode_queue = MagicMock()
-    enc._build_encode_item = MagicMock(side_effect=lambda frame, pts: (frame, pts, None))
+    enc._build_encode_item = MagicMock(
+        side_effect=lambda frame, pts, apply_lut=True: (
+            frame,
+            pts,
+            apply_lut,
+            None,
+        )
+    )
     return enc
 
 
+def _buffered_encoder_for_vendor(tmp_path, monkeypatch, vendor) -> NvidiaVideoEncoder:
+    monkeypatch.setattr(
+        video_encoder_module,
+        "vendor_for_device",
+        lambda _device: vendor,
+    )
+    return _buffered_encoder(tmp_path)
+
+
+def _queued_encode_items(enc):
+    return [call.args[0] for call in enc._encode_queue.put.call_args_list]
+
+
 class TestEncodeBuffer:
+    @pytest.mark.parametrize(
+        ("vendor", "encoder_name"),
+        [
+            (AcceleratorVendor.NVIDIA, "hevc_nvenc"),
+            (AcceleratorVendor.AMD, "hevc_amf"),
+        ],
+    )
+    def test_buffer_setup_preserves_vendor_encoder_selection(
+        self, tmp_path, monkeypatch, vendor, encoder_name
+    ):
+        monkeypatch.setattr(
+            video_encoder_module,
+            "vendor_for_device",
+            lambda _device: vendor,
+        )
+
+        enc = _make_encoder(tmp_path)
+
+        assert enc.encoder_name == encoder_name
+        assert enc.frame_buffer == []
+        assert enc._next_buffer_sequence == 0
+
     @pytest.mark.parametrize(
         ("dtype", "width", "expected_pitch"),
         [
@@ -911,26 +954,64 @@ class TestEncodeBuffer:
         enc = _buffered_encoder(tmp_path)
         enc.pts_origin = 100
         enc.encode("frame", 110)
-        assert enc.pts_heap == [10]
+        assert [item.pts for item in enc.frame_buffer] == [10]
 
     def test_bridge_frame_records_lut_bypass(self, tmp_path):
         enc = _buffered_encoder(tmp_path)
         enc.encode("frame", 10, apply_lut=False)
-        assert list(enc.frame_buffer) == ["frame"]
-        assert list(enc._lut_flags) == [False]
+        buffered = enc.frame_buffer[0]
+        assert buffered.frame == "frame"
+        assert buffered.apply_lut is False
 
-    def test_encode_pushes_to_buffer_and_heap(self, tmp_path):
+    def test_encode_pushes_atomic_item_to_ordered_buffer(self, tmp_path):
         enc = _buffered_encoder(tmp_path)
         enc.encode("frame0", 10)
-        assert list(enc.frame_buffer) == ["frame0"]
-        assert enc.pts_heap == [10]
+        buffered = enc.frame_buffer[0]
+        assert buffered.pts == 10
+        assert buffered.sequence == 0
+        assert buffered.frame == "frame0"
+        assert buffered.apply_lut is True
         assert enc.pts_set == {10}
 
-    def test_encode_dedup_pts(self, tmp_path):
+    def test_duplicate_pts_are_adjusted_and_emit_in_enqueue_order(self, tmp_path):
         enc = _buffered_encoder(tmp_path)
-        enc.encode("a", 5)
-        enc.encode("b", 5)
-        assert sorted(enc.pts_set) == [5, 6]
+        enc.encode("first", 5, apply_lut=False)
+        enc.encode("second", 5, apply_lut=True)
+
+        while enc.frame_buffer:
+            enc._process_buffer(flush_all=True)
+
+        assert _queued_encode_items(enc) == [
+            ("first", 5, False, None),
+            ("second", 6, True, None),
+        ]
+        assert enc.pts_set == set()
+
+    def test_equal_pts_items_use_sequence_as_heap_tiebreaker(self):
+        heap = []
+        heapq.heappush(
+            heap,
+            video_encoder_module._BufferedEncodeItem(
+                pts=5,
+                sequence=1,
+                frame="later",
+                apply_lut=True,
+            ),
+        )
+        heapq.heappush(
+            heap,
+            video_encoder_module._BufferedEncodeItem(
+                pts=5,
+                sequence=0,
+                frame="first",
+                apply_lut=False,
+            ),
+        )
+
+        assert [heapq.heappop(heap).frame, heapq.heappop(heap).frame] == [
+            "first",
+            "later",
+        ]
 
     def test_flush_starts_above_half_buffer(self, tmp_path):
         enc = _buffered_encoder(tmp_path)
@@ -938,14 +1019,98 @@ class TestEncodeBuffer:
             enc.encode(f"f{i}", i)
         enc._encode_queue.put.assert_not_called()
         enc.encode("one-more", 99)
-        enc._encode_queue.put.assert_called_once_with(("f0", 0, None))
+        enc._encode_queue.put.assert_called_once_with(("f0", 0, True, None))
 
-    def test_smallest_pts_pairs_with_oldest_frame(self, tmp_path):
+    def test_out_of_order_pts_keep_frame_and_lut_together(self, tmp_path):
         enc = _buffered_encoder(tmp_path)
-        for i, pts in enumerate([30, 10, 20, 40]):
-            enc.encode(f"f{i}", pts)
+        for frame, pts, apply_lut in [
+            ("pts30", 30, True),
+            ("pts10", 10, False),
+            ("pts20", 20, True),
+            ("pts40", 40, False),
+        ]:
+            enc.encode(frame, pts, apply_lut=apply_lut)
         enc._process_buffer(flush_all=True)
-        enc._encode_queue.put.assert_called_once_with(("f0", 10, None))
+        enc._encode_queue.put.assert_called_once_with(("pts10", 10, False, None))
+
+    def test_amd_tensor_frame_is_owned_until_delayed_encode(
+        self, tmp_path, monkeypatch
+    ):
+        enc = _buffered_encoder_for_vendor(
+            tmp_path,
+            monkeypatch,
+            AcceleratorVendor.AMD,
+        )
+        source = torch.tensor([[[1]], [[2]], [[3]]], dtype=torch.uint8)
+
+        enc.encode(source, 10, apply_lut=False)
+        buffered = enc.frame_buffer[0]
+        source.fill_(99)
+
+        assert buffered.frame is not source
+        assert torch.equal(
+            buffered.frame,
+            torch.tensor([[[1]], [[2]], [[3]]], dtype=torch.uint8),
+        )
+
+        enc._process_buffer(flush_all=True)
+
+        emitted_frame, emitted_pts, emitted_lut, _ = _queued_encode_items(enc)[0]
+        assert emitted_frame is buffered.frame
+        assert emitted_pts == 10
+        assert emitted_lut is False
+        assert torch.equal(
+            emitted_frame,
+            torch.tensor([[[1]], [[2]], [[3]]], dtype=torch.uint8),
+        )
+
+    def test_nvidia_tensor_frame_keeps_existing_no_copy_reference(
+        self, tmp_path, monkeypatch
+    ):
+        enc = _buffered_encoder_for_vendor(
+            tmp_path,
+            monkeypatch,
+            AcceleratorVendor.NVIDIA,
+        )
+        source = torch.tensor([[[1]], [[2]], [[3]]], dtype=torch.uint8)
+
+        enc.encode(source, 10, apply_lut=False)
+        buffered = enc.frame_buffer[0]
+
+        # NVIDIA keeps its established no-copy producer/worker contract.
+        assert buffered.frame is source
+        source.fill_(99)
+        assert torch.equal(
+            buffered.frame,
+            torch.tensor([[[99]], [[99]], [[99]]], dtype=torch.uint8),
+        )
+
+        enc._process_buffer(flush_all=True)
+
+        emitted_frame, emitted_pts, emitted_lut, _ = _queued_encode_items(enc)[0]
+        assert emitted_frame is source
+        assert emitted_pts == 10
+        assert emitted_lut is False
+
+    def test_flush_all_orders_complete_items_by_pts(self, tmp_path):
+        enc = _buffered_encoder(tmp_path)
+        for frame, pts, apply_lut in [
+            ("pts40", 40, False),
+            ("pts10", 10, True),
+            ("pts30", 30, False),
+            ("pts20", 20, True),
+        ]:
+            enc.encode(frame, pts, apply_lut=apply_lut)
+
+        while enc.frame_buffer:
+            enc._process_buffer(flush_all=True)
+
+        assert _queued_encode_items(enc) == [
+            ("pts10", 10, True, None),
+            ("pts20", 20, True, None),
+            ("pts30", 30, False, None),
+            ("pts40", 40, False, None),
+        ]
 
     def test_emitted_pts_stay_strictly_increasing_on_scrambled_source(self, tmp_path):
         enc = _buffered_encoder(tmp_path)


### PR DESCRIPTION
# Encoder buffered-frame ownership

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/312#issuecomment-5312165123).

## Summary

This candidate replaces the encoder's separate PTS heap, FIFO frame deque, and
LUT-flag deque with one ordered `_BufferedEncodeItem`. Each delayed frame now
carries its PTS, insertion sequence, and LUT decision together, so bounded PTS
reordering cannot pair a frame or LUT decision with another frame's timestamp.

Only AMD Torch inputs are cloned when they enter the delayed buffer. This gives
the encoder independent storage when AMD rocDecode later reuses a batch view
before the bounded buffer emits it. NVIDIA retains its existing no-copy Tensor
storage contract, avoiding a new NVENC input-copy performance cost.

## Scope and compatibility

- Public branch: `fix/encoder-buffer-ownership`.
- Commit: `e4406b71bfd764df0546f754d40807e96d33f1e3`.
- Base: `upstream/main` at `592472bda8aeb1fc0d5cea3d3ff6607add0ab0a7`.
- Changes are limited to `jasna/media/video_encoder.py` and its focused unit
  coverage.
- Encoder options, vendor routing, frame formats, rate control, decode paths,
  and pipeline behavior are unchanged.
- The ownership copy is deliberately AMD-only: it covers the rocDecode reuse
  hazard without changing NVIDIA's established no-copy buffering behavior.
- Existing duplicate-PTS adjustment and the emitted monotonic-PTS clamp remain
  in place. The item's `sequence` supplies a deterministic heap tiebreaker for
  equal PTS values.

## Validation

- Encoder-buffer unit selection: 27 passed.
- Existing AMD-mocked encoder checks: 2 passed.
- Full `tests/test_video_encoder_unit.py` suite: 117 passed with the unit
  suite's NVIDIA-default construction forced through its existing vendor seam.
- `compileall` passed for the changed encoder and unit-test module.
- The full `tests/test_video_encoder_unit.py` run has 17 existing
  environment-specific failures on this ROCm host: legacy NVIDIA-default tests
  construct `cuda:0`, which resolves to AMD here. The focused buffer tests and
  AMD-mocked checks above pass independently. No real hardware encode was run
  in this worktree.

## Test request

Because this changes the shared delayed encoder path, run a real encode
regression on both NVIDIA and AMD hardware before merge. Exercise an
out-of-order-PTS source and a decoder/batch configuration that can reuse source
views; verify frame count, output duration, PTS monotonicity, and LUT-on/LUT-off
frame placement.