### PR TITLE
perf: reuse detector within restoration session

### DIFF
--- a/jasna/pipeline.py
+++ b/jasna/pipeline.py
@@ -103,6 +103,8 @@ class Pipeline:
         segments: tuple[SegmentRange, ...] | None = None,
         splice_plan: SplicePlan | None = None,
         working_dir: Path | None = None,
+        detection_model: object | None = None,
+        detection_session: object | None = None,
     ) -> None:
         self.input_video = input_video
         self.output_video = output_video
@@ -120,14 +122,28 @@ class Pipeline:
         self.vr_mode = str(vr_mode)
         self.vr_projection = str(vr_projection)
 
-        self.detection_model = build_detection_model(
-            detection_model_name,
-            detection_model_path,
-            batch_size=self.batch_size,
-            device=self.device,
-            score_threshold=float(detection_score_threshold),
-            fp16=bool(fp16),
+        self._owns_detection_model = (
+            detection_model is None and detection_session is None
         )
+        if detection_model is not None:
+            self.detection_model = detection_model
+        elif detection_session is not None:
+            self.detection_model = detection_session.get_detection_model(
+                name=detection_model_name,
+                path=detection_model_path,
+                batch_size=self.batch_size,
+                score_threshold=float(detection_score_threshold),
+                fp16=bool(fp16),
+            )
+        else:
+            self.detection_model = build_detection_model(
+                detection_model_name,
+                detection_model_path,
+                batch_size=self.batch_size,
+                device=self.device,
+                score_threshold=float(detection_score_threshold),
+                fp16=bool(fp16),
+            )
         self.restoration_pipeline = restoration_pipeline
         self.disable_progress = bool(disable_progress)
         self.progress_callback = progress_callback
@@ -175,10 +191,14 @@ class Pipeline:
         )
 
     def close(self) -> None:
-        if hasattr(self, "detection_model") and self.detection_model is not None:
+        if (
+            getattr(self, "_owns_detection_model", True)
+            and hasattr(self, "detection_model")
+            and self.detection_model is not None
+        ):
             if hasattr(self.detection_model, "close"):
                 self.detection_model.close()
-            self.detection_model = None
+        self.detection_model = None
         self.restoration_pipeline = None
 
     _ASYNC_POLL_TIMEOUT = 0.05

--- a/jasna/session_factory.py
+++ b/jasna/session_factory.py
@@ -33,8 +33,59 @@ class RestorationSession:
     detection_model_path: Path
     restoration_pipeline: "RestorationPipeline"
     secondary_restorer: "SecondaryRestorer | None"
+    detection_model: object | None = None
+    detection_model_key: tuple[str, str, int, str, float, bool] | None = None
+
+    def get_detection_model(
+        self,
+        *,
+        name: str,
+        path: str | Path,
+        batch_size: int,
+        score_threshold: float,
+        fp16: bool,
+    ) -> object:
+        """Return the detector matching this pipeline's construction contract.
+
+        A restoration session can process multiple videos sequentially. Keep the
+        expensive detector alive between those pipelines, but replace it when a
+        setting that affects its construction changes.
+        """
+        model_path = Path(path)
+        key = (
+            str(name),
+            str(model_path.resolve()),
+            int(batch_size),
+            str(self.device),
+            float(score_threshold),
+            bool(fp16),
+        )
+        if self.detection_model_key == key and self.detection_model is not None:
+            return self.detection_model
+
+        if self.detection_model is not None and hasattr(self.detection_model, "close"):
+            self.detection_model.close()
+        self.detection_model = None
+        self.detection_model_key = None
+
+        from jasna.mosaic.detection_registry import build_detection_model
+
+        self.detection_model = build_detection_model(
+            str(name),
+            model_path,
+            batch_size=int(batch_size),
+            device=self.device,
+            score_threshold=float(score_threshold),
+            fp16=bool(fp16),
+        )
+        self.detection_model_key = key
+        return self.detection_model
 
     def close(self) -> None:
+        if self.detection_model is not None and hasattr(self.detection_model, "close"):
+            self.detection_model.close()
+        self.detection_model = None
+        self.detection_model_key = None
         self.restoration_pipeline.restorer.close()
         if self.secondary_restorer is not None and hasattr(self.secondary_restorer, "close"):
             self.secondary_restorer.close()
