### PR TITLE
fix(vr): preserve adaptive fisheye mask geometry

### DIFF
--- a/jasna/blend_buffer.py
+++ b/jasna/blend_buffer.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import itertools
-import logging
 import threading
 from collections.abc import Callable
+from functools import partial
 
 import torch
 import torch.nn.functional as F
@@ -12,8 +12,6 @@ from jasna.crop_buffer import scale_offsets
 from jasna.pipeline_items import SecondaryRestoreResult
 from jasna.tracking.blending import create_bbox_blend_mask
 
-_log = logging.getLogger(__name__)
-
 
 class BlendBuffer:
     def __init__(
@@ -21,16 +19,41 @@ class BlendBuffer:
         device: torch.device,
         blend_mask_fn: Callable[
             [torch.Tensor, tuple[int, int, int, int], tuple[int, int]], torch.Tensor
-        ] = create_bbox_blend_mask,
+        ] | None = None,
         vr_projector=None,
+        fisheye_eye_width: int | None = None,
     ):
         self.device = device
-        self.blend_mask_fn = blend_mask_fn
+        self.fisheye_eye_width = (
+            int(fisheye_eye_width) if fisheye_eye_width is not None else None
+        )
+        self.blend_mask_fn = blend_mask_fn or partial(
+            create_bbox_blend_mask,
+            fisheye_eye_width=self.fisheye_eye_width,
+        )
         self.vr_projector = vr_projector
         self._lock = threading.Lock()
         self.pending_map: dict[int, set[int]] = {}
         self._results: dict[int, SecondaryRestoreResult] = {}
         self._result_last_frame: dict[int, int] = {}
