### PR TITLE
fix(amd): support Windows ROCm source runtime

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -37,21 +37,20 @@ uv pip install ".[amd]" \
   --find-links https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.1/
 ```
 
-**AMD Windows** (ROCm 7.2.1 — Python 3.12, Adrenalin ≥ 26.2.2). Install the ROCm
-SDK + torch/torchvision ROCm wheels FIRST, with `--no-deps` so pip cannot silently
-replace them with the CPU `torch==2.9.1` from PyPI when a later dependency
-(torchvision, rfdetr, …) pulls torch — that swap is the usual cause of a
-"non-ROCm torch/torchvision" env:
+**AMD Windows** (ROCm 7.2.1 — Python 3.12, Adrenalin ≥ 26.2.2). Install the full
+ROCm environment listed by AMD, then expose the ROCm wheel directory to uv while
+installing Jasna. The `--find-links` argument is important: without it uv can
+replace a previously installed `torch==2.9.1+rocm7.2.1` with the PyPI CPU
+`torch==2.9.1` while resolving the remaining project dependencies.
 
 ```powershell
 $R = "https://repo.radeon.com/rocm/windows/rocm-rel-7.2.1"
-pip install --no-deps `
+pip install --no-cache-dir `
   "$R/rocm_sdk_core-7.2.1-py3-none-win_amd64.whl" `
+  "$R/rocm_sdk_devel-7.2.1-py3-none-win_amd64.whl" `
   "$R/rocm_sdk_libraries_custom-7.2.1-py3-none-win_amd64.whl" `
-  "$R/torch-2.9.1+rocm7.2.1-cp312-cp312-win_amd64.whl" `
-  "$R/torchvision-0.24.1+rocm7.2.1-cp312-cp312-win_amd64.whl"
-# then the remaining AMD deps (torch/torchvision above already satisfy the pins)
-uv pip install ".[amd]"
+  "$R/rocm-7.2.1.tar.gz"
+uv pip install -e ".[amd,dev]" --find-links "$R/"
 ```
 
 The `rocm_sdk_core` / `rocm_sdk_libraries_*` wheels are the ROCm runtime itself.
@@ -68,7 +67,9 @@ Verify ROCm actually stuck on either OS (the Linux Docker build asserts the same
 python -c "import torch, torchvision; assert torch.version.hip and '+rocm' in torchvision.__version__; print('ROCm OK', torch.__version__, torchvision.__version__)"
 ```
 
-`jasna[amd]` pins `torch==2.9.1` as a plain version on purpose: the ROCm wheels
+The `rocm_sdk_devel` wheel and `rocm` package are required parts of AMD's Windows
+environment setup; `rocm` provides the `rocm_sdk` module imported by torch at
+startup. `jasna[amd]` pins `torch==2.9.1` as a plain version on purpose: the ROCm wheels
 (`2.9.1+rocm7.2.1`) satisfy it, and a `+rocm7.2.1` *local-version* pin can't be
 shared across OSes. torchvision is pinned per OS (`0.24.0` on Linux, `0.24.1`
 on Windows) because the ROCm channels ship different versions — the Linux

--- a/jasna/models/basicvsrpp/__init__.py
+++ b/jasna/models/basicvsrpp/__init__.py
@@ -1,6 +1,15 @@
 # SPDX-FileCopyrightText: Lada Authors
 # SPDX-License-Identifier: AGPL-3.0
 
+from jasna.models.basicvsrpp.mmengine_compat import prepare_mmengine_for_windows_rocm
+
+
+# MMEngine imports distributed-only symbols before it exposes the model/config
+# helpers used below.  Windows ROCm inference is single-process and its torch
+# wheel omits those symbols, so prepare that dependency boundary first.
+prepare_mmengine_for_windows_rocm()
+
+
 def register_all_modules():
     from jasna.models.basicvsrpp.mmagic import register_all_modules
     register_all_modules()