@@ -173,4 +224,5 @@ def build_pipeline(
         segments=segments,
         splice_plan=splice_plan,
         working_dir=config.working_dir,
+        detection_session=session,
     )

--- a/tests/test_pipeline_init.py
+++ b/tests/test_pipeline_init.py
@@ -110,6 +110,44 @@ class TestPipelineInit:
         p = _make_pipeline(progress_callback=cb)
         assert p.progress_callback is cb
 
+    def test_close_does_not_close_session_owned_detector(self):
+        detector = MagicMock()
+        detection_session = MagicMock()
+        detection_session.get_detection_model.return_value = detector
+
+        pipeline = _make_pipeline(detection_session=detection_session)
+
+        detection_session.get_detection_model.assert_called_once_with(
+            name="rfdetr-v5",
+            path=Path("model.onnx"),
+            batch_size=4,
+            score_threshold=0.25,
+            fp16=True,
+        )
+        pipeline.close()
+
+        detector.close.assert_not_called()
+        assert pipeline.detection_model is None
+
+    def test_close_does_not_close_explicitly_supplied_detector(self):
+        detector = MagicMock()
+        pipeline = _make_pipeline(detection_model=detector)
+
+        pipeline.close()
+
+        detector.close.assert_not_called()
+        assert pipeline.detection_model is None
+
+    def test_close_closes_standalone_detector_once(self):
+        pipeline = _make_pipeline()
+        detector = pipeline.detection_model
+
+        pipeline.close()
+        pipeline.close()
+
+        detector.close.assert_called_once_with()
+        assert pipeline.detection_model is None
+
     def test_retarget_high_fps_defaults_off_and_can_be_enabled(self):
         assert _make_pipeline().retarget_high_fps is False
         assert _make_pipeline(retarget_high_fps=True).retarget_high_fps is True

--- a/tests/test_session_factory.py
+++ b/tests/test_session_factory.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -57,7 +59,20 @@ def _build_session(
     amd: bool = False,
 ):
     compile_result = MagicMock(use_basicvsrpp_tensorrt=True)
