### PR TITLE
fix(stream): guard zero elapsed rate logging

### DIFF
--- a/jasna/streaming_pipeline.py
+++ b/jasna/streaming_pipeline.py
@@ -48,9 +48,10 @@ class _StreamingFrameWriter:
         if frames_written == 1:
             log.debug("[stream-blend-encode] first frame encoded: %.2fs", time.monotonic() - self._t0)
         elif frames_written % 100 == 0:
+            elapsed = max(1e-6, time.monotonic() - self._t0)
             log.debug(
                 "[stream-blend-encode] %d frames encoded (%.1f fps)",
-                frames_written, frames_written / (time.monotonic() - self._t0),
+                frames_written, frames_written / elapsed,
             )
 
         current_seg = self._start_segment + frames_written // self._frames_per_seg

--- a/tests/test_streaming_pipeline_writer.py
+++ b/tests/test_streaming_pipeline_writer.py
@@ -1,0 +1,17 @@
+from unittest.mock import MagicMock, patch
+
+from jasna.streaming_pipeline import _StreamingFrameWriter
+
+
+def test_streaming_writer_handles_zero_elapsed_time():
+    encoder = MagicMock()
+    hls_server = MagicMock()
+    hls_server.frames_per_segment.return_value = 120
+
+    with patch("jasna.streaming_pipeline.time.monotonic", return_value=42.0):
+        writer = _StreamingFrameWriter(encoder, hls_server, start_segment=0)
+        writer.after_write(100)
+
+    encoder.raise_if_failed.assert_called_once_with()
+    hls_server.update_production.assert_called_once_with(0)
+    hls_server.wait_for_demand.assert_called_once()


### PR DESCRIPTION
## Summary
- clamp streaming rate-log elapsed time to a positive minimum
- prevent the 100-frame debug checkpoint from raising `ZeroDivisionError` when two monotonic samples are equal
- keep encoder failure propagation, segment production updates, and demand waiting unchanged

## Regression test
- freezes `time.monotonic()` at one value across writer construction and the 100-frame callback
- baseline reproduces `ZeroDivisionError: float division by zero`
- modified integration result: 1 passed

## Aggregate validation
- `python -m pytest -q tests/test_streaming.py tests/test_streaming_pipeline_writer.py -k "not ffmpeg_cmd_contains_nvenc"`
- 98 passed, 1 deselected on Windows AMD
- the deselected test is the existing NVIDIA-only encoder expectation (`h264_nvenc`) under the real AMD runtime
- `python -m compileall -q jasna/streaming_pipeline.py tests/test_streaming_pipeline_writer.py`
- `git diff --check upstream/main...HEAD`

## Integration
- merged into `integration/v0.10-full` as `c82647a`
- pushed to `spicystrippresident/jasna:integration/v0.10-full`
