### PR TITLE
feat(gui): remember working directory

### DIFF
--- a/jasna/gui/app.py
+++ b/jasna/gui/app.py
@@ -424,6 +424,10 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
             self._video_player_dialog.request_close()
             return
         try:
+            self._settings_panel.persist_working_directory()
+        except Exception:
+            logger.debug("Could not persist working directory during shutdown", exc_info=True)
+        try:
             if self._processor:
                 self._processor.stop()
                 self._processor.join(timeout=5.0)
@@ -575,6 +579,7 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
         output_folder = self._queue_panel.get_output_folder()
         output_pattern = self._queue_panel.get_output_pattern()
         settings = self._settings_panel.get_settings()
+        self._settings_panel.persist_working_directory(settings.working_directory)
 
         from jasna.gui.validation import validate_gui_start
         errors = validate_gui_start(settings)

--- a/jasna/gui/models.py
+++ b/jasna/gui/models.py
@@ -303,6 +303,7 @@ class PresetManager:
         self._last_selected: str = "Default"
         self._last_output_folder: str = ""
         self._last_output_pattern: str = "{original}_restored.mp4"
+        self._last_working_directory: str | None = None
         self._system_check_passed_version: str = ""
         self._load()
         
@@ -319,6 +320,7 @@ class PresetManager:
             self._last_selected = data.get("last_selected", "Default")
             self._last_output_folder = data.get("last_output_folder", "")
             self._last_output_pattern = data.get("last_output_pattern", "{original}_restored.mp4")
+            self._last_working_directory = data.get("last_working_directory")
             self._system_check_passed_version = data.get("system_check_passed_version", "")
             
             for name, preset_dict in data.get("user_presets", {}).items():
@@ -345,6 +347,10 @@ class PresetManager:
         data["user_presets"] = {name: asdict(preset) for name, preset in self._user_presets.items()}
         data["last_output_folder"] = self._last_output_folder
         data["last_output_pattern"] = self._last_output_pattern
+        if self._last_working_directory is None:
+            data.pop("last_working_directory", None)
+        else:
+            data["last_working_directory"] = self._last_working_directory
         data["system_check_passed_version"] = self._system_check_passed_version
         
         try:
@@ -423,6 +429,13 @@ class PresetManager:
 
     def set_last_output_pattern(self, pattern: str):
         self._last_output_pattern = pattern or "{original}_restored.mp4"
+        self._save()
+
+    def get_last_working_directory(self) -> str | None:
+        return self._last_working_directory
+
+    def set_last_working_directory(self, path: str):
+        self._last_working_directory = path or ""
         self._save()
 
     def get_system_check_passed_version(self) -> str:

--- a/jasna/gui/settings_panel.py
+++ b/jasna/gui/settings_panel.py
@@ -52,6 +52,7 @@ class SettingsPanel(ctk.CTkFrame):
         self._build_scrollable()
         self._build_sections()
         self._apply_preset(self._current_preset)
+        self._restore_last_working_directory()
 
     def _build_preset_bar(self):
         bar = ctk.CTkFrame(self, fg_color="transparent", height=48)
@@ -172,6 +173,20 @@ class SettingsPanel(ctk.CTkFrame):
 
     def set_last_output_pattern(self, pattern: str):
         self._preset_manager.set_last_output_pattern(pattern)
+
+    def persist_working_directory(self, path: str | None = None):
+        if path is None:
+            path = self._widgets["working_directory"].get().strip()
+        self._preset_manager.set_last_working_directory(path)
+
+    def _restore_last_working_directory(self):
+        path = self._preset_manager.get_last_working_directory()
+        if path is None:
+            return
+        entry = self._widgets["working_directory"]
+        entry.delete(0, "end")
+        entry.insert(0, path)
+        self._update_modified_indicator()
 
     def _update_button_states(self):
         """Update button states based on current preset."""

--- a/tests/test_gui_settings_persistence_paths.py
+++ b/tests/test_gui_settings_persistence_paths.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from jasna import os_utils
 from jasna.gui.models import AppSettings, PresetManager, get_settings_path
