### PR TITLE
perf(gui): add Windows AMD GPU telemetry and 24GB policy

### DIFF
--- a/jasna/gui/app.py
+++ b/jasna/gui/app.py
@@ -403,7 +403,7 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
             while not self._system_stats_stop.is_set():
                 stats = read_system_stats()
                 try:
-                    self.after(0, lambda s=stats: self._control_bar.set_system_stats(s))
+                    self.after(0, lambda s=stats: self._apply_system_stats(s))
                 except Exception:
                     logger.debug("System stats poller stopping (widget gone)", exc_info=True)
                     return
@@ -411,6 +411,13 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
 
         self._system_stats_thread = threading.Thread(target=_loop, daemon=True)
         self._system_stats_thread.start()
+
+    def _apply_system_stats(self, stats) -> None:
+        self._control_bar.set_system_stats(stats)
+        # Total VRAM is immutable while Jasna is running. Keep the last known
+        # value if a later telemetry sample times out.
+        if stats.total_vram_bytes is not None:
+            self._settings_panel.set_total_vram_bytes(stats.total_vram_bytes)
 
     def _stop_system_stats_poller(self):
         self._system_stats_stop.set()

--- a/jasna/gui/app.py
+++ b/jasna/gui/app.py
@@ -399,15 +399,19 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
         self._system_stats_stop.clear()
 
         def _loop():
-            from jasna.gui.system_stats import read_system_stats
-            while not self._system_stats_stop.is_set():
-                stats = read_system_stats()
-                try:
-                    self.after(0, lambda s=stats: self._apply_system_stats(s))
-                except Exception:
-                    logger.debug("System stats poller stopping (widget gone)", exc_info=True)
-                    return
-                self._system_stats_stop.wait(1.5)
+            from jasna.gui.system_stats import close_gpu_telemetry, read_system_stats
+
+            try:
+                while not self._system_stats_stop.is_set():
+                    stats = read_system_stats()
+                    try:
+                        self.after(0, lambda s=stats: self._apply_system_stats(s))
+                    except Exception:
+                        logger.debug("System stats poller stopping (widget gone)", exc_info=True)
+                        return
+                    self._system_stats_stop.wait(1.5)
+            finally:
+                close_gpu_telemetry()
 
         self._system_stats_thread = threading.Thread(target=_loop, daemon=True)
         self._system_stats_thread.start()

--- a/jasna/gui/hardware_policy.py
+++ b/jasna/gui/hardware_policy.py
@@ -1,0 +1,23 @@
+"""Conservative GUI defaults derived from lightweight hardware telemetry."""
+
+DEFAULT_DETECTION_BATCH_SIZE = 4
+HIGH_VRAM_DETECTION_BATCH_SIZE = 8
+
+# Board-advertised 24 GiB cards can report slightly less through the driver.
+# This stays above 20 GiB-class cards while accepting that reporting difference.
+HIGH_VRAM_MIN_BYTES = 23 * 1024**3
+
+
+def recommended_detection_batch_size(
+    detection_model: str,
+    total_vram_bytes: int | None,
+) -> int:
+    """Return the RX 7900 XTX-validated RF-DETR v6 detection batch."""
+
+    if (
+        str(detection_model).strip().lower() == "rfdetr-v6"
+        and total_vram_bytes is not None
+        and int(total_vram_bytes) >= HIGH_VRAM_MIN_BYTES
+    ):
+        return HIGH_VRAM_DETECTION_BATCH_SIZE
+    return DEFAULT_DETECTION_BATCH_SIZE

--- a/jasna/gui/settings_panel.py
+++ b/jasna/gui/settings_panel.py
@@ -15,6 +15,7 @@ from jasna.gui.components import (
     Tooltip,
 )
 from jasna.gui.icons import NativeIconButton
