### PR TITLE
test(detection): isolate accelerator vendor assumptions

### DIFF
--- a/tests/test_detection_registry.py
+++ b/tests/test_detection_registry.py
@@ -22,13 +22,26 @@ from jasna.mosaic.detection_registry import (
 )
 
 
+@pytest.fixture
+def nvidia_vendor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make NVIDIA-specific expectations independent of the host GPU."""
+    import jasna.mosaic.detection_registry as registry
+
+    monkeypatch.setattr(
+        registry, "is_amd_device", lambda *_args, **_kwargs: False
+    )
+    monkeypatch.setattr(
+        registry, "is_nvidia_device", lambda *_args, **_kwargs: True
+    )
+
+
 def test_default_detection_model_is_rfdetr_v6() -> None:
     assert DEFAULT_DETECTION_MODEL_NAME == "rfdetr-v6"
     assert "rfdetr-v6" in RFDETR_MODEL_NAMES
     assert "rfdetr-v6-large" in RFDETR_MODEL_NAMES
 
 
-def test_rfdetr_v6_weights_path() -> None:
+def test_rfdetr_v6_weights_path(nvidia_vendor: None) -> None:
     assert detection_model_weights_path("rfdetr-v6") == Path("model_weights/rfdetr-v6.onnx")
     assert coerce_detection_model_name("rfdetr-v6") == "rfdetr-v6"
 
@@ -142,7 +155,7 @@ def test_coerce_yolo_typo_raises_lists_valid_names() -> None:
 
 # --- detection_model_weights_path for dynamic rfdetr ---
 
-def test_dynamic_rfdetr_weights_path() -> None:
+def test_dynamic_rfdetr_weights_path(nvidia_vendor: None) -> None:
     assert detection_model_weights_path("rfdetr-v99") == Path("model_weights/rfdetr-v99.onnx")
 
 
@@ -156,14 +169,16 @@ def test_discover_nonexistent_dir(tmp_path: Path) -> None:
     assert discover_available_detection_models(tmp_path / "nope") == []
 
 
-def test_discover_rfdetr_only(tmp_path: Path) -> None:
+def test_discover_rfdetr_only(tmp_path: Path, nvidia_vendor: None) -> None:
     (tmp_path / "rfdetr-v5.onnx").touch()
     (tmp_path / "rfdetr-v3.onnx").touch()
     result = discover_available_detection_models(tmp_path)
     assert result == ["rfdetr-v5", "rfdetr-v3"]
 
 
-def test_discover_unknown_rfdetr_version(tmp_path: Path) -> None:
+def test_discover_unknown_rfdetr_version(
+    tmp_path: Path, nvidia_vendor: None
+) -> None:
     (tmp_path / "rfdetr-v99.onnx").touch()
     (tmp_path / "rfdetr-v5.onnx").touch()
     result = discover_available_detection_models(tmp_path)
@@ -193,7 +208,7 @@ def test_discover_bundled_vr_model(tmp_path: Path) -> None:
     ]
 
 
-def test_discover_mixed(tmp_path: Path) -> None:
+def test_discover_mixed(tmp_path: Path, nvidia_vendor: None) -> None:
     (tmp_path / "rfdetr-v5.onnx").touch()
     (tmp_path / "rfdetr-v3.onnx").touch()
     (tmp_path / "lada_mosaic_detection_model_v2.pt").touch()
@@ -230,7 +245,9 @@ def test_require_detection_model_weights_rejects_missing_path(tmp_path: Path) ->
         require_detection_model_weights("zelefans-vr-yolo-v2")
 
 
-def test_discover_ignores_non_matching_files(tmp_path: Path) -> None:
+def test_discover_ignores_non_matching_files(
+    tmp_path: Path, nvidia_vendor: None
+) -> None:
     (tmp_path / "rfdetr-v5.onnx").touch()
     (tmp_path / "some_random_model.onnx").touch()
     (tmp_path / "random.pt").touch()
@@ -244,17 +261,19 @@ def test_precompile_noop_on_cpu() -> None:
     precompile_detection_engine("rfdetr-v5", Path("m.onnx"), 1, torch.device("cpu"), True)
 
 
-def test_precompile_rfdetr_on_cuda() -> None:
-    with patch("jasna.trt.compile_onnx_to_tensorrt_engine") as mock_compile:
+def test_precompile_rfdetr_on_cuda(nvidia_vendor: None) -> None:
+    with patch("jasna.mosaic.rfdetr.compile_rfdetr_engine") as mock_compile:
         precompile_detection_engine("rfdetr-v5", Path("m.onnx"), 2, torch.device("cuda:0"), True)
         mock_compile.assert_called_once_with(
             Path("m.onnx"), torch.device("cuda:0"),
-            batch_size=4, fp16=True, workspace_gb=20, dynamic_batch=False,
+            batch_size=4, resolution=768, dynamic_batch=False, fp16=True,
         )
 
 
-def test_precompile_rfdetr_v6_uses_requested_dynamic_batch() -> None:
-    with patch("jasna.trt.compile_onnx_to_tensorrt_engine") as mock_compile:
+def test_precompile_rfdetr_v6_uses_requested_dynamic_batch(
+    nvidia_vendor: None,
+) -> None:
+    with patch("jasna.mosaic.rfdetr.compile_rfdetr_engine") as mock_compile:
         precompile_detection_engine(
             "rfdetr-v6",
             Path("m.onnx"),
@@ -264,11 +283,11 @@ def test_precompile_rfdetr_v6_uses_requested_dynamic_batch() -> None:
         )
         mock_compile.assert_called_once_with(
             Path("m.onnx"), torch.device("cuda:0"),
-            batch_size=8, fp16=True, workspace_gb=20, dynamic_batch=True,
+            batch_size=8, resolution=576, dynamic_batch=True, fp16=True,
         )
 
 
-def test_precompile_yolo_on_cuda() -> None:
+def test_precompile_yolo_on_cuda(nvidia_vendor: None) -> None:
     with (
         patch("jasna.mosaic.yolo_tensorrt_compilation.compile_yolo_to_tensorrt_engine") as mock_compile,
     ):
@@ -276,7 +295,7 @@ def test_precompile_yolo_on_cuda() -> None:
         mock_compile.assert_called_once()
 
 
-def test_precompile_zelefans_yolo_on_cuda() -> None:
+def test_precompile_zelefans_yolo_on_cuda(nvidia_vendor: None) -> None:
     with patch(
         "jasna.mosaic.yolo_tensorrt_compilation.compile_yolo_to_tensorrt_engine"
     ) as mock_compile:

--- a/tests/test_engine_compiler.py
+++ b/tests/test_engine_compiler.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,6 +15,19 @@ from jasna.engine_compiler import (
     _unet4x_engine_exists,
     ensure_engines_compiled,
 )
+
+
+@pytest.fixture
+def nvidia_vendor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make TensorRT engine expectations independent of the host GPU."""
+    import jasna.accelerator as accelerator
+
+    monkeypatch.setattr(
+        accelerator, "is_amd_device", lambda *_args, **_kwargs: False
+    )
+    monkeypatch.setattr(
+        accelerator, "is_nvidia_device", lambda *_args, **_kwargs: True
+    )
 
 
 def _mock_proc(lines: list[str], returncode: int = 0) -> MagicMock:
@@ -41,7 +56,9 @@ def test_request_defaults() -> None:
     assert req.unet4x is False
 
 
-def test_ensure_no_subprocess_when_basicvsrpp_exists(monkeypatch) -> None:
+def test_ensure_no_subprocess_when_basicvsrpp_exists(
+    monkeypatch, nvidia_vendor: None
+) -> None:
     monkeypatch.setattr("jasna.engine_compiler._basicvsrpp_engines_exist", lambda *_a, **_kw: True)
     req = EngineCompilationRequest(device="cuda:0", fp16=True, basicvsrpp=True, basicvsrpp_model_path="x")
     assert ensure_engines_compiled(req).use_basicvsrpp_tensorrt is True
@@ -53,7 +70,7 @@ def test_ensure_no_subprocess_when_not_requested() -> None:
     assert result.use_basicvsrpp_tensorrt is False
 
 
-def test_ensure_all_exist_no_subprocess(monkeypatch) -> None:
+def test_ensure_all_exist_no_subprocess(monkeypatch, nvidia_vendor: None) -> None:
     monkeypatch.setattr("jasna.engine_compiler._basicvsrpp_engines_exist", lambda *_a, **_kw: True)
     monkeypatch.setattr("jasna.engine_compiler._detection_engine_exists", lambda *_a, **_kw: True)
     monkeypatch.setattr("jasna.engine_compiler._unet4x_engine_exists", lambda *_a, **_kw: True)
