### PR TITLE
fix(gui): skip NVIDIA sysmem check on AMD

### DIFF
--- a/jasna/gui/wizard.py
+++ b/jasna/gui/wizard.py
@@ -1,12 +1,12 @@
 """First-run wizard for dependency checking."""
 
 import logging
-import os
 import subprocess
+import sys
 import threading
 import time
 import webbrowser
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
 import customtkinter as ctk
 
@@ -25,6 +25,22 @@ _HELP_URLS = {
 }
 
 _WARNING_ONLY_CHECKS = {"sysmem"}
+
+
+def _should_check_nvidia_sysmem(
+    *,
+    platform_name: str | None = None,
+    nvidia_probe: Callable[[], bool] | None = None,
+) -> bool:
+    """Return whether the Windows-only NVIDIA sysmem check applies."""
+    resolved_platform = sys.platform if platform_name is None else platform_name
+    if resolved_platform != "win32":
+        return False
+    if nvidia_probe is None:
+        from jasna.accelerator import is_nvidia_device
+
+        nvidia_probe = is_nvidia_device
+    return bool(nvidia_probe())
 
 
 def _evaluate_check_results(
@@ -55,6 +71,7 @@ class FirstRunWizard(ctk.CTkToplevel):
         self._checks_passed = False
         self._has_required_failure = True
         self._check_results = {}
+        self._include_sysmem_check = _should_check_nvidia_sysmem()
         
         self.title(t("wizard_window_title"))
         self.resizable(True, False)
@@ -127,7 +144,7 @@ class FirstRunWizard(ctk.CTkToplevel):
             ("cuda", t("wizard_check_cuda")),
             ("driver", t("wizard_check_driver")),
         ]
-        if os.name == "nt":
+        if self._include_sysmem_check:
             checks.append(("sysmem", t("wizard_check_sysmem")))
         
         for key, label in checks:
@@ -281,7 +298,7 @@ class FirstRunWizard(ctk.CTkToplevel):
         self._check_results["gpu"] = self._check_gpu()
         self._check_results["cuda"] = self._check_cuda()
         self._check_results["driver"] = os_utils.check_gpu_driver_version()
-        if os.name == "nt":
+        if self._include_sysmem_check:
             self._check_results["sysmem"] = os_utils.check_windows_nvidia_sysmem_fallback_policy()
 
     def _check_executable(self, name: str) -> tuple[bool, str]:

--- a/tests/test_gui_wizard_sysmem.py
+++ b/tests/test_gui_wizard_sysmem.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import types
+
+from jasna import os_utils
+from jasna.gui.wizard import FirstRunWizard, _should_check_nvidia_sysmem
+
+
+def test_nvidia_sysmem_check_is_included_on_windows_nvidia():
+    assert _should_check_nvidia_sysmem(
+        platform_name="win32", nvidia_probe=lambda: True
+    )
+
+
+def test_nvidia_sysmem_check_is_omitted_on_windows_amd():
+    assert not _should_check_nvidia_sysmem(
+        platform_name="win32", nvidia_probe=lambda: False
+    )
+
+
+def test_nvidia_sysmem_check_is_omitted_off_windows_without_probing():
+    def unexpected_probe() -> bool:
+        raise AssertionError("the NVIDIA probe must not run off Windows")
+
+    assert not _should_check_nvidia_sysmem(
+        platform_name="linux", nvidia_probe=unexpected_probe
+    )
+
+
+def _wizard_check_stub(*, include_sysmem: bool) -> types.SimpleNamespace:
+    def passing_check(*_args) -> tuple[bool, str]:
+        return True, "ok"
+
+    return types.SimpleNamespace(
+        _include_sysmem_check=include_sysmem,
+        _check_results={},
+        _check_executable=passing_check,
+        _check_gpu=passing_check,
+        _check_cuda=passing_check,
+    )
+
+
+def test_run_checks_omits_nvidia_sysmem_for_amd(monkeypatch):
+    stub = _wizard_check_stub(include_sysmem=False)
+    monkeypatch.setattr(os_utils, "check_ascii_install_path", lambda: (True, "ok"))
+    monkeypatch.setattr(os_utils, "check_gpu_driver_version", lambda: (True, "ok"))
+
+    def unexpected_check():
+        raise AssertionError("the NVIDIA sysmem check must not run for AMD")
+
+    monkeypatch.setattr(
+        os_utils, "check_windows_nvidia_sysmem_fallback_policy", unexpected_check
+    )
+
+    FirstRunWizard._run_checks_blocking(stub)
+
+    assert "sysmem" not in stub._check_results
+
+
+def test_run_checks_includes_nvidia_sysmem_for_nvidia(monkeypatch):
+    stub = _wizard_check_stub(include_sysmem=True)
+    monkeypatch.setattr(os_utils, "check_ascii_install_path", lambda: (True, "ok"))
+    monkeypatch.setattr(os_utils, "check_gpu_driver_version", lambda: (True, "ok"))
+    monkeypatch.setattr(
+        os_utils,
+        "check_windows_nvidia_sysmem_fallback_policy",
+        lambda: (False, "warning"),
+    )
+
+    FirstRunWizard._run_checks_blocking(stub)
+
+    assert stub._check_results["sysmem"] == (False, "warning")


### PR DESCRIPTION
## Summary
- show the CUDA sysmem fallback policy row only for Windows NVIDIA builds
- reuse one initialized applicability flag for both row creation and blocking checks
- cover Windows NVIDIA, Windows AMD, non-Windows short-circuiting, and check execution

## Windows AMD validation
- AMD Radeon RX 7900 XTX, ROCm 7.2.53211-158bd99533
- actual wizard keys: `ascii_path,ffprobe,gpu,cuda,driver`
- Computer Use visual check: System Check reported all checks passed and omitted `CUDA Sysmem Fallback Policy`

## Tests
- `python -m pytest -q tests/test_gui_wizard_sysmem.py tests/test_gui_startup_and_wizard.py -k "sysmem or evaluate"` — 8 passed, 3 deselected
- `python -m pytest -q tests/test_os_utils.py -k sysmem` — 6 passed (46 deselected on the integration branch)
- `python -m compileall -q jasna/gui/wizard.py tests/test_gui_wizard_sysmem.py`
- `git diff --check upstream/main...HEAD`
- integration collection comparison against its parent with the same command: 128 passed / 21 failed / 2 deselected before and after; the new feature file adds 5 passing tests. The unchanged failures are existing Windows/AMD fixture isolation issues.

## Integration
- merged into `integration/v0.10-full` as `432862c`
- pushed to `spicystrippresident/jasna:integration/v0.10-full`
