### PR TITLE
feat(cli): expose VR restoration projection

### DIFF
--- a/jasna/cli_help.py
+++ b/jasna/cli_help.py
@@ -22,6 +22,11 @@ CLI_HELP: dict[str, str] = {
         "forces fisheye conditioning for every region. Detection, tracking, and "
         "blending stay in source coordinates. (default: %(default)s)"
     ),
+    "vr_projection": (
+        "Explicit restoration projection for SBS regions. Auto keeps the conservative "
+        "studio/metadata routing; raw, fisheye, and gnomonic force one projection for "
+        "every detected region. This does not change detection or blend coordinates."
+    ),
     "tvai_ffmpeg_path": "Path to Topaz Video ffmpeg.exe (default: %(default)s)",
     "tvai_model": 'Topaz model name for tvai_up (e.g. "iris-2", "prob-4", "iris-3") (default: %(default)s)',
     "tvai_scale": "Topaz tvai_up scale (1=no scale). Output size is 256*scale (default: %(default)s)",

--- a/jasna/main.py
+++ b/jasna/main.py
@@ -62,6 +62,7 @@ def _session_config_from_args(
         rtx_denoise=str(args.rtx_denoise).lower(),
         rtx_deblur=str(args.rtx_deblur).lower(),
         vr_mode=str(args.vr_mode),
+        vr_projection=str(args.vr_projection),
         codec=codec,
         encoder_settings=encoder_settings,
         lut_path=lut_path,
@@ -421,6 +422,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="auto",
         choices=["auto", "off", "sbs", "sbs-fisheye"],
         help=CLI_HELP["vr_mode"],
+    )
+    projection.add_argument(
+        "--vr-projection",
+        type=str,
+        default="auto",
+        choices=["auto", "raw", "fisheye", "gnomonic"],
+        help=CLI_HELP["vr_projection"],
     )
 
     streaming = parser.add_argument_group("Streaming")

--- a/tests/test_session_config.py
+++ b/tests/test_session_config.py
@@ -71,6 +71,7 @@ def test_cli_defaults_map_to_expected_config() -> None:
     assert config.rtx_denoise == "medium"
     assert config.rtx_deblur == "none"
     assert config.vr_mode == "auto"
+    assert config.vr_projection == "auto"
     assert config.codec == "hevc"
     assert config.encoder_settings == {}
     assert config.lut_path is None
@@ -91,6 +92,7 @@ def test_cli_non_default_args_are_mapped() -> None:
             "--secondary-restoration", "rtx-super-res",
             "--rtx-quality", "ultra",
             "--vr-mode", "sbs",
+            "--vr-projection", "gnomonic",
             "--no-progress",
             "--working-directory", "/fast/scratch",
             "--retarget-high-fps",
@@ -107,6 +109,7 @@ def test_cli_non_default_args_are_mapped() -> None:
     assert config.secondary_restoration == "rtx-super-res"
     assert config.rtx_quality == "ultra"
     assert config.vr_mode == "sbs"
+    assert config.vr_projection == "gnomonic"
     assert config.disable_progress is True
     assert config.working_dir == Path("/fast/scratch")
     assert config.retarget_high_fps is True


### PR DESCRIPTION
# Expose the existing VR restoration projection in the CLI

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/316#issuecomment-5312168289).

## Scope

The GUI and `SessionConfig` already support `auto`, `raw`, `fisheye`, and
`gnomonic` restoration projection modes. This focused CLI parity change adds
`--vr-projection` and forwards it into the existing session field.

It does not add a projection implementation, change automatic routing, alter
detection/blend coordinates, or touch encoding, decoding, Smart Render, GUI,
or logging behavior. The branch is based directly on `upstream/main` and is
independently mergeable.

## Validation

Parser/session tests cover the default and an explicit gnomonic selection.
Please run one ordinary CLI job and one SBS job with
`--vr-projection gnomonic`; both NVIDIA and AMD use the same argument path.

Important paths:

- `jasna/main.py`
- `jasna/cli_help.py`
- `tests/test_session_config.py`