@@ -64,12 +81,14 @@ def test_ensure_all_exist_no_subprocess(monkeypatch) -> None:
     assert ensure_engines_compiled(req).use_basicvsrpp_tensorrt is True
 
 
-def test_ensure_basicvsrpp_fp32_no_tensorrt() -> None:
+def test_ensure_basicvsrpp_fp32_no_tensorrt(nvidia_vendor: None) -> None:
     req = EngineCompilationRequest(device="cuda:0", fp16=False, basicvsrpp=True, basicvsrpp_model_path="x")
     assert ensure_engines_compiled(req).use_basicvsrpp_tensorrt is False
 
 
-def test_ensure_spawns_subprocess_on_missing(monkeypatch) -> None:
+def test_ensure_spawns_subprocess_on_missing(
+    monkeypatch, nvidia_vendor: None
+) -> None:
     popen_calls = []
     proc = _mock_proc(["Compiling...\n", "Done.\n"])
     monkeypatch.setattr("jasna.engine_compiler.subprocess.Popen", lambda cmd, **kw: (popen_calls.append(cmd), proc)[1])
@@ -91,7 +110,9 @@ def test_ensure_spawns_subprocess_on_missing(monkeypatch) -> None:
     assert any("Compiling" in m for m in log_messages)
 
 
-def test_ensure_subprocess_failure_raises(monkeypatch) -> None:
+def test_ensure_subprocess_failure_raises(
+    monkeypatch, nvidia_vendor: None
+) -> None:
     monkeypatch.setattr("jasna.engine_compiler._basicvsrpp_engines_exist", lambda *_a, **_kw: False)
     monkeypatch.setattr("jasna.engine_compiler.subprocess.Popen", lambda *a, **kw: _mock_proc(["error\n"], returncode=1))
 
@@ -100,7 +121,9 @@ def test_ensure_subprocess_failure_raises(monkeypatch) -> None:
         ensure_engines_compiled(req)
 
 
-def test_ensure_frozen_exe_uses_compile_engines_flag(monkeypatch) -> None:
+def test_ensure_frozen_exe_uses_compile_engines_flag(
+    monkeypatch, nvidia_vendor: None
+) -> None:
     monkeypatch.setattr("jasna.engine_compiler._basicvsrpp_engines_exist", lambda *_a, **_kw: False)
     monkeypatch.setattr("jasna.engine_compiler.is_frozen", lambda: True)
     fake_sys = type("FakeSys", (), {"executable": "C:/app/jasna.exe"})()
@@ -119,7 +142,9 @@ def test_ensure_frozen_exe_uses_compile_engines_flag(monkeypatch) -> None:
     assert "-m" not in popen_calls[0]
 
 
-def test_ensure_create_no_window_on_windows(monkeypatch) -> None:
+def test_ensure_create_no_window_on_windows(
+    monkeypatch, nvidia_vendor: None
+) -> None:
     monkeypatch.setattr("jasna.engine_compiler._basicvsrpp_engines_exist", lambda *_a, **_kw: False)
     monkeypatch.setattr("jasna.engine_compiler.os.name", "nt")
     # CREATE_NO_WINDOW is a Windows-only subprocess attribute; inject it so the nt branch
@@ -137,7 +162,9 @@ def test_ensure_create_no_window_on_windows(monkeypatch) -> None:
     assert popen_kwargs.get("creationflags") == subprocess.CREATE_NO_WINDOW
 
 