@@ -92,6 +93,39 @@ def test_preset_manager_persists_working_directory(monkeypatch, tmp_path: Path) 
     loaded = mgr2.get_preset("WithWorkDir")
     assert loaded is not None
     assert loaded.working_directory == r"D:\scratch"
+
+
+def test_preset_manager_saves_last_working_directory_separately(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(os_utils.sys, "platform", "win32", raising=False)
+    monkeypatch.setenv("APPDATA", str(tmp_path / "Roaming"))
+
+    manager = PresetManager()
+    assert manager.get_last_working_directory() is None
+    manager.set_last_working_directory(r"D:\scratch\jobs")
+
+    reloaded = PresetManager()
+    assert reloaded.get_last_working_directory() == r"D:\scratch\jobs"
+    data = json.loads(get_settings_path().read_text(encoding="utf-8"))
+    assert data["last_working_directory"] == r"D:\scratch\jobs"
+
+
+def test_settings_panel_restores_last_working_directory() -> None:
+    from jasna.gui.settings_panel import SettingsPanel
+
+    panel = SettingsPanel.__new__(SettingsPanel)
+    entry = MagicMock()
+    panel._widgets = {"working_directory": entry}
+    panel._preset_manager = MagicMock()
+    panel._preset_manager.get_last_working_directory.return_value = "/fast/jobs"
+    panel._update_modified_indicator = MagicMock()
+
+    panel._restore_last_working_directory()
+
+    entry.delete.assert_called_once_with(0, "end")
+    entry.insert.assert_called_once_with(0, "/fast/jobs")
+    panel._update_modified_indicator.assert_called_once_with()
 
 
 def test_preset_manager_persists_frame_rate_retargeting(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_restoration_preview.py
+++ b/tests/test_restoration_preview.py
@@ -431,6 +431,39 @@ def test_app_start_guard_blocks_running_queue_reset() -> None:
     app._queue_panel.get_jobs.assert_not_called()
 
 
+def test_app_start_persists_the_active_working_directory() -> None:
+    app = JasnaApp.__new__(JasnaApp)
+    app._preview_gpu_busy = False
+    app._processor = MagicMock()
+    app._processor.is_running.return_value = False
+    app._queue_panel = MagicMock()
+    app._queue_panel.get_jobs.return_value = [object()]
+    app._queue_panel.get_jobs_ref.return_value = [object()]
+    app._queue_panel.get_output_folder.return_value = ""
+    app._queue_panel.get_output_pattern.return_value = "{original}_restored.mp4"
+    app._settings_panel = MagicMock()
+    app._settings_panel.get_settings.return_value = AppSettings(
+        working_directory="/fast/jobs"
+    )
+    app._status_pill = MagicMock()
+    app._control_bar = MagicMock()
+    app._video_player_btn = MagicMock()
+    app._log_panel = MagicMock()
+    app._job_start_times = {}
+    app._processing_start_time = 0.0
+    preflight = SimpleNamespace(missing=(), should_warn_first_run_slow=False)
+
+    with (
+        patch("jasna.gui.validation.validate_gui_start", return_value=[]),
+        patch("jasna.gui.engine_preflight.run_engine_preflight", return_value=preflight),
+    ):
+        app._on_start()
+
+    app._settings_panel.persist_working_directory.assert_called_once_with(
+        "/fast/jobs"
+    )
+
+
 def test_app_prepares_entire_queue_before_starting_processor() -> None:
     app = JasnaApp.__new__(JasnaApp)
     app._preview_gpu_busy = False


### PR DESCRIPTION
# Remember the last GUI working directory

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/317#issuecomment-5312169129).

## Scope

This focused GUI preference change remembers the most recently active working
directory independently of named presets. It restores that value after loading
the selected preset and saves it when a batch starts or the application closes.

The setting continues to use the existing user settings JSON. No video,
encoder, decoder, scan, Smart Render, output-path, or preset schema behavior is
changed. An absent key preserves the current default.

## Validation

Tests cover JSON round-trip, settings-panel restoration, batch-start
persistence, and the existing GUI/preset suite. Please smoke-test one source
run on Windows and Linux: select a directory, restart Jasna, and confirm the
same value is shown without changing the selected preset.