+    tvai_cls = MagicMock(name="TvaiSecondaryRestorer")
+    unet_cls = MagicMock(name="Unet4xSecondaryRestorer")
+    rtx_cls = MagicMock(name="RtxSuperresSecondaryRestorer")
+    secondary_modules = {}
+    for module_name, class_name, class_mock in (
+        ("tvai_secondary_restorer", "TvaiSecondaryRestorer", tvai_cls),
+        ("unet4x_secondary_restorer", "Unet4xSecondaryRestorer", unet_cls),
+        ("rtx_superres_secondary_restorer", "RtxSuperresSecondaryRestorer", rtx_cls),
+    ):
+        module = ModuleType(f"jasna.restorer.{module_name}")
+        setattr(module, class_name, class_mock)
+        secondary_modules[module.__name__] = module
     with (
+        patch.dict(sys.modules, secondary_modules),
         patch("jasna.accelerator.is_amd_device", return_value=amd),
         patch(
             "jasna.engine_compiler.ensure_engines_compiled",
@@ -65,9 +80,6 @@ def _build_session(
         ) as compiled,
         patch("jasna.restorer.basicvsrpp_mosaic_restorer.BasicvsrppMosaicRestorer") as restorer_cls,
         patch("jasna.restorer.restoration_pipeline.RestorationPipeline") as pipeline_cls,
-        patch("jasna.restorer.tvai_secondary_restorer.TvaiSecondaryRestorer") as tvai_cls,
-        patch("jasna.restorer.unet4x_secondary_restorer.Unet4xSecondaryRestorer") as unet_cls,
-        patch("jasna.restorer.rtx_superres_secondary_restorer.RtxSuperresSecondaryRestorer") as rtx_cls,
     ):
         session = build_restoration_session(
             config,
@@ -75,6 +87,28 @@ def _build_session(
             log_callback=None,
         )
     return session, compiled, restorer_cls, pipeline_cls, tvai_cls, unet_cls, rtx_cls
+
+
+def _detection_cache_session(*, device: object = "cpu") -> RestorationSession:
+    return RestorationSession(
+        device=device,
+        detection_model_name="rfdetr-v5",
+        detection_model_path=Path("det.onnx"),
+        restoration_pipeline=MagicMock(),
+        secondary_restorer=None,
+    )
+
+
+def _detection_request(**overrides) -> dict[str, object]:
+    request: dict[str, object] = {
+        "name": "rfdetr-v5",
+        "path": Path("det.onnx"),
+        "batch_size": 4,
+        "score_threshold": 0.25,
+        "fp16": True,
+    }
+    request.update(overrides)
+    return request
 
 
 def test_session_without_secondary() -> None:
@@ -164,6 +198,104 @@ def test_session_close_closes_restorers() -> None:
     session.secondary_restorer.close.assert_called_once_with()
 
 
+def test_detection_model_cache_reuses_same_key() -> None:
+    session = _detection_cache_session()
+    detector = MagicMock()
+    first_request = _detection_request(path=Path("models") / ".." / "det.onnx")
+    second_request = _detection_request(path=Path("det.onnx"))
+
+    with patch(
+        "jasna.mosaic.detection_registry.build_detection_model",
+        return_value=detector,
+    ) as build_detection_model:
+        first = session.get_detection_model(**first_request)
+        second = session.get_detection_model(**second_request)
+
+    assert first is detector
+    assert second is detector
+    build_detection_model.assert_called_once_with(
+        "rfdetr-v5",
+        Path("models") / ".." / "det.onnx",
+        batch_size=4,
+        device="cpu",
+        score_threshold=0.25,
+        fp16=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "changed_field, changed_value",
+    [
+        ("name", "lada-yolo-v4"),
+        ("path", Path("other-det.onnx")),
+        ("batch_size", 8),
+        ("score_threshold", 0.5),
+        ("fp16", False),
+        ("device", "cuda:1"),
+    ],
+)
+def test_detection_model_cache_rebuilds_when_construction_input_changes(
+    changed_field: str,
+    changed_value: object,
+) -> None:
+    session = _detection_cache_session()
+    first_detector = MagicMock()
+    second_detector = MagicMock()
+    request = _detection_request()
+
+    with patch(
+        "jasna.mosaic.detection_registry.build_detection_model",
+        side_effect=(first_detector, second_detector),
+    ) as build_detection_model:
+        assert session.get_detection_model(**request) is first_detector
+        if changed_field == "device":
+            session.device = changed_value
+            changed_request = request
+        else:
+            changed_request = _detection_request(**{changed_field: changed_value})
+        assert session.get_detection_model(**changed_request) is second_detector
+
+    assert build_detection_model.call_count == 2
+    first_detector.close.assert_called_once_with()
+    second_detector.close.assert_not_called()
+    assert session.detection_model is second_detector
+    assert session.detection_model_key is not None
+
+
+def test_detection_model_cache_clears_closed_detector_if_rebuild_fails() -> None:
+    session = _detection_cache_session()
+    old_detector = MagicMock()
+    session.detection_model = old_detector
+    session.detection_model_key = ("old", "det.onnx", 4, "cpu", 0.25, True)
+
+    with (
+        patch(
+            "jasna.mosaic.detection_registry.build_detection_model",
+            side_effect=RuntimeError("load failed"),
+        ),
+        pytest.raises(RuntimeError, match="load failed"),
+    ):
+        session.get_detection_model(**_detection_request())
+
+    old_detector.close.assert_called_once_with()
+    assert session.detection_model is None
+    assert session.detection_model_key is None
+
+
+def test_session_close_closes_cached_detector_once_and_clears_cache() -> None:
+    session = _detection_cache_session()
+    detector = MagicMock()
+    session.detection_model = detector
+    session.detection_model_key = ("cached", "det.onnx", 4, "cpu", 0.25, True)
+
+    session.close()
+    session.close()
+
+    detector.close.assert_called_once_with()
+    assert session.detection_model is None
+    assert session.detection_model_key is None
+
+
 def test_build_pipeline_passes_through_config_and_session() -> None:
     config = _config(
         lut_path="lut.cube",
@@ -201,6 +333,7 @@ def test_build_pipeline_passes_through_config_and_session() -> None:
     assert kwargs["detection_model_name"] == "rfdetr-v5"
     assert kwargs["detection_model_path"] == Path("det.onnx")
     assert kwargs["detection_score_threshold"] == 0.25
+    assert kwargs["detection_session"] is session
     assert kwargs["restoration_pipeline"] is session.restoration_pipeline
     assert kwargs["codec"] == "hevc"
     assert kwargs["encoder_settings"] == {"cq": 25}
@@ -240,3 +373,27 @@ def test_build_pipeline_defaults_optional_runtime_inputs() -> None:
     assert kwargs["progress_callback"] is None
     assert kwargs["segments"] is None
     assert kwargs["splice_plan"] is None
+    assert kwargs["detection_session"] is session
+
+
+def test_build_pipeline_reuses_session_detector_across_sequential_videos() -> None:
+    session = _detection_cache_session()
+    detector = MagicMock()
+
+    with patch(
+        "jasna.mosaic.detection_registry.build_detection_model",
+        return_value=detector,
+    ) as build_detection_model:
+        first = build_pipeline(_config(), session, Path("first.mp4"), Path("first-out.mp4"))
+        second = build_pipeline(_config(), session, Path("second.mp4"), Path("second-out.mp4"))
+
+    assert first.detection_model is detector
+    assert second.detection_model is detector
+    build_detection_model.assert_called_once()
+
+    first.close()
+    second.close()
+    detector.close.assert_not_called()
+
+    session.close()
+    detector.close.assert_called_once_with()


### PR DESCRIPTION
# Restoration-session detector cache

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/318#issuecomment-5312169957).

## Scope

This independently mergeable candidate is based directly on `upstream/main` at
`592472bda8aeb1fc0d5cea3d3ff6607add0ab0a7`.

Public branch: `perf/detector-session-cache`.

Candidate commit: `937766d23ca84d2ae14b339d23fd32593818d5ff`
(`perf: reuse detection model within restoration session`).

It selectively restores the video detector lifecycle from the frozen v0.10
snapshot `47bab409e1ac198eb4d0ca17a77b233db300f256`. It has no dependency on
the local integration branch or any other candidate.

## Lifecycle

- `RestorationSession.get_detection_model()` retains one detector for
  sequential video pipelines with the same construction contract.
- The cache key includes detector name, canonical weights path, requested batch
  size, session device, score threshold, and FP16 setting. A change closes the
  old detector, clears its cache state, then builds the replacement.
- `build_pipeline()` supplies the shared session to every video `Pipeline`.
  Closing such a pipeline only drops its reference; `RestorationSession.close()`
  owns and closes the cached detector exactly once, then clears it.
- A direct `Pipeline(...)` with no externally supplied detector/session retains
  the existing behavior: it builds and closes its own detector. An explicitly
  supplied detector is also treated as externally owned.

## Non-impact

This candidate does not include encoder-backend or software-reference changes,
Smart Render processing signatures/workspaces, working-directory persistence,
scan-specific detector ownership, image restore caching, CLI/GUI settings,
output durability, or any processing-path changes from the frozen branch.

## Validation

- `python -m pytest tests/test_session_factory.py tests/test_pipeline_init.py`:
  **37 passed**.
- The focused tests cover same-key reuse (including canonical equivalent paths),
  replacement for every detector-construction input, failed-rebuild cleanup,
  session finalization, sequential `build_pipeline()` reuse, session-owned
  pipeline non-close, explicitly supplied detector ownership, and standalone
  pipeline close behavior.
- `python -m compileall -q jasna/session_factory.py jasna/pipeline.py
  tests/test_session_factory.py tests/test_pipeline_init.py`: passed.
- `git diff --check`: passed before commit.

No real GPU/media run is claimed by these CPU-mock tests.

## Shared NVIDIA and AMD smoke requested

On both NVIDIA and AMD, process two short videos sequentially in one video
restoration session with identical detector settings. Confirm both outputs are
correct and that the detector initializes once rather than once per video;
then close or cancel the session and confirm GPU resources release cleanly.
Use representative 8-bit input and, where available, a 10-bit/P010 input. A
normal direct CLI-created pipeline should still load and release its detector
as before.

## Important paths

- `jasna/session_factory.py`
- `jasna/pipeline.py`
- `tests/test_session_factory.py`
- `tests/test_pipeline_init.py`