-def test_ensure_does_not_print_when_log_callback_given(monkeypatch) -> None:
+def test_ensure_does_not_print_when_log_callback_given(
+    monkeypatch, nvidia_vendor: None
+) -> None:
     # The frozen GUI drops its console (FreeConsole), so stdout is invalid — an
     # unconditional print() would raise WinError 6. With a log_callback (GUI path), the
     # progress message must go to the callback and never to print().
@@ -154,7 +181,9 @@ def test_ensure_does_not_print_when_log_callback_given(monkeypatch) -> None:
     assert any("Compiling" in m for m in log_messages)
 
 
-def test_ensure_popen_stdin_is_devnull(monkeypatch) -> None:
+def test_ensure_popen_stdin_is_devnull(
+    monkeypatch, nvidia_vendor: None
+) -> None:
     # The detached GUI's stdin handle is invalid; the child must not inherit it.
     monkeypatch.setattr("jasna.engine_compiler._basicvsrpp_engines_exist", lambda *_a, **_kw: False)
     popen_kwargs: dict = {}
@@ -178,14 +207,16 @@ def test_subprocess_compile_patches_frozen_torch(monkeypatch) -> None:
     assert called, "patch_frozen_torch must run before any torch_tensorrt/_inductor import"
 
 
-def test_detection_engine_exists_rfdetr(tmp_path: Path) -> None:
+def test_detection_engine_exists_rfdetr(
+    tmp_path: Path, nvidia_vendor: None
+) -> None:
     onnx_path = tmp_path / "model.onnx"
     onnx_path.write_text("x")
     assert _detection_engine_exists(
         "rfdetr-v5", str(onnx_path), 4, True, "cuda:0"
     ) is False
 