+
+    def _combine_fisheye_masks_temporally(
+        self,
+        masks: list[torch.Tensor],
+        local_i: int,
+        current_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Union compatible previous/current/next Fisheye detector masks."""
+        mask_lr = current_mask > 0
+        available_masks = [mask_lr]
+        for neighbor_i in (local_i - 1, local_i + 1):
+            if 0 <= neighbor_i < len(masks):
+                neighbor = masks[neighbor_i]
+                if neighbor.shape == mask_lr.shape:
+                    available_masks.append(neighbor.to(mask_lr.device) > 0)
+        for neighbor_mask in available_masks[1:]:
+            mask_lr.logical_or_(neighbor_mask)
+        return mask_lr
 
     def register_frame(self, frame_idx: int, pending_track_ids: set[int]) -> None:
         if pending_track_ids:
@@ -59,7 +82,10 @@ class BlendBuffer:
         start = sr.start_frame
 
         with self._lock:
-            for i in itertools.chain(range(clip_offset), range(clip_offset + kept_count, sr.frame_count)):
+            for i in itertools.chain(
+                range(clip_offset),
+                range(clip_offset + kept_count, sr.frame_count),
+            ):
                 pending = self.pending_map.get(start + i)
                 if pending is not None:
                     pending.discard(sr.track_id)
@@ -130,7 +156,11 @@ class BlendBuffer:
             return
 
         frame_u8 = sr.restored_frames[local_i].to(device)
-        pad_offset, resize_shape = scale_offsets(frame_u8, sr.pad_offsets[local_i], sr.resize_shapes[local_i])
+        pad_offset, resize_shape = scale_offsets(
+            frame_u8,
+            sr.pad_offsets[local_i],
+            sr.resize_shapes[local_i],
+        )
         i_clip = clip_offset + local_i
         cw = sr.crossfade_weights.get(i_clip, 1.0) if sr.crossfade_weights else 1.0
 
@@ -140,8 +170,16 @@ class BlendBuffer:
         resize_h, resize_w = resize_shape
 
         mask_lr = sr.masks[local_i].to(device)
+        if self.fisheye_eye_width is not None:
+            mask_lr = self._combine_fisheye_masks_temporally(
+                sr.masks,
+                local_i,
+                mask_lr,
+            )
 
-        unpadded = frame_u8[:, pad_top:pad_top + resize_h, pad_left:pad_left + resize_w]
+        unpadded = frame_u8[
+            :, pad_top:pad_top + resize_h, pad_left:pad_left + resize_w
+        ]
         resized_back = F.interpolate(
             unpadded.unsqueeze(0).float(),
             size=(crop_h, crop_w),

--- a/jasna/crop_buffer.py
+++ b/jasna/crop_buffer.py
@@ -7,10 +7,13 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
+from jasna.vr_mask_geometry import sbs_fisheye_dilation_ratios
+
 RESTORATION_SIZE = 256
 BORDER_RATIO = 0.06
 MIN_BORDER = 20
 MAX_EXPANSION_FACTOR = 1.0
+MAX_SBS_BORDER_FACTOR = 0.5
 
 
 def _torch_pad_reflect(image: torch.Tensor, paddings: tuple[int, int, int, int]) -> torch.Tensor:
@@ -25,15 +28,20 @@ def _torch_pad_reflect(image: torch.Tensor, paddings: tuple[int, int, int, int])
 
 def expand_bbox(
     x1: int, y1: int, x2: int, y2: int, frame_h: int, frame_w: int,
+    *,
+    min_border_y: int = 0,
+    min_border_x: int = 0,
 ) -> tuple[int, int, int, int]:
     w = x2 - x1
     h = y2 - y1
 
     border = max(MIN_BORDER, int(max(w, h) * BORDER_RATIO)) if BORDER_RATIO > 0.0 else 0
-    x1_exp = max(0, x1 - border)
-    y1_exp = max(0, y1 - border)
-    x2_exp = min(frame_w, x2 + border)
-    y2_exp = min(frame_h, y2 + border)
+    border_y = max(border, int(min_border_y))
+    border_x = max(border, int(min_border_x))
+    x1_exp = max(0, x1 - border_x)
+    y1_exp = max(0, y1 - border_y)
+    x2_exp = min(frame_w, x2 + border_x)
+    y2_exp = min(frame_h, y2 + border_y)
 
     w = x2_exp - x1_exp
     h = y2_exp - y1_exp
@@ -110,6 +118,8 @@ def compute_enlarged_bbox(
     frame_h: int,
     frame_w: int,
     x_bounds: tuple[int, int] | None = None,
+    *,
+    fisheye_geometry: bool = False,
 ) -> tuple[int, int, int, int]:
     """Clamp ``bbox`` to ``x_bounds`` (an SBS eye seam) and grow it toward the
     256 restoration aspect via ``expand_bbox``. Shared by the axis-aligned 2D
@@ -126,6 +136,17 @@ def compute_enlarged_bbox(
     x2 = max(x_min, min(x2, x_max))
     y2 = max(0, min(y2, frame_h))
 
+    min_border_y = min_border_x = 0
+    if fisheye_geometry and x_bounds is not None and x2 > x1 and y2 > y1:
+        ratio_y, ratio_x = sbs_fisheye_dilation_ratios(
+            (x1, y1, x2, y2), frame_h, x_max - x_min
+        )
+        # Keep enough restored context for the wider rim mask without letting a
+        # small detection turn into a huge, low-detail 256px restoration crop.
+        border_cap = max(MIN_BORDER, round(max(x2 - x1, y2 - y1) * MAX_SBS_BORDER_FACTOR))
+        min_border_y = min(round(frame_h * ratio_y), border_cap)
+        min_border_x = min(round(frame_h * ratio_x), border_cap)
+
     x1_exp, y1_exp, x2_exp, y2_exp = expand_bbox(
         x1 - x_min,
         y1,
@@ -133,6 +154,8 @@ def compute_enlarged_bbox(
         y2,
         frame_h,
         x_max - x_min,
+        min_border_y=min_border_y,
+        min_border_x=min_border_x,
     )
     return x1_exp + x_min, y1_exp, x2_exp + x_min, y2_exp
 
@@ -144,9 +167,14 @@ def extract_crop(
     frame_w: int,
     *,
     x_bounds: tuple[int, int] | None = None,
+    fisheye_geometry: bool = False,
 ) -> RawCrop:
     x1_exp, y1_exp, x2_exp, y2_exp = compute_enlarged_bbox(
-        bbox, frame_h, frame_w, x_bounds
+        bbox,
+        frame_h,
+        frame_w,
+        x_bounds,
+        fisheye_geometry=fisheye_geometry,
     )
     if frame.device.type == "cpu":
         crop = torch.from_numpy(np.array(frame.numpy()[:, y1_exp:y2_exp, x1_exp:x2_exp]))

--- a/jasna/gui/restoration_preview.py
+++ b/jasna/gui/restoration_preview.py
@@ -440,7 +440,15 @@ class RestorationPreviewWorker:
         metadata_queue: Queue = Queue(maxsize=settings.max_clip_size * 5)
 
         error_holder: list[BaseException] = []
-        blend_buffer = BlendBuffer(device=session.device, vr_projector=vr_projector)
+        blend_buffer = BlendBuffer(
+            device=session.device,
+            vr_projector=vr_projector,
+            fisheye_eye_width=(
+                int(self.metadata.video_width) // 2
+                if vr_resolution.fisheye_mask_geometry
+                else None
+            ),
+        )
         crop_buffers: dict[int, CropBuffer] = {}
         crop_lock = threading.Lock()
         primary_idle_event = threading.Event()
@@ -503,6 +511,7 @@ class RestorationPreviewWorker:
                     end_pts=window.end_pts,
                     vr_mode=vr_resolution.resolved,
                     vr_projector=vr_projector,
+                    fisheye_mask_geometry=vr_resolution.fisheye_mask_geometry,
                 ),
                 name="PreviewDecodeDetect", daemon=True,
             ),

--- a/jasna/pipeline.py
+++ b/jasna/pipeline.py
@@ -365,7 +365,15 @@ class Pipeline:
         metadata_queue: Queue[FrameMeta | object] = Queue(maxsize=self.max_clip_size * 5)
 
         error_holder: list[BaseException] = []
-        blend_buffer = BlendBuffer(device=device, vr_projector=self._vr_projector)
+        blend_buffer = BlendBuffer(
+            device=device,
+            vr_projector=self._vr_projector,
+            fisheye_eye_width=(
+                int(metadata.video_width) // 2
+                if self._vr_resolution.fisheye_mask_geometry
+                else None
+            ),
+        )
         crop_buffers: dict[int, CropBuffer] = {}
         crop_lock = threading.Lock()
         primary_idle_event = threading.Event()
@@ -449,6 +457,7 @@ class Pipeline:
                     output_fps=float(frame_rate.output_fps),
                     vr_mode=self._vr_resolution.resolved,
                     vr_projector=self._vr_projector,
+                    fisheye_mask_geometry=self._vr_resolution.fisheye_mask_geometry,
                     cancel_event=self._cancel_event,
                 ),
                 name="DecodeDetect", daemon=True,