+from jasna.gui.hardware_policy import recommended_detection_batch_size
 from jasna.gui.locales import t
 from jasna.gui.settings_sections.advanced import (
     TEMPORAL_FILTER_SLIDER_MAX,
@@ -47,6 +48,7 @@ class SettingsPanel(ctk.CTkFrame):
         self._applying_preset = False  # Flag to prevent modification tracking during apply
         self._widgets: dict = {}
         self._on_interactive_image_restore: callable | None = None
+        self._total_vram_bytes: int | None = None
 
         self._build_preset_bar()
         self._build_scrollable()
@@ -198,7 +200,12 @@ class SettingsPanel(ctk.CTkFrame):
         """Update dropdown text to show modified status."""
         current_settings = self.get_settings()
         if self._saved_preset_settings:
-            self._is_modified = asdict(current_settings) != asdict(self._saved_preset_settings)
+            current_values = asdict(current_settings)
+            saved_values = asdict(self._saved_preset_settings)
+            # The hidden hardware-derived batch is not a user preset value.
+            current_values.pop("batch_size", None)
+            saved_values.pop("batch_size", None)
+            self._is_modified = current_values != saved_values
         else:
             self._is_modified = False
 
@@ -358,9 +365,19 @@ class SettingsPanel(ctk.CTkFrame):
         values: dict = {}
         for section in self._sections:
             values.update(section.collect())
+        batch_size = recommended_detection_batch_size(
+            values.get("detection_model", AppSettings.detection_model),
+            self._total_vram_bytes,
+        )
         return AppSettings(
-            batch_size=4,  # Fixed default value
+            batch_size=batch_size,
             **values,
+        )
+
+    def set_total_vram_bytes(self, total_vram_bytes: int | None) -> None:
+        """Update telemetry used by the hidden hardware-derived default."""
+        self._total_vram_bytes = (
+            int(total_vram_bytes) if total_vram_bytes is not None else None
         )
 
     def set_enabled(self, enabled: bool):

--- a/jasna/gui/system_stats.py
+++ b/jasna/gui/system_stats.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-import subprocess
 
 from jasna import os_utils
 
@@ -62,7 +63,41 @@ def _read_amd_sysfs() -> tuple[int | None, int | None, int | None]:
     return None, None, None
 
 
+def _read_loaded_torch_amd() -> tuple[int | None, int | None, int | None]:
+    """Read the active HIP device without importing or initializing torch here."""
+    torch = sys.modules.get("torch")
+    if torch is None or not getattr(getattr(torch, "version", None), "hip", None):
+        return None, None, None
+
+    try:
+        cuda = torch.cuda
+        if not cuda.is_available():
+            return None, None, None
+        device = cuda.current_device()
+        total = int(cuda.get_device_properties(device).total_memory)
+        if total <= 0:
+            return None, None, None
+    except Exception:
+        return None, None, None
+
+    vram_util: int | None = None
+    try:
+        free, _driver_total = cuda.mem_get_info(device)
+        used = max(0, total - int(free))
+        vram_util = _clamp_pct((used / total) * 100.0)
+    except Exception:
+        # Total capacity is enough for the hidden batch policy. Utilization is
+        # best-effort because some Windows ROCm builds omit AMD SMI support.
+        pass
+    return None, vram_util, total
+
+
 def read_gpu_vram() -> tuple[int | None, int | None, int | None]:
+    if sys.platform == "win32":
+        amd_stats = _read_loaded_torch_amd()
+        if amd_stats[2] is not None:
+            return amd_stats
+
     exe_path = os_utils.find_executable("nvidia-smi")
     if exe_path is None:
         return _read_amd_sysfs()

--- a/jasna/gui/system_stats.py
+++ b/jasna/gui/system_stats.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from jasna import os_utils
 
 _DRM_CLASS_PATH = Path("/sys/class/drm")
+_windows_gpu_reader = None
+_windows_gpu_reader_luid: str | None = None
 
 
 @dataclass(frozen=True)
@@ -82,6 +84,10 @@ def _read_loaded_torch_amd() -> tuple[int | None, int | None, int | None]:
     except Exception:
         return None, None, None
 
+    gpu_util: int | None = None
+    if sys.platform == "win32":
+        gpu_util = _read_windows_amd_gpu_util(str(torch.version.hip), device)
+
     vram_util: int | None = None
     try:
         free, _driver_total = cuda.mem_get_info(device)
@@ -91,7 +97,48 @@ def _read_loaded_torch_amd() -> tuple[int | None, int | None, int | None]:
         # Total capacity is enough for the hidden batch policy. Utilization is
         # best-effort because some Windows ROCm builds omit AMD SMI support.
         pass
-    return None, vram_util, total
+    return gpu_util, vram_util, total
+
+
+def _loaded_hip_device_luid(hip_version: str, device: int) -> str | None:
+    from jasna.gui.windows_gpu_usage import hip_luid_from_loaded_runtime
+
+    return hip_luid_from_loaded_runtime(hip_version, device)
+
+
+def _new_windows_gpu_reader():
+    from jasna.gui.windows_gpu_usage import WindowsGpuUsageReader
+
+    return WindowsGpuUsageReader()
+
+
+def _read_windows_amd_gpu_util(hip_version: str, device: int) -> int | None:
+    global _windows_gpu_reader, _windows_gpu_reader_luid
+
+    try:
+        luid = _loaded_hip_device_luid(hip_version, device)
+        if luid is None:
+            return None
+        if _windows_gpu_reader is None or _windows_gpu_reader_luid != luid:
+            close_gpu_telemetry()
+            _windows_gpu_reader = _new_windows_gpu_reader()
+            _windows_gpu_reader_luid = luid
+        return _windows_gpu_reader.read_percent(luid)
+    except Exception:
+        close_gpu_telemetry()
+        return None
+
+
+def close_gpu_telemetry() -> None:
+    global _windows_gpu_reader, _windows_gpu_reader_luid
+
+    reader, _windows_gpu_reader = _windows_gpu_reader, None
+    _windows_gpu_reader_luid = None
+    if reader is not None:
+        try:
+            reader.close()
+        except Exception:
+            pass
 
 
 def read_gpu_vram() -> tuple[int | None, int | None, int | None]:

--- a/jasna/gui/system_stats.py
+++ b/jasna/gui/system_stats.py
@@ -15,6 +15,7 @@ class SystemStats:
     vram_util: int | None
     ram_util: int
     cpu_util: int
+    total_vram_bytes: int | None = None
 
 
 def _clamp_pct(value: float) -> int:
@@ -26,7 +27,7 @@ def _clamp_pct(value: float) -> int:
     return v
 
 
-def _parse_nvidia_smi_csv_line(line: str) -> tuple[int, int]:
+def _parse_nvidia_smi_csv_line(line: str) -> tuple[int, int, int]:
     parts = [p.strip() for p in (line or "").split(",")]
     if len(parts) < 3:
         raise ValueError(f"Unexpected nvidia-smi output: {line!r}")
@@ -36,10 +37,11 @@ def _parse_nvidia_smi_csv_line(line: str) -> tuple[int, int]:
     if mem_total <= 0:
         raise ValueError(f"Unexpected nvidia-smi total memory: {mem_total!r}")
     vram_util = _clamp_pct((mem_used / mem_total) * 100.0)
-    return gpu_util, vram_util
+    total_vram_bytes = int(mem_total * 1024 * 1024)
+    return gpu_util, vram_util, total_vram_bytes
 
 
-def _read_amd_sysfs() -> tuple[int | None, int | None]:
+def _read_amd_sysfs() -> tuple[int | None, int | None, int | None]:
     for card in sorted(_DRM_CLASS_PATH.glob("card[0-9]*")):
         device = card / "device"
         try:
@@ -54,13 +56,13 @@ def _read_amd_sysfs() -> tuple[int | None, int | None]:
             used = int((device / "mem_info_vram_used").read_text(encoding="utf-8"))
             total = int((device / "mem_info_vram_total").read_text(encoding="utf-8"))
             vram_util = _clamp_pct((used / total) * 100.0) if total > 0 else None
-            return gpu_util, vram_util
+            return gpu_util, vram_util, total
         except (OSError, ValueError):
             continue
-    return None, None
+    return None, None, None
 
 
-def read_gpu_vram() -> tuple[int | None, int | None]:
+def read_gpu_vram() -> tuple[int | None, int | None, int | None]:
     exe_path = os_utils.find_executable("nvidia-smi")
     if exe_path is None:
         return _read_amd_sysfs()
@@ -80,20 +82,20 @@ def read_gpu_vram() -> tuple[int | None, int | None]:
             **os_utils.subprocess_no_window_kwargs(),
         )
     except (subprocess.TimeoutExpired, OSError):