-    from jasna.trt import get_onnx_tensorrt_engine_path
+    from jasna.engine_paths import get_onnx_tensorrt_engine_path
     engine = get_onnx_tensorrt_engine_path(
         onnx_path,
         batch_size=4,
@@ -200,12 +231,12 @@ def test_detection_engine_exists_rfdetr(tmp_path: Path) -> None:
 
 
 def test_detection_engine_exists_rfdetr_v6_uses_dynamic_path(
-    tmp_path: Path,
+    tmp_path: Path, nvidia_vendor: None
 ) -> None:
     onnx_path = tmp_path / "rfdetr-v6.onnx"
     onnx_path.write_text("x")
 
-    from jasna.trt import get_onnx_tensorrt_engine_path
+    from jasna.engine_paths import get_onnx_tensorrt_engine_path
 
     engine = get_onnx_tensorrt_engine_path(
         onnx_path,
@@ -252,9 +283,16 @@ def test_unet4x_engine_exists_encrypted(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("jasna.engine_paths.UNET4X_ONNX_PATH", onnx_path)
     enc_engine = tmp_path / "unet-4x.fp16.linux.engine.enc"
     monkeypatch.setattr("jasna.engine_paths.get_unet4x_encrypted_engine_path", lambda fp16=True: enc_engine)
-    monkeypatch.setattr(
-        "jasna.protection.protected_model.decrypt_engine_bytes",
-        lambda model_id, data: b"decrypted-engine",
+    protected_model = ModuleType("jasna.protection.protected_model")
+    protected_model.decrypt_engine_bytes = (
+        lambda model_id, data: b"decrypted-engine"
+    )
+    protection = ModuleType("jasna.protection")
+    protection.ProtectionError = type("ProtectionError", (Exception,), {})
+    protection.protected_model = protected_model
+    monkeypatch.setitem(sys.modules, "jasna.protection", protection)
+    monkeypatch.setitem(
+        sys.modules, "jasna.protection.protected_model", protected_model
     )
 
     assert _unet4x_engine_exists(fp16=True) is False

--- a/tests/test_gui_engine_preflight.py
+++ b/tests/test_gui_engine_preflight.py
@@ -13,8 +13,13 @@ from jasna.gui.models import AppSettings
 @pytest.fixture(autouse=True)
 def _use_nvidia_preflight_by_default(monkeypatch):
     import jasna.accelerator as accelerator
+    import jasna.mosaic.detection_registry as registry
 
-    monkeypatch.setattr(accelerator, "is_amd_device", lambda _device: False)
+    def fake_is_amd(_device=None):
+        return False
+
+    monkeypatch.setattr(accelerator, "is_amd_device", fake_is_amd)
+    monkeypatch.setattr(registry, "is_amd_device", fake_is_amd)
 
 
 def _touch(path: Path) -> None:
@@ -163,10 +168,17 @@ def test_amd_preflight_has_no_engine_requirements(
     (tmp_path / "model_weights").mkdir(parents=True, exist_ok=True)
 
     import jasna.accelerator as accelerator
+    import jasna.mosaic.detection_registry as registry
 
     # AMD runs RF-DETR (rfdetr torch model) and YOLO through PyTorch and skips
     # BasicVSR++ TensorRT, so nothing needs precompiling.
-    monkeypatch.setattr(accelerator, "is_amd_device", lambda _device: True)
+    def fake_is_amd(_device=None):
+        return True
+
+    monkeypatch.setattr(accelerator, "is_amd_device", fake_is_amd)
+    monkeypatch.setattr(registry, "is_amd_device", fake_is_amd)
+
+    assert registry.rfdetr_weights_suffix() == ".pt"
 
     result = run_engine_preflight(AppSettings(compile_basicvsrpp=True))
 

--- a/tests/test_model_weights_dir.py
+++ b/tests/test_model_weights_dir.py
@@ -3,9 +3,22 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 import jasna.engine_paths as engine_paths
 from jasna.engine_paths import model_weights_dir
 from jasna.mosaic import detection_registry
+
+
+@pytest.fixture
+def nvidia_vendor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ONNX weight expectations independent of the host GPU."""
+    monkeypatch.setattr(
+        detection_registry, "is_amd_device", lambda *_args, **_kwargs: False
+    )
+    monkeypatch.setattr(
+        detection_registry, "is_nvidia_device", lambda *_args, **_kwargs: True
+    )
 
 
 def test_model_weights_dir_in_dev_is_cwd_relative(monkeypatch) -> None:
@@ -22,7 +35,9 @@ def test_model_weights_dir_when_frozen_is_next_to_executable(monkeypatch, tmp_pa
     assert model_weights_dir() == tmp_path / "model_weights"
 
 
-def test_detection_model_weights_path_uses_helper(monkeypatch, tmp_path: Path) -> None:
+def test_detection_model_weights_path_uses_helper(
+    monkeypatch, tmp_path: Path, nvidia_vendor: None
+) -> None:
     fake_exe = tmp_path / "jasna-cli.exe"
     fake_exe.touch()
     monkeypatch.setattr(sys, "frozen", True, raising=False)
@@ -32,7 +47,9 @@ def test_detection_model_weights_path_uses_helper(monkeypatch, tmp_path: Path) -
     assert p == tmp_path / "model_weights" / "rfdetr-v5.onnx"
 
 
-def test_discover_available_detection_models_uses_helper(monkeypatch, tmp_path: Path) -> None:
+def test_discover_available_detection_models_uses_helper(
+    monkeypatch, tmp_path: Path, nvidia_vendor: None
+) -> None:
     weights_dir = tmp_path / "model_weights"
     weights_dir.mkdir()
     (weights_dir / "rfdetr-v5.onnx").touch()
@@ -48,7 +65,9 @@ def test_discover_available_detection_models_uses_helper(monkeypatch, tmp_path: 
     assert "lada-yolo-v4" in names
 
 
-def test_discover_available_detection_models_explicit_dir_overrides(tmp_path: Path) -> None:
+def test_discover_available_detection_models_explicit_dir_overrides(
+    tmp_path: Path, nvidia_vendor: None
+) -> None:
     weights_dir = tmp_path / "weights"
     weights_dir.mkdir()
     (weights_dir / "rfdetr-v3.onnx").touch()

--- a/tests/test_rfdetr_postprocess.py
+++ b/tests/test_rfdetr_postprocess.py
@@ -1,4 +1,6 @@
+import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -298,21 +300,29 @@ class TestRfDetrCall:
 
 
 class TestCompileRfdetrEngine:
-    def test_delegates_to_compile_onnx(self):
-        with patch("jasna.trt.compile_onnx_to_tensorrt_engine", return_value=Path("out.engine")) as mock_compile:
-            result = compile_rfdetr_engine(
-                Path("model.onnx"),
-                torch.device("cuda:0"),
-                batch_size=4,
-                resolution=576,
-                dynamic_batch=True,
-                fp16=True,
-            )
-            mock_compile.assert_called_once_with(
-                Path("model.onnx"), torch.device("cuda:0"),
-                batch_size=4, fp16=True, workspace_gb=20, dynamic_batch=True,
-            )
-            assert result == Path("out.engine")
+    def test_delegates_to_compile_onnx(self, monkeypatch):
+        import jasna.mosaic.rfdetr as module
+
+        mock_compile = MagicMock(return_value=Path("out.engine"))
+        trt_module = ModuleType("jasna.trt")
+        trt_module.compile_onnx_to_tensorrt_engine = mock_compile
+        monkeypatch.setitem(sys.modules, "jasna.trt", trt_module)
+        monkeypatch.setattr(module, "is_amd_device", lambda _device: False)
+        monkeypatch.setattr(module, "is_nvidia_device", lambda _device: True)
+
+        result = compile_rfdetr_engine(
+            Path("model.onnx"),
+            torch.device("cuda:0"),
+            batch_size=4,
+            resolution=576,
+            dynamic_batch=True,
+            fp16=True,
+        )
+        mock_compile.assert_called_once_with(
+            Path("model.onnx"), torch.device("cuda:0"),
+            batch_size=4, fp16=True, workspace_gb=20, dynamic_batch=True,
+        )
+        assert result == Path("out.engine")
 
     def test_amd_is_a_noop_returning_the_weights_path(self, monkeypatch, tmp_path):
         import jasna.mosaic.rfdetr as module


### PR DESCRIPTION
## Summary
- isolate NVIDIA-specific RF-DETR weight-path, discovery, and engine expectations from the physical host GPU
- force NVIDIA predicates only in tests that exercise ONNX/TensorRT routing while preserving explicit AMD `.pt` and no-op assertions
- mock `compile_rfdetr_engine` at the detection-registry boundary and inject lightweight optional backend modules for direct compiler tests
- use engine-path helpers without importing TensorRT and isolate encrypted-engine tests from release-only protection modules
- isolate GUI preflight's accelerator and detection-registry vendor bindings together; both fakes accept the production function's optional device argument

## GUI preflight fixture follow-up

`detection_registry` directly imports `is_amd_device` and calls it without an
argument, while `engine_preflight` imports the accelerator predicate lazily and
passes a device. The previous fixture patched only the latter module with a
one-argument lambda. A fresh full-module run therefore failed six cases with:

```text
TypeError: <lambda>() missing 1 required positional argument: '_device'
```

The fixture now patches both bindings with the same optional-argument fake. The
AMD case also asserts `.pt` routing before checking that no TensorRT engines are
required. No production file changes.

## Validation
- Original PR baseline on Windows AMD: `25 failed, 54 passed`
- Original modified focused suite: `79 passed in 2.76s`
- Related accelerator/detection/engine collection: `117 passed, 1 skipped in 3.78s`
- GUI preflight follow-up baseline: `6 failed, 2 passed, 1 skipped`
- GUI preflight follow-up modified: `8 passed, 1 skipped in 1.61s`
- Adjacent detection registry/compiler/model-weight/postprocess suite: `79 passed in 2.14s`
- `python -m pip check`: `No broken requirements found.`
- both rollback patches were tested on detached worktree copies; original hashes and baseline behavior were restored

Public branch head: `7b0daf9`; independent base: `upstream/main`. The same PR head
is collected on `integration/v0.10-full` for aggregate validation.