--- a/jasna/pipeline_processing.py
+++ b/jasna/pipeline_processing.py
@@ -16,7 +16,6 @@ from jasna.tracking.scene_detector import SceneCutDetector
 
 logger = logging.getLogger(__name__)
 
-
 @dataclass(frozen=True)
 class BatchProcessResult:
     next_frame_idx: int
@@ -135,6 +134,7 @@ def process_frame_batch(
     min_detection_duration: int = 0,
     scene_detector: SceneCutDetector | None = None,
     vr_projector=None,
+    fisheye_mask_geometry: bool = False,
 ) -> BatchProcessResult:
     effective_bs = len(pts_list)
     if effective_bs == 0:
@@ -155,7 +155,9 @@ def process_frame_batch(
         valid_masks = detections.masks[i]
 
         scene_cut_clips = tracker.flush() if i in scene_cuts else []
-        ended_clips, active_track_ids = tracker.update(current_frame_idx, valid_boxes, valid_masks)
+        ended_clips, active_track_ids = tracker.update(
+            current_frame_idx, valid_boxes, valid_masks
+        )
         ended_clips = scene_cut_clips + ended_clips
 
         blend_buffer.register_frame(current_frame_idx, active_track_ids)
@@ -169,7 +171,8 @@ def process_frame_batch(
                 crop_buffers[track_id] = CropBuffer(track_id=track_id, start_frame=clip.start_frame)
             bbox = clip.bboxes[-1]
             raw_crop = _extract_region_crop(
-                frame, bbox, frame_h, frame_w, crop_eye_width, vr_projector
+                frame, bbox, frame_h, frame_w, crop_eye_width, vr_projector,
+                fisheye_mask_geometry,
             )
             crop_buffers[track_id].add(raw_crop)
 
@@ -180,7 +183,8 @@ def process_frame_batch(
             if crop_buffers[tid].frame_count < ec.clip.frame_count:
                 bbox = ec.clip.bboxes[-1]
                 raw_crop = _extract_region_crop(
-                    frame, bbox, frame_h, frame_w, crop_eye_width, vr_projector
+                    frame, bbox, frame_h, frame_w, crop_eye_width, vr_projector,
+                    fisheye_mask_geometry,
                 )
                 crop_buffers[tid].add(raw_crop)
 
@@ -211,13 +215,18 @@ def _extract_region_crop(
     frame_w: int,
     crop_eye_width: int | None,
     vr_projector,
+    fisheye_mask_geometry: bool,
 ) -> RawCrop:
     x_bounds = _eye_bounds(bbox, crop_eye_width, frame_w)
     if vr_projector is not None:
         return vr_projector.extract_region_crop(
-            frame, bbox, frame_h, frame_w, x_bounds=x_bounds
+            frame, bbox, frame_h, frame_w, x_bounds=x_bounds,
+            fisheye_geometry=fisheye_mask_geometry,
         )
-    return extract_crop(frame, bbox, frame_h, frame_w, x_bounds=x_bounds)
+    return extract_crop(
+        frame, bbox, frame_h, frame_w, x_bounds=x_bounds,
+        fisheye_geometry=fisheye_mask_geometry,
+    )
 
 
 def _eye_bounds(

--- a/jasna/pipeline_threads.py
+++ b/jasna/pipeline_threads.py
@@ -60,6 +60,7 @@ def decode_detect_loop(
     debug_memory: PipelineDebugMemoryLogger | None = None,
     vr_mode: str = "off",
     vr_projector=None,
+    fisheye_mask_geometry: bool = False,
 ) -> None:
     timer = LoopTimer("decode-detect")
     try:
@@ -184,6 +185,7 @@ def decode_detect_loop(
                                     min_detection_duration=min_detection_duration,
                                     scene_detector=scene_detector,
                                     vr_projector=vr_projector,
+                                    fisheye_mask_geometry=fisheye_mask_geometry,
                                 )
                                 frame_idx = res.next_frame_idx
                             else:

--- a/jasna/streaming_pipeline.py
+++ b/jasna/streaming_pipeline.py
@@ -204,7 +204,15 @@ def _run_streaming_pass(
     metadata_queue: Queue[FrameMeta | object] = Queue(maxsize=pipeline.max_clip_size * 5)
 
     error_holder: list[BaseException] = []
-    blend_buffer = BlendBuffer(device=device, vr_projector=pipeline._vr_projector)
+    blend_buffer = BlendBuffer(
+        device=device,
+        vr_projector=pipeline._vr_projector,
+        fisheye_eye_width=(
+            int(metadata.video_width) // 2
+            if pipeline._vr_resolution.fisheye_mask_geometry
+            else None
+        ),
+    )
     crop_buffers: dict[int, CropBuffer] = {}
     crop_lock = threading.Lock()
     primary_idle_event = threading.Event()
@@ -247,6 +255,7 @@ def _run_streaming_pass(
                 seek_ts=seek_ts,
                 vr_mode=pipeline._vr_resolution.resolved,
                 vr_projector=pipeline._vr_projector,
+                fisheye_mask_geometry=pipeline._vr_resolution.fisheye_mask_geometry,
             ),
             name="StreamDecodeDetect", daemon=True,
         ),

--- a/jasna/tracking/blending.py
+++ b/jasna/tracking/blending.py
@@ -4,10 +4,14 @@ import torch
 import torch.nn.functional as F
 
 from jasna.accelerator import is_nvidia_device
+from jasna.vr_mask_geometry import (
+    SBS_CENTER_DILATION_RATIO,
+    sbs_fisheye_dilation_ratios,
+)
 
 _KERNEL_CACHE: dict[tuple[str, torch.dtype, str, int], torch.Tensor] = {}
 
-BLEND_DILATION_RATIO = 0.028
+BLEND_DILATION_RATIO = SBS_CENTER_DILATION_RATIO
 BLEND_FALLOFF_RATIO = 0.028
 
 
@@ -77,6 +81,9 @@ def create_blend_mask(
     frame_height: int,
     scale_y: float,
     scale_x: float,
+    *,
+    dilation_ratio_y: float | None = None,
+    dilation_ratio_x: float | None = None,
 ) -> torch.Tensor:
     """Create blend mask from detection mask with dilation and falloff.
 
@@ -92,11 +99,14 @@ def create_blend_mask(
     mask = crop_mask.reshape(crop_mask.shape[-2], crop_mask.shape[-1])
     blend_dtype = mask.dtype if mask.is_floating_point() else torch.get_default_dtype()
 
-    dilation_px = max(3, round(frame_height * BLEND_DILATION_RATIO))
+    ratio_y = BLEND_DILATION_RATIO if dilation_ratio_y is None else dilation_ratio_y
+    ratio_x = BLEND_DILATION_RATIO if dilation_ratio_x is None else dilation_ratio_x
+    dilation_px_y = max(3, round(frame_height * ratio_y))
+    dilation_px_x = max(3, round(frame_height * ratio_x))
     falloff_px = max(3, round(frame_height * BLEND_FALLOFF_RATIO))
 
-    dilation_y = max(1, round(dilation_px / scale_y))
-    dilation_x = max(1, round(dilation_px / scale_x))
+    dilation_y = max(1, round(dilation_px_y / scale_y))
+    dilation_x = max(1, round(dilation_px_x / scale_x))
     falloff_y = max(1, round(falloff_px / scale_y))
     falloff_x = max(1, round(falloff_px / scale_x))
 
@@ -112,6 +122,8 @@ def create_bbox_blend_mask(
     mask_lr: torch.Tensor,
     bbox_xyxy: tuple[int, int, int, int],
     frame_shape: tuple[int, int],
+    *,
+    fisheye_eye_width: int | None = None,
 ) -> torch.Tensor:
     """Blend mask for a frame-coords bbox, returned at bbox resolution.
 
@@ -129,7 +141,19 @@ def create_bbox_blend_mask(
     mx2 = ((x2 - 1) * wm) // frame_w + 1
     mask_slice = mask_lr[my1:my2, mx1:mx2]
 
-    blend_lr = create_blend_mask(mask_slice, frame_h, frame_h / hm, frame_w / wm)
+    dilation_ratio_y = dilation_ratio_x = None
+    if fisheye_eye_width is not None:
+        dilation_ratio_y, dilation_ratio_x = sbs_fisheye_dilation_ratios(
+            bbox_xyxy, frame_h, fisheye_eye_width
+        )
+    blend_lr = create_blend_mask(
+        mask_slice,
+        frame_h,
+        frame_h / hm,
+        frame_w / wm,
+        dilation_ratio_y=dilation_ratio_y,
+        dilation_ratio_x=dilation_ratio_x,
+    )
     return F.interpolate(
         blend_lr.unsqueeze(0).unsqueeze(0),
         size=(y2 - y1, x2 - x1),

--- a/jasna/vr180.py
+++ b/jasna/vr180.py
@@ -41,6 +41,7 @@ class VrModeResolution:
     reason: str
     display_aspect: float
     projection: str
+    fisheye_mask_geometry: bool
 
     @property
     def is_sbs(self) -> bool:
@@ -169,16 +170,29 @@ def resolve_vr_mode(
     else:
         resolved_projection = resolve_projection(input_path)
 
+    source_projection = resolve_projection(input_path) if resolved == "sbs" else "none"
     result = VrModeResolution(
         requested,
         resolved,
         reason,
         aspect,
         resolved_projection,
+        resolved == "sbs"
+        and (
+            requested == "sbs-fisheye"
+            or source_projection == "fisheye"
+            or resolved_projection == "fisheye"
+        ),
     )
     message = (
-        "VR mode: requested=%s resolved=%s projection=%s reason=%s"
-        % (result.requested, result.resolved, result.projection, result.reason)
+        "VR mode: requested=%s resolved=%s projection=%s mask_geometry=%s reason=%s"
+        % (
+            result.requested,
+            result.resolved,
+            result.projection,
+            "adaptive-fisheye" if result.fisheye_mask_geometry else "fixed",
+            result.reason,
+        )
     )
     if "unusual SBS" in result.reason:
         log.warning(message)

--- a/jasna/vr_mask_geometry.py
+++ b/jasna/vr_mask_geometry.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import math
+
+
+SBS_CENTER_DILATION_RATIO = 0.028
+SBS_RIM_DILATION_RATIO = 0.060
+SBS_RIM_START_RADIUS = 0.45
+SBS_RADIAL_EXPANSION_FRACTION = 0.60
+
+
+def sbs_fisheye_dilation_ratios(
+    bbox_xyxy: tuple[float, float, float, float],
+    frame_height: int,
+    eye_width: int,
+) -> tuple[float, float]:
+    """Return (y, x) source-space dilation ratios for one SBS eye.
+
+    The source projection stretches content increasingly toward an eye's rim.
+    Most of that stretch is tangential, so a lower-edge region grows more in X
+    while a side-edge region grows more in Y. The centre retains the legacy
+    2.8% dilation and the strongest rim axis is capped at 6%.
+    """
+    frame_height = int(frame_height)
+    eye_width = int(eye_width)
+    if frame_height <= 0 or eye_width <= 0:
+        raise ValueError(
+            f"Invalid SBS geometry: height={frame_height}, eye_width={eye_width}"
+        )
+
+    x1, y1, x2, y2 = map(float, bbox_xyxy)
+    center_x = (x1 + x2) * 0.5
+    center_y = (y1 + y2) * 0.5
+    eye_index = math.floor(center_x / eye_width)
+    eye_center_x = (eye_index + 0.5) * eye_width
+
+    rx = (center_x - eye_center_x) / (eye_width * 0.5)
+    ry = (center_y - frame_height * 0.5) / (frame_height * 0.5)
+    radius = math.hypot(rx, ry)
+    if radius <= SBS_RIM_START_RADIUS:
+        return SBS_CENTER_DILATION_RATIO, SBS_CENTER_DILATION_RATIO
+
+    t = min(
+        1.0,
+        (radius - SBS_RIM_START_RADIUS) / (1.0 - SBS_RIM_START_RADIUS),
+    )
+    t = t * t * (3.0 - 2.0 * t)
+    extra = (SBS_RIM_DILATION_RATIO - SBS_CENTER_DILATION_RATIO) * t
+
+    tangent_x = abs(ry) / radius
+    tangent_y = abs(rx) / radius
+    floor = SBS_RADIAL_EXPANSION_FRACTION
+    ratio_x = SBS_CENTER_DILATION_RATIO + extra * (
+        floor + (1.0 - floor) * tangent_x
+    )
+    ratio_y = SBS_CENTER_DILATION_RATIO + extra * (
+        floor + (1.0 - floor) * tangent_y
+    )
+    return ratio_y, ratio_x

--- a/jasna/vr_projection.py
+++ b/jasna/vr_projection.py
@@ -336,8 +336,15 @@ class _RegionProjector:
         frame_w: int,
         *,
         x_bounds: tuple[int, int] | None = None,
+        fisheye_geometry: bool = False,
     ) -> RawCrop:
-        x1, y1, x2, y2 = compute_enlarged_bbox(bbox, frame_h, frame_w, x_bounds)
+        x1, y1, x2, y2 = compute_enlarged_bbox(
+            bbox,
+            frame_h,
+            frame_w,
+            x_bounds,
+            fisheye_geometry=fisheye_geometry,
+        )
         offset = x_bounds[0] if x_bounds is not None else self._eye_offset((x1, y1, x2, y2))
         local = (x1 - offset, y1, x2 - offset, y2)
         patch_size = self._patch_size((x1, y1, x2, y2))

--- a/tests/test_restoration_preview.py
+++ b/tests/test_restoration_preview.py
@@ -277,6 +277,49 @@ def test_preview_pass_forwards_scene_detection(monkeypatch) -> None:
     worker.close()
 
 
+def test_preview_pass_forwards_fisheye_mask_geometry(monkeypatch) -> None:
+    from jasna import blend_buffer, pipeline_threads, vr_projection, vram_offloader
+
+    class ImmediateThread:
+        def __init__(self, *, target, **_kwargs):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+        def is_alive(self):
+            return False
+
+        def join(self, timeout=None):
+            pass
+
+    decode_detect = MagicMock()
+    blend_buffer_factory = MagicMock()
+    monkeypatch.setattr(pipeline_threads, "decode_detect_loop", decode_detect)
+    monkeypatch.setattr(pipeline_threads, "primary_restore_loop", MagicMock())
+    monkeypatch.setattr(pipeline_threads, "secondary_restore_loop", MagicMock())
+    monkeypatch.setattr(pipeline_threads, "blend_encode_loop", MagicMock())
+    monkeypatch.setattr(restoration_preview.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(vram_offloader, "VramOffloader", MagicMock())
+    monkeypatch.setattr(blend_buffer, "BlendBuffer", blend_buffer_factory)
+    monkeypatch.setattr(vr_projection, "build_vr_projector", MagicMock())
+    monkeypatch.setattr(torch.cuda, "empty_cache", MagicMock())
+    worker = RestorationPreviewWorker("video.mp4", _metadata())
+    settings = AppSettings(vr_mode="sbs-fisheye")
+    worker.request(2.0, settings, projection="fisheye")
+    command = worker._commands.get_nowait()
+    session = SimpleNamespace(
+        device=torch.device("cpu"),
+        restoration_pipeline=SimpleNamespace(secondary_num_workers=1),
+    )
+
+    worker._run_preview_pass(command, session, MagicMock())
+
+    assert blend_buffer_factory.call_args.kwargs["fisheye_eye_width"] == 960
+    assert decode_detect.call_args.kwargs["fisheye_mask_geometry"] is True
+    worker.close()
+
+
 def test_restoration_worker_cancels_before_queueing_replacement() -> None:
     worker = RestorationPreviewWorker("unused.mp4", _metadata())
     order = []

--- a/tests/test_vr_fisheye_mask_geometry.py
+++ b/tests/test_vr_fisheye_mask_geometry.py
@@ -1,0 +1,77 @@
+from fractions import Fraction
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from jasna.crop_buffer import compute_enlarged_bbox
+from jasna.vr180 import resolve_vr_mode
+from jasna.vr_mask_geometry import (
+    SBS_CENTER_DILATION_RATIO,
+    SBS_RIM_DILATION_RATIO,
+    sbs_fisheye_dilation_ratios,
+)
+
+
+def _metadata(width: int = 4096, height: int = 2048):
+    return SimpleNamespace(
+        video_width=width,
+        video_height=height,
+        sample_aspect_ratio=Fraction(1, 1),
+        stereo_layout="",
+        spherical_projection="",
+    )
+
+
+def test_fisheye_center_keeps_legacy_dilation() -> None:
+    ratios = sbs_fisheye_dilation_ratios(
+        (900.0, 900.0, 1100.0, 1100.0),
+        frame_height=2048,
+        eye_width=2048,
+    )
+
+    assert ratios == pytest.approx(
+        (SBS_CENTER_DILATION_RATIO, SBS_CENTER_DILATION_RATIO)
+    )
+
+
+def test_fisheye_rim_expands_more_but_stays_capped() -> None:
+    ratio_y, ratio_x = sbs_fisheye_dilation_ratios(
+        (900.0, 1800.0, 1100.0, 2000.0),
+        frame_height=2048,
+        eye_width=2048,
+    )
+
+    assert SBS_CENTER_DILATION_RATIO < ratio_y <= SBS_RIM_DILATION_RATIO
+    assert ratio_y < ratio_x <= SBS_RIM_DILATION_RATIO
+
+
+def test_fisheye_crop_adds_context_without_crossing_eye_seam() -> None:
+    bbox = (1900, 1800, 2038, 2000)
+    plain = compute_enlarged_bbox(
+        bbox,
+        2048,
+        4096,
+        (0, 2048),
+    )
+    fisheye = compute_enlarged_bbox(
+        bbox,
+        2048,
+        4096,
+        (0, 2048),
+        fisheye_geometry=True,
+    )
+
+    assert fisheye[0] <= plain[0]
+    assert fisheye[1] <= plain[1]
+    assert fisheye[2] <= 2048
+    assert fisheye[3] <= 2048
+
+
+def test_explicit_fisheye_mode_enables_geometry_only_for_sbs() -> None:
+    fisheye = resolve_vr_mode("sbs-fisheye", _metadata(), Path("video.mp4"))
+    flat = resolve_vr_mode("off", _metadata(), Path("video.mp4"))
+
+    assert fisheye.is_sbs
+    assert fisheye.fisheye_mask_geometry
+    assert not flat.fisheye_mask_geometry


### PR DESCRIPTION
# Adaptive VR fisheye crop and mask geometry

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/315#issuecomment-5312167478).

## Summary

This candidate fixes a focused VR geometry problem: a fixed rectangular crop
can include large invalid fisheye areas, while paste-back may blend outside the
visible lens. It derives a per-region valid mask from source-space fisheye
geometry and carries that mask through crop, restoration and blending.

## Changes

- compute lens-valid source masks for fisheye regions;
- tighten crop bounds without clipping the detected mosaic mask;
- combine projection validity with the existing blend mask;
- use the same geometry in offline, threaded, streaming, restored-still and
  restored-playback preview paths;
- keep raw/gnomonic and ordinary 2D behavior unchanged.

## Scope and compatibility

- Public branch: `fix/vr-fisheye-mask-geometry` (`e2ca3ca`).
- Base: `upstream/main`; independently mergeable.
- No encoder, decoder, scan settings, CLI or logging change. The GUI change is
  limited to forwarding the existing resolved geometry into restoration
  previews; it adds no control or user-visible string.
- GPU vendor independent; NVIDIA and AMD should both run a fisheye visual smoke.

## Validation

- Dedicated geometry tests cover lens intersection, bbox clipping, mask
  propagation, paste-back boundaries, and preview argument parity.
- Automated integration tests pass; final acceptance still needs human visual
  review on moving mosaic regions near the fisheye edge, because numeric mask
  tests cannot judge seams or flicker.

## Test request

Compare the same short SBS fisheye ROI before/after on NVIDIA and AMD. Inspect
edge motion, restored-region continuity and unchanged pixels outside the lens,
and confirm a rim-adjacent region matches between preview and final output.