--- a/jasna/models/basicvsrpp/mmengine_compat.py
+++ b/jasna/models/basicvsrpp/mmengine_compat.py
@@ -1,0 +1,80 @@
+"""Compatibility helpers for MMEngine on the Windows ROCm torch wheel.
+
+The Windows ROCm build intentionally omits distributed c10d, while MMEngine
+imports a few distributed-only names even for single-process inference.  Keep
+the compatibility surface local to the BasicVSR++ dependency boundary so CUDA
+and Linux ROCm imports are left untouched.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from typing import Any
+
+
+_FSDP_MODULE = "mmengine.model.wrappers.fully_sharded_distributed"
+
+
+def _distributed_c10d_available() -> bool:
+    try:
+        importlib.import_module("torch._C._distributed_c10d")
+    except (ImportError, ModuleNotFoundError):
+        return False
+    return True
+
+
+def prepare_mmengine_for_windows_rocm(
+    torch_module: Any | None = None,
+    *,
+    platform: str | None = None,
+    c10d_available: bool | None = None,
+) -> tuple[str, ...]:
+    """Make MMEngine importable for single-process Windows ROCm inference.
+
+    Returns the names of compatibility surfaces installed by this call.  The
+    optional arguments make the narrowly scoped behavior unit-testable without
+    replacing the active torch installation.
+    """
+
+    if torch_module is None:
+        import torch as torch_module
+
+    active_platform = sys.platform if platform is None else platform
+    torch_version = getattr(torch_module, "version", None)
+    if active_platform != "win32" or not getattr(torch_version, "hip", None):
+        return ()
+
+    installed: list[str] = []
+    torch_dist = getattr(torch_module, "distributed", None)
+    if torch_dist is not None and not hasattr(torch_dist, "ReduceOp"):
+
+        class _ReduceOp:
+            SUM = "sum"
+            PRODUCT = "product"
+            MIN = "min"
+            MAX = "max"
+            BAND = "band"
+            BOR = "bor"
+            BXOR = "bxor"
+
+        torch_dist.ReduceOp = _ReduceOp
+        installed.append("torch.distributed.ReduceOp")
+
+    if c10d_available is None:
+        c10d_available = _distributed_c10d_available()
+    if not c10d_available and _FSDP_MODULE not in sys.modules:
+        module = types.ModuleType(_FSDP_MODULE)
+
+        class MMFullyShardedDataParallel:
+            def __init__(self, *args, **kwargs):
+                raise RuntimeError(
+                    "MMEngine FSDP is unavailable in this Windows ROCm torch build"
+                )
+
+        module.MMFullyShardedDataParallel = MMFullyShardedDataParallel
+        sys.modules[_FSDP_MODULE] = module
+        installed.append("mmengine FSDP stub")
+
+    return tuple(installed)

--- a/tests/test_mmengine_windows_rocm_compat.py
+++ b/tests/test_mmengine_windows_rocm_compat.py
@@ -1,0 +1,72 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from jasna.models.basicvsrpp.mmengine_compat import (
+    _FSDP_MODULE,
+    prepare_mmengine_for_windows_rocm,
+)
+
+
+def _fake_rocm_torch(*, with_reduce_op: bool = False):
+    distributed = SimpleNamespace()
+    if with_reduce_op:
+        distributed.ReduceOp = SimpleNamespace(SUM="existing")
+    return SimpleNamespace(
+        distributed=distributed,
+        version=SimpleNamespace(hip="7.2.1"),
+    )
+
+
+def test_compatibility_is_scoped_to_windows_rocm(monkeypatch):
+    monkeypatch.delitem(sys.modules, _FSDP_MODULE, raising=False)
+    linux_torch = _fake_rocm_torch()
+
+    installed = prepare_mmengine_for_windows_rocm(
+        linux_torch,
+        platform="linux",
+        c10d_available=False,
+    )
+
+    assert installed == ()
+    assert not hasattr(linux_torch.distributed, "ReduceOp")
+    assert _FSDP_MODULE not in sys.modules
+
+
+def test_missing_windows_rocm_distributed_surfaces_are_stubbed(monkeypatch):
+    monkeypatch.delitem(sys.modules, _FSDP_MODULE, raising=False)
+    torch_module = _fake_rocm_torch()
+
+    installed = prepare_mmengine_for_windows_rocm(
+        torch_module,
+        platform="win32",
+        c10d_available=False,
+    )
+
+    assert installed == (
+        "torch.distributed.ReduceOp",
+        "mmengine FSDP stub",
+    )
+    assert torch_module.distributed.ReduceOp.SUM == "sum"
+    assert torch_module.distributed.ReduceOp.BXOR == "bxor"
+    with pytest.raises(RuntimeError, match="Windows ROCm"):
+        sys.modules[_FSDP_MODULE].MMFullyShardedDataParallel()
+
+
+def test_compatibility_setup_is_idempotent(monkeypatch):
+    monkeypatch.delitem(sys.modules, _FSDP_MODULE, raising=False)
+    torch_module = _fake_rocm_torch()
+    prepare_mmengine_for_windows_rocm(
+        torch_module,
+        platform="win32",
+        c10d_available=False,
+    )
+
+    installed = prepare_mmengine_for_windows_rocm(
+        torch_module,
+        platform="win32",
+        c10d_available=False,
+    )
+
+    assert installed == ()


### PR DESCRIPTION
## Summary

- add a narrowly scoped Windows ROCm compatibility boundary before BasicVSR++ imports MMEngine
- provide the `ReduceOp` names MMEngine evaluates during import when the Windows ROCm torch wheel exposes only a partial `torch.distributed`
- replace MMEngine's unavailable FSDP module with an explicit fail-fast shell; Jasna's BasicVSR++ path is single-process inference
- align the Windows source setup with AMD's complete ROCm 7.2.1 environment and make uv resolve the ROCm torch/torchvision wheels through `--find-links`

## Problem

The ROCm 7.2.1 Windows torch wheel intentionally omits distributed c10d. MMEngine 0.10.7 imports `torch.distributed.ReduceOp` and FSDP at module import time even though Jasna never uses distributed inference. On a clean Windows AMD environment this prevented `jasna.pipeline` and `RestorationPipeline` from importing.

The previous development command also omitted `rocm_sdk_devel` and the `rocm` package. In a clean venv, uv then replaced the preinstalled `torch==2.9.1+rocm7.2.1` with PyPI `torch==2.9.1`; the resulting ROCm torch import also lacked the `rocm_sdk` module.

AMD's current Windows installation reference is: https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/windows/install-pytorch.html

## Scope

- independent base: `upstream/main` at `592472bda8aeb1fc0d5cea3d3ff6607add0ab0a7`
- runtime patch activates only for `sys.platform == "win32"` with `torch.version.hip`
- Linux ROCm and NVIDIA/CUDA import behavior remains unchanged
- FSDP remains explicitly unavailable on the Windows ROCm wheel; the shim exists only to let single-process inference import

## Validation

Windows 11, Python 3.12.10, RX 7900 XTX, ROCm torch 2.9.1+rocm7.2.1:

- `python -m pip check`: no broken requirements
- focused pipeline/restoration/compatibility tests: **75 passed**
- pipeline thread tests: **36 passed, 1 unrelated pre-existing timing test deselected**
- real imports: `WINDOWS_ROCM_IMPORT_OK 2.9.1+rocm7.2.1 Pipeline RestorationPipeline`
- real BasicVSR++ checkpoint GPU smoke: `PR_GPU_SMOKE_OK ... 1 (256, 256, 3) torch.uint8`
- uv resolver with the documented `--find-links`: selected `torch==2.9.1+rocm7.2.1` and `torchvision==0.24.1+rocm7.2.1`