-        return None, None
+        return None, None, None
 
     if completed.returncode != 0:
-        return None, None
+        return None, None, None
 
     lines = (completed.stdout or "").splitlines()
     first = next((ln for ln in lines if ln.strip()), "")
     if first == "":
-        return None, None
+        return None, None, None
 
     try:
         return _parse_nvidia_smi_csv_line(first)
     except ValueError:
-        return None, None
+        return None, None, None
 
 
 def read_cpu_ram() -> tuple[int, int]:
@@ -105,10 +107,11 @@ def read_cpu_ram() -> tuple[int, int]:
 
 def read_system_stats() -> SystemStats:
     cpu_util, ram_util = read_cpu_ram()
-    gpu_util, vram_util = read_gpu_vram()
+    gpu_util, vram_util, total_vram_bytes = read_gpu_vram()
     return SystemStats(
         gpu_util=gpu_util,
         vram_util=vram_util,
+        total_vram_bytes=total_vram_bytes,
         ram_util=ram_util,
         cpu_util=cpu_util,
     )

--- a/jasna/gui/system_stats.py
+++ b/jasna/gui/system_stats.py
@@ -64,7 +64,7 @@ def _read_amd_sysfs() -> tuple[int | None, int | None, int | None]:
 
 
 def _read_loaded_torch_amd() -> tuple[int | None, int | None, int | None]:
-    """Read the active HIP device without importing or initializing torch here."""
+    """Read GUI device zero from HIP without importing or initializing torch."""
     torch = sys.modules.get("torch")
     if torch is None or not getattr(getattr(torch, "version", None), "hip", None):
         return None, None, None
@@ -73,7 +73,9 @@ def _read_loaded_torch_amd() -> tuple[int | None, int | None, int | None]:
         cuda = torch.cuda
         if not cuda.is_available():
             return None, None, None
-        device = cuda.current_device()
+        # GUI sessions currently run inference on logical ``cuda:0``. Query the
+        # same device instead of inheriting mutable per-thread CUDA state.
+        device = 0
         total = int(cuda.get_device_properties(device).total_memory)
         if total <= 0:
             return None, None, None
@@ -94,9 +96,14 @@ def _read_loaded_torch_amd() -> tuple[int | None, int | None, int | None]:
 
 def read_gpu_vram() -> tuple[int | None, int | None, int | None]:
     if sys.platform == "win32":
-        amd_stats = _read_loaded_torch_amd()
-        if amd_stats[2] is not None:
-            return amd_stats
+        torch = sys.modules.get("torch")
+        if torch is not None and getattr(
+            getattr(torch, "version", None), "hip", None
+        ):
+            # Once the loaded runtime identifies the GUI as AMD, never mix in
+            # capacity from a second NVIDIA adapter after a transient HIP query
+            # failure. A later poll can retry the same AMD source.
+            return _read_loaded_torch_amd()
 
     exe_path = os_utils.find_executable("nvidia-smi")
     if exe_path is None:

