### PR TITLE
fix(encoder): preserve source format contracts

### DIFF
--- a/jasna/media/video_encoder.py
+++ b/jasna/media/video_encoder.py
@@ -274,6 +274,7 @@ NVENC_H264_SOURCE_BITRATE_CAP_FACTOR = 2.0
 # Any VBV buffer of roughly a second or more never becomes the binding
 # constraint; only sub-second buffers throttle, which is the #243 unit trap.
 SOURCE_BITRATE_CAP_BUFFER_RATIO = 2
+FFMPEG_ENCODER_RATE_MAX = 2_147_483_647
 
 
 def source_bitrate_cap_options(
@@ -295,9 +296,17 @@ def source_bitrate_cap_options(
             metadata.codec_name.lower(), DEFAULT_SOURCE_BITRATE_CAP_FACTOR
         )
     maxrate = int(metadata.video_bitrate * factor)
+    bufsize = maxrate * SOURCE_BITRATE_CAP_BUFFER_RATIO
+    if maxrate > FFMPEG_ENCODER_RATE_MAX or bufsize > FFMPEG_ENCODER_RATE_MAX:
+        logger.warning(
+            "Source bitrate ceiling for %s exceeds the encoder option range; "
+            "encoding without a source-tied bitrate ceiling",
+            metadata.video_file,
+        )
+        return {}
     return {
         "maxrate": str(maxrate),
-        "bufsize": str(maxrate * SOURCE_BITRATE_CAP_BUFFER_RATIO),
+        "bufsize": str(bufsize),
     }
 
 

--- a/jasna/pipeline.py
+++ b/jasna/pipeline.py
@@ -588,6 +588,7 @@ class Pipeline:
             lut_path=self.lut_path,
             sharpen_strength=self.sharpen_strength,
             output_fps=frame_rate.output_fps,
+            match_input_bit_depth=True,
             fmp4=self.fmp4,
         )
         try:

--- a/tests/test_pipeline_run.py
+++ b/tests/test_pipeline_run.py
@@ -193,6 +193,34 @@ class TestPipelineRun:
 
         assert encoder_cls.call_args.kwargs["fmp4"] is True
 
+    def test_full_render_matches_input_bit_depth(self):
+        p = _make_pipeline()
+
+        reader_cls, _, _ = _make_two_readers([])
+        mock_encoder = MagicMock()
+        mock_encoder.__enter__ = MagicMock(return_value=mock_encoder)
+        mock_encoder.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("jasna.pipeline.get_video_meta_data", return_value=_fake_metadata()),
+            patch("jasna.pipeline_threads.NvidiaVideoReader", reader_cls),
+            patch(
+                "jasna.pipeline.NvidiaVideoEncoder",
+                return_value=mock_encoder,
+            ) as encoder_cls,
+            patch("jasna.pipeline_threads.torch.cuda.set_device"),
+            patch(
+                "jasna.pipeline_threads.torch.inference_mode",
+                return_value=MagicMock(
+                    __enter__=MagicMock(),
+                    __exit__=MagicMock(return_value=False),
+                ),
+            ),
+        ):
+            p.run()
+
+        assert encoder_cls.call_args.kwargs["match_input_bit_depth"] is True
+
     def test_fmp4_is_dropped_for_segment_processing(self):
         p = _make_pipeline()
         p.fmp4 = True

--- a/tests/test_video_encoder_unit.py
+++ b/tests/test_video_encoder_unit.py
@@ -27,6 +27,7 @@ from jasna.media.video_encoder import (
     _mov_container_options,
     _normalized_audio_layout,
     NvidiaVideoEncoder,
+    source_bitrate_cap_options,
 )
 
 
@@ -549,6 +550,14 @@ class TestEncoderOptions:
         enc = _make_encoder(tmp_path, video_bitrate=0)
         assert "maxrate" not in enc.encoder_options
         assert "bufsize" not in enc.encoder_options
+
+    def test_source_bitrate_ceiling_skips_values_outside_encoder_range(self):
+        options = source_bitrate_cap_options(
+            _fake_metadata(video_bitrate=2_000_000_000),
+            output_codec="hevc",
+            vendor=AcceleratorVendor.NVIDIA,
+        )
+        assert options == {}
 
     @pytest.mark.parametrize("codec", ["hevc", "h264"])
     def test_explicit_maxrate_replaces_derived_ceiling(self, tmp_path, codec):


### PR DESCRIPTION
# Preserve full-render bit depth and safe bitrate ceilings

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/313#issuecomment-5312165908).

## Summary

This focused candidate restores two small shared encoder contracts. Full HEVC
and AV1 restoration now follows the source bit depth just like Smart Render,
and an automatically derived source-bitrate ceiling is omitted when FFmpeg's
signed 32-bit encoder option range cannot represent its `maxrate` or `bufsize`.

## Changes

- pass `match_input_bit_depth=True` to the ordinary full-render encoder;
- retain Main10/P010 for 10-bit HEVC/AV1 sources while allowing 8-bit sources
  to remain 8-bit instead of being promoted to Main10;
- calculate both derived `maxrate` and `bufsize` before applying them;
- log and omit the automatic ceiling if either value exceeds `2,147,483,647`;
- leave explicit user encoder settings and H.264 pixel format behavior intact.

## Scope and compatibility

- Public branch: `fix/encoder-output-contract` (`6e5930c`).
- Base: `upstream/main`; independently mergeable.
- Shared encoder call site: Linux/Windows and AMD/NVIDIA all use this contract.
- No decoder, scanner, GUI, model, Smart Render splice or native-code change.

## Validation

- Focused unit tests: **2 passed**.
- The bit-depth test verifies the full pipeline passes the source-matching
  contract to the encoder.
- The overflow test calls `source_bitrate_cap_options` directly with an
  explicit NVIDIA vendor, so it is independent of the AMD development host.
- A wider encoder unit class has known environment-dependent failures on this
  AMD host because those legacy tests assume NVIDIA defaults; production code
  was not changed to satisfy the wrong hardware assumption.

## Test request

On NVIDIA and Windows AMD, run short 8-bit and 10-bit HEVC plus AV1 full
restoration clips. Confirm output profile/pixel format matches the source,
duration/frame count is unchanged and normal source-bitrate caps still apply.