--- a/jasna/gui/windows_gpu_usage.py
+++ b/jasna/gui/windows_gpu_usage.py
@@ -1,0 +1,246 @@
+"""Windows GPU-engine utilization for an already-loaded HIP device."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import ctypes
+from ctypes import wintypes
+import math
+import re
+import struct
+
+
+_ERROR_SUCCESS = 0x00000000
+_PDH_CSTATUS_NEW_DATA = 0x00000001
+_PDH_MORE_DATA = 0x800007D2
+_PDH_FMT_DOUBLE = 0x00000200
+_HIP_PROPS_BUFFER_BYTES = 4096
+_HIP_PROPS_LUID_OFFSET = 272
+
+_GPU_ENGINE_INSTANCE = re.compile(
+    r"^pid_\d+_luid_(0x[0-9a-f]+)_(0x[0-9a-f]+)_phys_(\d+)_eng_(\d+)_engtype_.*$",
+    re.IGNORECASE,
+)
+
+
+class _PdhFormattedValueUnion(ctypes.Union):
+    _fields_ = [
+        ("long_value", wintypes.LONG),
+        ("double_value", ctypes.c_double),
+        ("large_value", ctypes.c_longlong),
+        ("ansi_string_value", ctypes.c_char_p),
+        ("wide_string_value", wintypes.LPWSTR),
+    ]
+
+
+class _PdhFormattedValue(ctypes.Structure):
+    _fields_ = [
+        ("status", wintypes.DWORD),
+        ("value", _PdhFormattedValueUnion),
+    ]
+
+
+class _PdhFormattedValueItem(ctypes.Structure):
+    _fields_ = [
+        ("name", wintypes.LPWSTR),
+        ("formatted_value", _PdhFormattedValue),
+    ]
+
+
+def _status_hex(status: int) -> str:
+    return f"0x{int(status) & 0xFFFFFFFF:08X}"
+
+
+def _format_windows_luid(raw_luid: bytes) -> str | None:
+    if len(raw_luid) != 8 or not any(raw_luid):
+        return None
+    low, high = struct.unpack("<II", raw_luid)
+    return f"0x{high:08x}_0x{low:08x}"
+
+
+def hip_luid_from_loaded_runtime(hip_version: str, device: int = 0) -> str | None:
+    """Return the HIP device LUID without importing torch or loading HIP."""
+
+    match = re.fullmatch(r"7\.(?:2)(?:\..*)?", str(hip_version or ""))
+    if match is None:
+        return None
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetModuleHandleW.argtypes = (wintypes.LPCWSTR,)
+    kernel32.GetModuleHandleW.restype = wintypes.HMODULE
+    kernel32.GetProcAddress.argtypes = (wintypes.HMODULE, ctypes.c_char_p)
+    kernel32.GetProcAddress.restype = ctypes.c_void_p
+
+    module = kernel32.GetModuleHandleW("amdhip64_7.dll")
+    if not module:
+        return None
+    address = kernel32.GetProcAddress(module, b"hipGetDevicePropertiesR0600")
+    if not address:
+        return None
+
+    get_properties = ctypes.WINFUNCTYPE(
+        ctypes.c_int,
+        ctypes.c_void_p,
+        ctypes.c_int,
+    )(address)
+    properties = (ctypes.c_ubyte * _HIP_PROPS_BUFFER_BYTES)()
+    if get_properties(ctypes.byref(properties), int(device)) != _ERROR_SUCCESS:
+        return None
+    return _format_windows_luid(
+        bytes(properties)[
+            _HIP_PROPS_LUID_OFFSET : _HIP_PROPS_LUID_OFFSET + 8
+        ]
+    )
+
+
+def _aggregate_gpu_engine_util(
+    items: Iterable[tuple[str, int, float]],
+    luid: str,
+) -> int | None:
+    """Return the busiest physical engine for one adapter LUID."""
+
+    target = str(luid or "").lower()
+    if not target:
+        return None
+    totals: dict[tuple[str, str], float] = {}
+    for name, counter_status, value in items:
+        if counter_status not in {_ERROR_SUCCESS, _PDH_CSTATUS_NEW_DATA}:
+            continue
+        if not math.isfinite(value):
+            continue
+        match = _GPU_ENGINE_INSTANCE.match(name)
+        if match is None:
+            continue
+        high, low, physical_engine, engine = match.groups()
+        if f"{high.lower()}_{low.lower()}" != target:
+            continue
+        key = physical_engine, engine
+        totals[key] = totals.get(key, 0.0) + max(0.0, value)
+    if not totals:
+        return None
+    busiest = max(min(100.0, value) for value in totals.values())
+    return max(0, min(100, int(round(busiest))))
+
+
+class WindowsGpuUsageReader:
+    """Persistent PDH query; the first sample primes rate counters."""
+
+    def __init__(self) -> None:
+        self._pdh = ctypes.WinDLL("pdh", use_last_error=True)
+        self._bind()
+        self._query = ctypes.c_void_p()
+        self._counter = ctypes.c_void_p()
+        self._primed = False
+
+        status = self._pdh.PdhOpenQueryW(None, 0, ctypes.byref(self._query))
+        if status != _ERROR_SUCCESS:
+            self.close()
+            raise OSError(f"PdhOpenQueryW returned {_status_hex(status)}")
+        status = self._pdh.PdhAddEnglishCounterW(
+            self._query,
+            r"\GPU Engine(*)\Utilization Percentage",
+            0,
+            ctypes.byref(self._counter),
+        )
+        if status != _ERROR_SUCCESS:
+            self.close()
+            raise OSError(f"PdhAddEnglishCounterW returned {_status_hex(status)}")
+
+    def _bind(self) -> None:
+        self._pdh.PdhOpenQueryW.argtypes = (
+            wintypes.LPCWSTR,
+            ctypes.c_size_t,
+            ctypes.POINTER(ctypes.c_void_p),
+        )
+        self._pdh.PdhOpenQueryW.restype = wintypes.DWORD
+        self._pdh.PdhAddEnglishCounterW.argtypes = (
+            ctypes.c_void_p,
+            wintypes.LPCWSTR,
+            ctypes.c_size_t,
+            ctypes.POINTER(ctypes.c_void_p),
+        )
+        self._pdh.PdhAddEnglishCounterW.restype = wintypes.DWORD
+        self._pdh.PdhCollectQueryData.argtypes = (ctypes.c_void_p,)
+        self._pdh.PdhCollectQueryData.restype = wintypes.DWORD
+        self._pdh.PdhGetFormattedCounterArrayW.argtypes = (
+            ctypes.c_void_p,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+            ctypes.POINTER(wintypes.DWORD),
+            ctypes.c_void_p,
+        )
+        self._pdh.PdhGetFormattedCounterArrayW.restype = wintypes.DWORD
+        self._pdh.PdhRemoveCounter.argtypes = (ctypes.c_void_p,)
+        self._pdh.PdhRemoveCounter.restype = wintypes.DWORD
+        self._pdh.PdhCloseQuery.argtypes = (ctypes.c_void_p,)
+        self._pdh.PdhCloseQuery.restype = wintypes.DWORD
+
+    def _collect(self) -> None:
+        status = self._pdh.PdhCollectQueryData(self._query)
+        if status != _ERROR_SUCCESS:
+            raise OSError(f"PdhCollectQueryData returned {_status_hex(status)}")
+
+    def _items(self) -> tuple[tuple[str, int, float], ...]:
+        for _attempt in range(2):
+            buffer_size = wintypes.DWORD(0)
+            item_count = wintypes.DWORD(0)
+            status = self._pdh.PdhGetFormattedCounterArrayW(
+                self._counter,
+                _PDH_FMT_DOUBLE,
+                ctypes.byref(buffer_size),
+                ctypes.byref(item_count),
+                None,
+            )
+            if status != _PDH_MORE_DATA or buffer_size.value == 0:
+                raise OSError(
+                    "PdhGetFormattedCounterArrayW size probe returned "
+                    f"{_status_hex(status)}"
+                )
+            buffer = ctypes.create_string_buffer(buffer_size.value)
+            status = self._pdh.PdhGetFormattedCounterArrayW(
+                self._counter,
+                _PDH_FMT_DOUBLE,
+                ctypes.byref(buffer_size),
+                ctypes.byref(item_count),
+                ctypes.cast(buffer, ctypes.c_void_p),
+            )
+            if status == _PDH_MORE_DATA:
+                continue
+            if status != _ERROR_SUCCESS:
+                raise OSError(
+                    "PdhGetFormattedCounterArrayW data read returned "
+                    f"{_status_hex(status)}"
+                )
+            item_size = ctypes.sizeof(_PdhFormattedValueItem)
+            if item_count.value * item_size > len(buffer):
+                raise OSError("PDH GPU Engine item array exceeds its buffer")
+            items = ctypes.cast(
+                buffer,
+                ctypes.POINTER(_PdhFormattedValueItem),
+            )
+            return tuple(
+                (
+                    items[index].name or "",
+                    int(items[index].formatted_value.status),
+                    float(items[index].formatted_value.value.double_value),
+                )
+                for index in range(item_count.value)
+            )
+        raise OSError("PDH GPU Engine instances changed during both reads")
+
+    def read_percent(self, luid: str) -> int | None:
+        if not self._primed:
+            self._collect()
+            self._primed = True
+            return None
+        self._collect()
+        return _aggregate_gpu_engine_util(self._items(), luid)
+
+    def close(self) -> None:
+        counter, self._counter = self._counter, ctypes.c_void_p()
+        query, self._query = self._query, ctypes.c_void_p()
+        self._primed = False
+        if counter:
+            self._pdh.PdhRemoveCounter(counter)
+        if query:
+            self._pdh.PdhCloseQuery(query)

--- a/tests/test_hardware_policy.py
+++ b/tests/test_hardware_policy.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from jasna.gui.app import JasnaApp
+from jasna.gui.hardware_policy import (
+    DEFAULT_DETECTION_BATCH_SIZE,
+    HIGH_VRAM_DETECTION_BATCH_SIZE,
+    HIGH_VRAM_MIN_BYTES,
+    recommended_detection_batch_size,
+)
+from jasna.gui.models import AppSettings
+from jasna.gui.settings_panel import SettingsPanel
+
+
+def test_only_rfdetr_v6_on_at_least_23_gib_uses_batch_eight() -> None:
+    assert recommended_detection_batch_size("rfdetr-v6", HIGH_VRAM_MIN_BYTES) == (
+        HIGH_VRAM_DETECTION_BATCH_SIZE
+    )
+    assert recommended_detection_batch_size("RFDETR-V6", 24 * 1024**3) == 8
+    assert recommended_detection_batch_size("rfdetr-v6", HIGH_VRAM_MIN_BYTES - 1) == (
+        DEFAULT_DETECTION_BATCH_SIZE
+    )
+    assert recommended_detection_batch_size("rfdetr-v6", None) == 4
+    assert recommended_detection_batch_size("rfdetr-v6-large", 24 * 1024**3) == 4
+
+
+def test_settings_panel_derives_hidden_batch_from_latest_vram_telemetry() -> None:
+    panel = SimpleNamespace(
+        _sections=[SimpleNamespace(collect=lambda: {"detection_model": "rfdetr-v6"})],
+        _total_vram_bytes=24 * 1024**3,
+    )
+
+    settings = SettingsPanel.get_settings(panel)
+
+    assert isinstance(settings, AppSettings)
+    assert settings.batch_size == 8
+
+
+def test_app_keeps_last_known_vram_capacity_when_sample_is_missing() -> None:
+    app = SimpleNamespace(
+        _control_bar=SimpleNamespace(set_system_stats=MagicMock()),
+        _settings_panel=SimpleNamespace(set_total_vram_bytes=MagicMock()),
+    )
+    known = SimpleNamespace(total_vram_bytes=24 * 1024**3)
+    missing = SimpleNamespace(total_vram_bytes=None)
+
+    JasnaApp._apply_system_stats(app, known)
+    JasnaApp._apply_system_stats(app, missing)
+
+    assert app._control_bar.set_system_stats.call_count == 2
+    app._settings_panel.set_total_vram_bytes.assert_called_once_with(24 * 1024**3)

--- a/tests/test_system_stats.py
+++ b/tests/test_system_stats.py
@@ -109,13 +109,18 @@ def test_read_gpu_vram_prefers_loaded_hip_torch_on_windows(monkeypatch) -> None:
     )
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
     monkeypatch.setattr(system_stats.sys, "platform", "win32")
+    monkeypatch.setattr(
+        system_stats,
+        "_read_windows_amd_gpu_util",
+        lambda _hip_version, _device: 61,
+    )
 
     def _should_not_find(_name):
         raise AssertionError("active HIP telemetry must precede nvidia-smi")
 
     monkeypatch.setattr(system_stats.os_utils, "find_executable", _should_not_find)
 
-    assert system_stats.read_gpu_vram() == (None, 25, 1200)
+    assert system_stats.read_gpu_vram() == (61, 25, 1200)
 
 
 def test_read_loaded_torch_amd_uses_gui_device_zero(monkeypatch) -> None:
@@ -141,9 +146,19 @@ def test_read_loaded_torch_amd_uses_gui_device_zero(monkeypatch) -> None:
         ),
     )
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(system_stats.sys, "platform", "win32")
+    monkeypatch.setattr(
+        system_stats,
+        "_read_windows_amd_gpu_util",
+        lambda hip_version, device: calls.append(("util", hip_version, device)) or 62,
+    )
 
-    assert system_stats._read_loaded_torch_amd() == (None, 25, 1200)
-    assert calls == [("properties", 0), ("memory", 0)]
+    assert system_stats._read_loaded_torch_amd() == (62, 25, 1200)
+    assert calls == [
+        ("properties", 0),
+        ("util", "7.2", 0),
+        ("memory", 0),
+    ]
 
 
 def test_read_gpu_vram_does_not_mix_loaded_hip_and_nvidia_on_windows(
@@ -203,8 +218,74 @@ def test_read_loaded_torch_amd_keeps_total_when_usage_query_fails(
         ),
     )
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(system_stats.sys, "platform", "win32")
+    monkeypatch.setattr(
+        system_stats,
+        "_read_windows_amd_gpu_util",
+        lambda _hip_version, _device: 45,
+    )
 
-    assert system_stats._read_loaded_torch_amd() == (None, None, 1200)
+    assert system_stats._read_loaded_torch_amd() == (45, None, 1200)
+
+
+def test_windows_amd_gpu_reader_is_reused_after_its_prime_sample(monkeypatch) -> None:
+    class Reader:
+        def __init__(self):
+            self.values = iter((None, 74))
+            self.closed = False
+
+        def read_percent(self, luid):
+            assert luid == "0x00000000_0x0000f823"
+            return next(self.values)
+
+        def close(self):
+            self.closed = True
+
+    reader = Reader()
+    monkeypatch.setattr(
+        system_stats,
+        "_loaded_hip_device_luid",
+        lambda _hip_version, _device: "0x00000000_0x0000f823",
+    )
+    monkeypatch.setattr(system_stats, "_new_windows_gpu_reader", lambda: reader)
+    system_stats.close_gpu_telemetry()
+
+    assert system_stats._read_windows_amd_gpu_util("7.2", 0) is None
+    assert system_stats._read_windows_amd_gpu_util("7.2", 0) == 74
+    assert not reader.closed
+    system_stats.close_gpu_telemetry()
+    assert reader.closed
+
+
+def test_windows_amd_gpu_reader_failure_resets_for_a_later_poll(monkeypatch) -> None:
+    readers = []
+
+    class Reader:
+        def __init__(self):
+            self.closed = False
+            readers.append(self)
+
+        def read_percent(self, _luid):
+            if len(readers) == 1:
+                raise OSError("PDH query failed")
+            return 33
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(
+        system_stats,
+        "_loaded_hip_device_luid",
+        lambda _hip_version, _device: "0x00000000_0x0000f823",
+    )
+    monkeypatch.setattr(system_stats, "_new_windows_gpu_reader", Reader)
+    system_stats.close_gpu_telemetry()
+
+    assert system_stats._read_windows_amd_gpu_util("7.2", 0) is None
+    assert readers[0].closed
+    assert system_stats._read_windows_amd_gpu_util("7.2", 0) == 33
+    assert len(readers) == 2
+    system_stats.close_gpu_telemetry()
 
 
 def test_read_cpu_ram_uses_psutil(monkeypatch) -> None:

--- a/tests/test_system_stats.py
+++ b/tests/test_system_stats.py
@@ -43,9 +43,10 @@ def test_color_for_percent_interpolates_midpoints() -> None:
 
 
 def test_parse_nvidia_smi_csv_line_parses_gpu_and_vram_pct() -> None:
-    gpu, vram = system_stats._parse_nvidia_smi_csv_line("85, 1200, 2400")
+    gpu, vram, total = system_stats._parse_nvidia_smi_csv_line("85, 1200, 2400")
     assert gpu == 85
     assert vram == 50
+    assert total == 2400 * 1024 * 1024
 
 
 def test_read_gpu_vram_returns_none_when_gpu_tools_and_amd_sysfs_are_missing(
@@ -59,9 +60,10 @@ def test_read_gpu_vram_returns_none_when_gpu_tools_and_amd_sysfs_are_missing(
 
     monkeypatch.setattr(system_stats.subprocess, "run", _should_not_run)
 
-    gpu, vram = system_stats.read_gpu_vram()
+    gpu, vram, total = system_stats.read_gpu_vram()
     assert gpu is None
     assert vram is None
+    assert total is None
 
 
 def test_read_gpu_vram_reads_amd_sysfs_without_torch(monkeypatch, tmp_path) -> None:
@@ -74,7 +76,7 @@ def test_read_gpu_vram_reads_amd_sysfs_without_torch(monkeypatch, tmp_path) -> N
     monkeypatch.setattr(system_stats.os_utils, "find_executable", lambda name: None)
     monkeypatch.setattr(system_stats, "_DRM_CLASS_PATH", tmp_path)
 
-    assert system_stats.read_gpu_vram() == (73, 25)
+    assert system_stats.read_gpu_vram() == (73, 25, 1200)
 
 
 def test_read_gpu_vram_parses_first_device(monkeypatch) -> None:
@@ -85,9 +87,10 @@ def test_read_gpu_vram_parses_first_device(monkeypatch) -> None:
 
     monkeypatch.setattr(system_stats.subprocess, "run", _fake_run)
 
-    gpu, vram = system_stats.read_gpu_vram()
+    gpu, vram, total = system_stats.read_gpu_vram()
     assert gpu == 85
     assert vram == 50
+    assert total == 2400 * 1024 * 1024
 
 
 def test_read_cpu_ram_uses_psutil(monkeypatch) -> None:

--- a/tests/test_system_stats.py
+++ b/tests/test_system_stats.py
@@ -118,6 +118,57 @@ def test_read_gpu_vram_prefers_loaded_hip_torch_on_windows(monkeypatch) -> None:
     assert system_stats.read_gpu_vram() == (None, 25, 1200)
 
 
+def test_read_loaded_torch_amd_uses_gui_device_zero(monkeypatch) -> None:
+    calls = []
+
+    def _get_properties(device):
+        calls.append(("properties", device))
+        return SimpleNamespace(total_memory=1200)
+
+    def _get_memory(device):
+        calls.append(("memory", device))
+        return 900, 1200
+
+    fake_torch = SimpleNamespace(
+        version=SimpleNamespace(hip="7.2"),
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            current_device=lambda: (_ for _ in ()).throw(
+                AssertionError("system telemetry must match GUI cuda:0")
+            ),
+            get_device_properties=_get_properties,
+            mem_get_info=_get_memory,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    assert system_stats._read_loaded_torch_amd() == (None, 25, 1200)
+    assert calls == [("properties", 0), ("memory", 0)]
+
+
+def test_read_gpu_vram_does_not_mix_loaded_hip_and_nvidia_on_windows(
+    monkeypatch,
+) -> None:
+    fake_torch = SimpleNamespace(
+        version=SimpleNamespace(hip="7.2"),
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            get_device_properties=lambda _device: (_ for _ in ()).throw(
+                RuntimeError("HIP capacity query failed")
+            ),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(system_stats.sys, "platform", "win32")
+
+    def _should_not_find(_name):
+        raise AssertionError("loaded HIP runtime must not use NVIDIA capacity")
+
+    monkeypatch.setattr(system_stats.os_utils, "find_executable", _should_not_find)
+
+    assert system_stats.read_gpu_vram() == (None, None, None)
+
+
 def test_read_loaded_torch_amd_does_not_import_torch(monkeypatch) -> None:
     monkeypatch.delitem(sys.modules, "torch", raising=False)
 

--- a/tests/test_system_stats.py
+++ b/tests/test_system_stats.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 import subprocess
+import sys
+from types import SimpleNamespace
 
 from jasna.gui import system_stats
 from jasna.gui.control_bar import _color_for_percent, _format_duration
@@ -52,6 +53,7 @@ def test_parse_nvidia_smi_csv_line_parses_gpu_and_vram_pct() -> None:
 def test_read_gpu_vram_returns_none_when_gpu_tools_and_amd_sysfs_are_missing(
     monkeypatch, tmp_path
 ) -> None:
+    monkeypatch.setattr(system_stats.sys, "platform", "linux")
     monkeypatch.setattr(system_stats.os_utils, "find_executable", lambda name: None)
     monkeypatch.setattr(system_stats, "_DRM_CLASS_PATH", tmp_path)
 
@@ -73,6 +75,7 @@ def test_read_gpu_vram_reads_amd_sysfs_without_torch(monkeypatch, tmp_path) -> N
     (device / "gpu_busy_percent").write_text("73\n", encoding="utf-8")
     (device / "mem_info_vram_used").write_text("300\n", encoding="utf-8")
     (device / "mem_info_vram_total").write_text("1200\n", encoding="utf-8")
+    monkeypatch.setattr(system_stats.sys, "platform", "linux")
     monkeypatch.setattr(system_stats.os_utils, "find_executable", lambda name: None)
     monkeypatch.setattr(system_stats, "_DRM_CLASS_PATH", tmp_path)
 
@@ -80,6 +83,7 @@ def test_read_gpu_vram_reads_amd_sysfs_without_torch(monkeypatch, tmp_path) -> N
 
 
 def test_read_gpu_vram_parses_first_device(monkeypatch) -> None:
+    monkeypatch.setattr(system_stats.sys, "platform", "linux")
     monkeypatch.setattr(system_stats.os_utils, "find_executable", lambda name: "nvidia-smi")
 
     def _fake_run(cmd, **kwargs):
@@ -91,6 +95,65 @@ def test_read_gpu_vram_parses_first_device(monkeypatch) -> None:
     assert gpu == 85
     assert vram == 50
     assert total == 2400 * 1024 * 1024
+
+
+def test_read_gpu_vram_prefers_loaded_hip_torch_on_windows(monkeypatch) -> None:
+    fake_torch = SimpleNamespace(
+        version=SimpleNamespace(hip="7.2"),
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            current_device=lambda: 0,
+            get_device_properties=lambda _device: SimpleNamespace(total_memory=1200),
+            mem_get_info=lambda _device: (900, 1200),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(system_stats.sys, "platform", "win32")
+
+    def _should_not_find(_name):
+        raise AssertionError("active HIP telemetry must precede nvidia-smi")
+
+    monkeypatch.setattr(system_stats.os_utils, "find_executable", _should_not_find)
+
+    assert system_stats.read_gpu_vram() == (None, 25, 1200)
+
+
+def test_read_loaded_torch_amd_does_not_import_torch(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+    assert system_stats._read_loaded_torch_amd() == (None, None, None)
+
+
+def test_read_loaded_torch_amd_fails_open(monkeypatch) -> None:
+    fake_torch = SimpleNamespace(
+        version=SimpleNamespace(hip="7.2"),
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            current_device=lambda: (_ for _ in ()).throw(RuntimeError("query failed")),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    assert system_stats._read_loaded_torch_amd() == (None, None, None)
+
+
+def test_read_loaded_torch_amd_keeps_total_when_usage_query_fails(
+    monkeypatch,
+) -> None:
+    fake_torch = SimpleNamespace(
+        version=SimpleNamespace(hip="7.2"),
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            current_device=lambda: 0,
+            get_device_properties=lambda _device: SimpleNamespace(total_memory=1200),
+            mem_get_info=lambda _device: (_ for _ in ()).throw(
+                RuntimeError("usage query failed")
+            ),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    assert system_stats._read_loaded_torch_amd() == (None, None, 1200)
 
 
 def test_read_cpu_ram_uses_psutil(monkeypatch) -> None:

--- a/tests/test_windows_gpu_usage.py
+++ b/tests/test_windows_gpu_usage.py
@@ -1,0 +1,65 @@
+from jasna.gui.windows_gpu_usage import (
+    _aggregate_gpu_engine_util,
+    _format_windows_luid,
+)
+
+
+def _instance(luid, physical, engine, pid=100, engine_type="Compute_0"):
+    return (
+        f"pid_{pid}_luid_{luid}_phys_{physical}_eng_{engine}_"
+        f"engtype_{engine_type}"
+    )
+
+
+def test_format_windows_luid_uses_pdh_high_then_low_order() -> None:
+    assert _format_windows_luid(bytes.fromhex("23f8000000000000")) == (
+        "0x00000000_0x0000f823"
+    )
+    assert _format_windows_luid(bytes(8)) is None
+
+
+def test_gpu_engine_util_filters_luid_and_uses_busiest_engine() -> None:
+    target = "0x00000000_0x0000f823"
+    other = "0x00000000_0x0001c552"
+    items = [
+        (_instance(target, 0, 0), 0, 31.2),
+        (_instance(target, 0, 1), 0, 72.6),
+        (_instance(other, 0, 0), 0, 99.0),
+    ]
+
+    assert _aggregate_gpu_engine_util(items, target) == 73
+
+
+def test_gpu_engine_util_sums_processes_on_one_engine_and_caps_at_100() -> None:
+    target = "0x00000000_0x0000f823"
+    items = [
+        (_instance(target, 0, 4, pid=10), 0, 61.0),
+        (_instance(target, 0, 4, pid=20), 1, 52.0),
+        (_instance(target, 0, 5, pid=30), 0, 40.0),
+    ]
+
+    assert _aggregate_gpu_engine_util(items, target) == 100
+
+
+def test_gpu_engine_util_distinguishes_idle_from_unknown() -> None:
+    target = "0x00000000_0x0000f823"
+
+    assert _aggregate_gpu_engine_util(
+        [(_instance(target, 0, 0), 0, 0.0)],
+        target,
+    ) == 0
+    assert _aggregate_gpu_engine_util(
+        [(_instance("0x00000000_0x0001c552", 0, 0), 0, 0.0)],
+        target,
+    ) is None
+
+
+def test_gpu_engine_util_ignores_invalid_status_values_and_names() -> None:
+    target = "0x00000000_0x0000f823"
+    items = [
+        (_instance(target, 0, 0), 0xC0000BC6, 90.0),
+        (_instance(target, 0, 1), 0, float("nan")),
+        ("malformed", 0, 80.0),
+    ]
+
+    assert _aggregate_gpu_engine_util(items, target) is None


### PR DESCRIPTION
# Windows AMD GPU telemetry and optional 24 GiB RF-DETR v6 batch policy

Chinese companion: [中文说明](https://github.com/Kruk2/jasna/pull/319#issuecomment-5312170815).

## Important scope warning

This candidate is independent of the other functional PRs. The batch increase was
measured on a 24 GB Radeon RX 7900 XTX. Because the policy is vendor-neutral and
a 24 GB NVIDIA board also satisfies the guard, an RTX 3090/4090 real-video A/B
remains mandatory before upstream merge.

## Summary

- The GUI derives a hidden RF-DETR v6 detection batch from total VRAM: at least
  23 GiB selects batch 8; every excluded or unknown case remains at batch 4.
- Windows obtains AMD total VRAM from an already-loaded HIP `torch` runtime. It
  does not import or initialize torch from the system-stat poller.
- Telemetry queries logical `cuda:0`, matching the GUI inference device instead
  of mutable thread-local current-device state.
- Once loaded torch identifies the runtime as HIP, a transient AMD query failure
  remains unknown and is retried later; it never substitutes capacity from a
  second NVIDIA adapter. `mem_get_info()` remains best-effort.
- Windows AMD GPU activity uses the native PDH GPU Engine counters, filtered to HIP `cuda:0` by its adapter LUID; no AMD SMI dependency is added.
- The first rate-counter sample remains unknown; later 1.5 s samples report 0-100%, including an explicit 0% idle value.
- Linux AMD sysfs and NVIDIA-only SMI paths remain unchanged.

## Guard and exclusions

- public branch: `perf/amd-rfdetr-24gb-policy` (`9cfdea2`);
- independent base: `upstream/main`; all PR heads are also collected on
  `integration/v0.10-full` for aggregate validation;
- only model name exactly `rfdetr-v6` and total VRAM >=23 GiB uses 8;
- rfdetr-v6-large, fixed-batch v5, YOLO, CLI jobs, missing telemetry and smaller
  GPUs stay at 4;
- manual preset persistence does not save the hardware-derived hidden value.

## Windows AMD telemetry validation

Real RX 7900 XTX / ROCm-HIP runtime:

```text
physical total_memory=25753026560
original read_gpu_vram=(None, None, None)
original batch_from_telemetry=4
current first read_gpu_vram=(None, 1, 25753026560)
current loaded read_gpu_vram=(26, 1, 25753026560)
current settled read_gpu_vram=(0, 1, 25753026560)
current batch_from_telemetry=8
```

The initial same-suite baseline/current comparison was `19 passed` / `23 passed`.
The source-isolation follow-up was `23 passed` / `25 passed` and proves:

```text
before: device_calls=[('properties', 1), ('memory', 1)]
before failed_hip_stats=(91, 0, 25769803776)
after:  device_calls=[('properties', 0), ('memory', 0)]
after  failed_hip_stats=(None, None, None)
```

Modified checks: `compileall` exit 0, `pip check` reports no broken requirements,
and `git diff --check` exits 0. Both reverse patches were executed on separate
copies; original SHA-256 hashes, baseline behavior and focused tests were restored.


## Windows AMD GPU activity validation

The installed PyTorch HIP wrapper exposes `torch.cuda.utilization()` but it fails
because AMD SMI is absent on this Windows runtime. The implementation therefore
uses the built-in Windows PDH GPU Engine counter and maps it to HIP `cuda:0` with
the LUID returned by the already-loaded `amdhip64_7.dll` R0600 ABI.

```text
prime (None, 1, 25753026560)
load_loops=7569 load_seconds=1.500
post_load (26, 1, 25753026560)
settled (0, 1, 25753026560)
NATIVE_LOAD_PROBE_EXIT=0
```

Steady telemetry reads take roughly 2.2-2.5 ms in the integrated probe. The
focused Windows/native-adjacent suite reports `38 passed`; compileall and
git diff checks exit 0. PDH handles are closed on poller shutdown, query errors
fail open, and a later poll recreates the reader.

## RX 7900 XTX real-video A/B

- Real 8K Main10/P010 route: 141.854 s at batch 4 vs 134.751 s at batch 8
  (5.27% faster), peak system VRAM 21.036 GiB.
- Real 8K 8-bit/NV12 route: 122.927 s vs 116.863 s (5.19% faster), peak VRAM
  16.702 GiB.
- All six comparison outputs retained 1202/1202 frames, exact display-order
  PTS and source bit depth, and passed full software decode without OOM, native
  fallback or GPU reset.

## Required upstream test

Do not merge based only on the RX 7900 XTX result. Run the same batch-4/batch-8
real-video A/B on at least one RTX 3090 or RTX 4090, checking output equality,
wall time, peak VRAM, temperature, OOM and TensorRT behavior. If that test is not
available, skip this PR; no other candidate depends on it.