### PR TITLE
Fix Windows AMD HEVC Main10 and AV1 decoding

### DIFF
--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -27,7 +27,8 @@ _libcuda: ctypes.CDLL | None = None
 # Decode backend selection (`JASNA_DECODE_BACKEND` overrides the default):
 # - "auto":    NVIDIA tries VALI first and falls back to PyAV hwaccel, then PyAV
 #              software, when VALI cannot open or decode the first frame. AMD
-#              keeps its AMF -> software escalation.
+#              keeps its AMF -> software escalation except that Windows HEVC
+#              Main10/P010 uses software decode plus ROCm upload directly.
 # - "vali":    VALI only; any failure raises (NVIDIA only).
 # - "pyav-hw": skip VALI, use the PyAV hwaccel path with its software fallback.
 # - "pyav-sw": force FFmpeg software decoding with GPU upload on every vendor.
@@ -55,6 +56,26 @@ def _decode_backend() -> str:
             f"expected {_DECODE_BACKENDS}"
         )
     return backend
+
+
+def _requires_windows_amd_software_decode(
+    metadata: VideoMetadata,
+    vendor: AcceleratorVendor,
+) -> bool:
+    """Return whether auto mode must avoid PyAV's AMF decoder.
+
+    PyAV can open AMF for HEVC Main10 on Windows, but cannot transfer the
+    resulting P010 hardware frame into a usable ``VideoFrame``.  Decode those
+    inputs with FFmpeg on the CPU and keep the existing ROCm upload path.  An
+    explicit ``pyav-hw`` selection still bypasses this automatic workaround so
+    AMF remains available for diagnostics.
+    """
+    return (
+        sys.platform == "win32"
+        and vendor is AcceleratorVendor.AMD
+        and str(metadata.codec_name).lower() == "hevc"
+        and bool(metadata.is_10bit)
+    )
 
 
 def _cuda_driver() -> ctypes.CDLL:
@@ -286,8 +307,19 @@ class NvidiaVideoReader:
                     return self
             elif backend == "vali":
                 raise VideoDecodeError("The VALI decode backend requires an NVIDIA device")
-        software_only = backend == "pyav-sw"
+        windows_amd_main10 = backend == "auto" and _requires_windows_amd_software_decode(
+            self.metadata,
+            self.vendor,
+        )
+        software_only = backend == "pyav-sw" or windows_amd_main10
         self._software_only = software_only
+        if windows_amd_main10:
+            log.warning(
+                "Windows AMD HEVC Main10/P010 cannot transfer PyAV AMF hardware "
+                "frames; using FFmpeg software decoding and uploading frames to ROCm "
+                "for %s",
+                self.file,
+            )
         try:
             if not software_only and self.vendor is AcceleratorVendor.NVIDIA:
                 hwaccel = HWAccel(

--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -28,7 +28,8 @@ _libcuda: ctypes.CDLL | None = None
 # - "auto":    NVIDIA tries VALI first and falls back to PyAV hwaccel, then PyAV
 #              software, when VALI cannot open or decode the first frame. AMD
 #              keeps its AMF -> software escalation except that Windows HEVC
-#              Main10/P010 uses software decode plus ROCm upload directly.
+#              HEVC Main10/P010 and AV1 use software decode plus ROCm upload
+#              directly on Windows.
 # - "vali":    VALI only; any failure raises (NVIDIA only).
 # - "pyav-hw": skip VALI, use the PyAV hwaccel path with its software fallback.
 # - "pyav-sw": force FFmpeg software decoding with GPU upload on every vendor.
@@ -64,17 +65,23 @@ def _requires_windows_amd_software_decode(
 ) -> bool:
     """Return whether auto mode must avoid PyAV's AMF decoder.
 
-    PyAV can open AMF for HEVC Main10 on Windows, but cannot transfer the
-    resulting P010 hardware frame into a usable ``VideoFrame``.  Decode those
-    inputs with FFmpeg on the CPU and keep the existing ROCm upload path.  An
-    explicit ``pyav-hw`` selection still bypasses this automatic workaround so
-    AMF remains available for diagnostics.
+    PyAV cannot transfer Windows AMF HEVC Main10/P010 frames into usable
+    ``VideoFrame`` objects.  PyAV defaults AV1 to libdav1d, while forcing its
+    AMF AV1 decoder is unreliable across frame transfer and shutdown.  Decode
+    those inputs with FFmpeg on the CPU and keep the existing ROCm upload path.
+    An explicit ``pyav-hw`` selection still bypasses this automatic workaround
+    so AMF remains available for diagnostics.
     """
     return (
         sys.platform == "win32"
         and vendor is AcceleratorVendor.AMD
-        and str(metadata.codec_name).lower() == "hevc"
-        and bool(metadata.is_10bit)
+        and (
+            str(metadata.codec_name).lower() == "av1"
+            or (
+                str(metadata.codec_name).lower() == "hevc"
+                and bool(metadata.is_10bit)
+            )
+        )
     )
 
 
@@ -307,19 +314,31 @@ class NvidiaVideoReader:
                     return self
             elif backend == "vali":
                 raise VideoDecodeError("The VALI decode backend requires an NVIDIA device")
-        windows_amd_main10 = backend == "auto" and _requires_windows_amd_software_decode(
-            self.metadata,
-            self.vendor,
-        )
-        software_only = backend == "pyav-sw" or windows_amd_main10
-        self._software_only = software_only
-        if windows_amd_main10:
-            log.warning(
-                "Windows AMD HEVC Main10/P010 cannot transfer PyAV AMF hardware "
-                "frames; using FFmpeg software decoding and uploading frames to ROCm "
-                "for %s",
-                self.file,
+        windows_amd_software_decode = (
+            backend == "auto"
+            and _requires_windows_amd_software_decode(
+                self.metadata,
+                self.vendor,
             )
+        )
+        software_only = backend == "pyav-sw" or windows_amd_software_decode
+        self._software_only = software_only
+        if windows_amd_software_decode:
+            codec_name = str(self.metadata.codec_name).lower()
+            if codec_name == "av1":
+                log.warning(
+                    "Windows AMD AV1 PyAV AMF decoding is unreliable across frame "
+                    "transfer and shutdown; using FFmpeg software decoding and "
+                    "uploading frames to ROCm for %s",
+                    self.file,
+                )
+            else:
+                log.warning(
+                    "Windows AMD HEVC Main10/P010 cannot transfer PyAV AMF hardware "
+                    "frames; using FFmpeg software decoding and uploading frames to "
+                    "ROCm for %s",
+                    self.file,
+                )
         try:
             if not software_only and self.vendor is AcceleratorVendor.NVIDIA:
                 hwaccel = HWAccel(

--- a/tests/test_video_decoder_backends.py
+++ b/tests/test_video_decoder_backends.py
@@ -22,7 +22,7 @@ def _clear_decode_backend_env(monkeypatch) -> None:
     monkeypatch.delenv(module.DECODE_BACKEND_ENV, raising=False)
 
 
-def _metadata() -> VideoMetadata:
+def _metadata(codec_name: str = "h264", is_10bit: bool = False) -> VideoMetadata:
     return VideoMetadata(
         video_file="input.mp4",
         video_height=16,
@@ -30,31 +30,40 @@ def _metadata() -> VideoMetadata:
         video_fps=30.0,
         average_fps=30.0,
         video_fps_exact=Fraction(30, 1),
-        codec_name="h264",
+        codec_name=codec_name,
         duration=1.0,
         time_base=Fraction(1, 30),
         start_pts=0,
         color_range=AvColorRange.MPEG,
         color_space=AvColorspace.ITU709,
         num_frames=30,
-        is_10bit=False,
+        is_10bit=is_10bit,
     )
 
 
-def _reader(monkeypatch, vendor: AcceleratorVendor) -> module.NvidiaVideoReader:
+def _reader(
+    monkeypatch,
+    vendor: AcceleratorVendor,
+    metadata: VideoMetadata | None = None,
+) -> module.NvidiaVideoReader:
     monkeypatch.setattr(module, "vendor_for_device", lambda _device: vendor)
     monkeypatch.setattr(module, "current_stream", lambda _device: None)
-    return module.NvidiaVideoReader("input.mp4", 4, torch.device("cuda:0"), _metadata())
+    return module.NvidiaVideoReader(
+        "input.mp4",
+        4,
+        torch.device("cuda:0"),
+        metadata or _metadata(),
+    )
 
 
-def _fake_container(is_hwaccel: bool) -> MagicMock:
+def _fake_container(is_hwaccel: bool, codec_name: str = "h264") -> MagicMock:
     ctx = SimpleNamespace(
         is_hwaccel=is_hwaccel,
         width=16,
         height=16,
         color_range=0,
         thread_type=None,
-        name="h264",
+        name=codec_name,
     )
     container = MagicMock()
     container.streams.video = [SimpleNamespace(codec_context=ctx)]
@@ -119,6 +128,90 @@ def test_auto_backend_skips_vali_on_amd(monkeypatch) -> None:
     reader.__enter__()
     vali_factory.assert_not_called()
     amf_setup.assert_called_once()
+
+
+def test_auto_windows_amd_hevc_main10_uses_software_decode(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(module, "DECODE_BACKEND", "auto")
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    container = _fake_container(False, "hevc")
+    monkeypatch.setattr(module.av, "open", MagicMock(return_value=container))
+    reader = _reader(
+        monkeypatch,
+        AcceleratorVendor.AMD,
+        _metadata(codec_name="hevc", is_10bit=True),
+    )
+    amf_setup = MagicMock()
+    monkeypatch.setattr(reader, "_setup_amf_decoder", amf_setup)
+
+    with caplog.at_level("WARNING"):
+        reader.__enter__()
+
+    amf_setup.assert_not_called()
+    assert reader._software_only is True
+    assert module.av.open.call_args.kwargs == {}
+    assert container.streams.video[0].codec_context.thread_type == "AUTO"
+    assert "Windows AMD HEVC Main10/P010" in caplog.text
+    assert "ROCm" in caplog.text
+
+
+def test_explicit_pyav_hw_keeps_windows_amd_hevc_main10_amf(monkeypatch) -> None:
+    monkeypatch.setattr(module, "DECODE_BACKEND", "pyav-hw")
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        module.av,
+        "open",
+        MagicMock(return_value=_fake_container(False, "hevc")),
+    )
+    reader = _reader(
+        monkeypatch,
+        AcceleratorVendor.AMD,
+        _metadata(codec_name="hevc", is_10bit=True),
+    )
+    amf_setup = MagicMock()
+    monkeypatch.setattr(reader, "_setup_amf_decoder", amf_setup)
+
+    reader.__enter__()
+
+    amf_setup.assert_called_once()
+    assert reader._software_only is False
+
+
+@pytest.mark.parametrize(
+    ("codec_name", "is_10bit"),
+    [("h264", False), ("h264", True), ("hevc", False)],
+)
+def test_auto_windows_amd_other_formats_keep_amf(
+    monkeypatch,
+    codec_name: str,
+    is_10bit: bool,
+) -> None:
+    monkeypatch.setattr(module, "DECODE_BACKEND", "auto")
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        module.av,
+        "open",
+        MagicMock(return_value=_fake_container(False, codec_name)),
+    )
+    reader = _reader(
+        monkeypatch,
+        AcceleratorVendor.AMD,
+        _metadata(codec_name=codec_name, is_10bit=is_10bit),
+    )
+    amf_setup = MagicMock()
+    monkeypatch.setattr(reader, "_setup_amf_decoder", amf_setup)
+
+    reader.__enter__()
+
+    amf_setup.assert_called_once()
+    assert reader._software_only is False
+
+
+def test_windows_hevc_main10_policy_does_not_change_nvidia(monkeypatch) -> None:
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    assert not module._requires_windows_amd_software_decode(
+        _metadata(codec_name="hevc", is_10bit=True),
+        AcceleratorVendor.NVIDIA,
+    )
 
 
 def test_pyav_sw_backend_skips_hwaccel_and_amf(monkeypatch) -> None:

--- a/tests/test_video_decoder_backends.py
+++ b/tests/test_video_decoder_backends.py
@@ -130,15 +130,29 @@ def test_auto_backend_skips_vali_on_amd(monkeypatch) -> None:
     amf_setup.assert_called_once()
 
 
-def test_auto_windows_amd_hevc_main10_uses_software_decode(monkeypatch, caplog) -> None:
+@pytest.mark.parametrize(
+    ("codec_name", "is_10bit", "log_marker"),
+    [
+        ("hevc", True, "HEVC Main10/P010"),
+        ("av1", False, "AV1 PyAV AMF"),
+        ("av1", True, "AV1 PyAV AMF"),
+    ],
+)
+def test_auto_windows_amd_problem_formats_use_software_decode(
+    monkeypatch,
+    caplog,
+    codec_name: str,
+    is_10bit: bool,
+    log_marker: str,
+) -> None:
     monkeypatch.setattr(module, "DECODE_BACKEND", "auto")
     monkeypatch.setattr(module.sys, "platform", "win32")
-    container = _fake_container(False, "hevc")
+    container = _fake_container(False, codec_name)
     monkeypatch.setattr(module.av, "open", MagicMock(return_value=container))
     reader = _reader(
         monkeypatch,
         AcceleratorVendor.AMD,
-        _metadata(codec_name="hevc", is_10bit=True),
+        _metadata(codec_name=codec_name, is_10bit=is_10bit),
     )
     amf_setup = MagicMock()
     monkeypatch.setattr(reader, "_setup_amf_decoder", amf_setup)
@@ -150,22 +164,30 @@ def test_auto_windows_amd_hevc_main10_uses_software_decode(monkeypatch, caplog) 
     assert reader._software_only is True
     assert module.av.open.call_args.kwargs == {}
     assert container.streams.video[0].codec_context.thread_type == "AUTO"
-    assert "Windows AMD HEVC Main10/P010" in caplog.text
+    assert log_marker in caplog.text
     assert "ROCm" in caplog.text
 
 
-def test_explicit_pyav_hw_keeps_windows_amd_hevc_main10_amf(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("codec_name", "is_10bit"),
+    [("hevc", True), ("av1", False), ("av1", True)],
+)
+def test_explicit_pyav_hw_bypasses_windows_amd_software_policy(
+    monkeypatch,
+    codec_name: str,
+    is_10bit: bool,
+) -> None:
     monkeypatch.setattr(module, "DECODE_BACKEND", "pyav-hw")
     monkeypatch.setattr(module.sys, "platform", "win32")
     monkeypatch.setattr(
         module.av,
         "open",
-        MagicMock(return_value=_fake_container(False, "hevc")),
+        MagicMock(return_value=_fake_container(False, codec_name)),
     )
     reader = _reader(
         monkeypatch,
         AcceleratorVendor.AMD,
-        _metadata(codec_name="hevc", is_10bit=True),
+        _metadata(codec_name=codec_name, is_10bit=is_10bit),
     )
     amf_setup = MagicMock()
     monkeypatch.setattr(reader, "_setup_amf_decoder", amf_setup)
@@ -206,10 +228,18 @@ def test_auto_windows_amd_other_formats_keep_amf(
     assert reader._software_only is False
 
 
-def test_windows_hevc_main10_policy_does_not_change_nvidia(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("codec_name", "is_10bit"),
+    [("hevc", True), ("av1", False), ("av1", True)],
+)
+def test_windows_software_decode_policy_does_not_change_nvidia(
+    monkeypatch,
+    codec_name: str,
+    is_10bit: bool,
+) -> None:
     monkeypatch.setattr(module.sys, "platform", "win32")
     assert not module._requires_windows_amd_software_decode(
-        _metadata(codec_name="hevc", is_10bit=True),
+        _metadata(codec_name=codec_name, is_10bit=is_10bit),
         AcceleratorVendor.NVIDIA,
     )
 


### PR DESCRIPTION
## Summary
- detect Windows AMD HEVC Main10/P010 inputs in the automatic decoder selection
- bypass PyAV AMF for that exact HEVC combination because AMF opens but P010 hardware-frame transfer fails with `EINVAL`
- make Windows AMD AV1 auto selection explicit: PyAV otherwise silently selects libdav1d, while forced AMF P010 download fails with `EINVAL` and AMF AV1 teardown proved unreliable in a bounded generated-codec probe
- decode those inputs with FFmpeg software threading and keep the existing ROCm batch upload path
- preserve explicit `JASNA_DECODE_BACKEND=pyav-hw` as a diagnostic bypass and leave H.264, HEVC 8-bit, and NVIDIA selection unchanged

## Validation
- `python -m pytest -q tests/test_video_decoder_backends.py tests/test_amd_support.py -ra` — 56 passed, 1 skipped
- three real HEVC Main10 inputs — baseline `RESULT ok=0 failed=3`; modified `RESULT ok=3 failed=0`
- real AV1 8-bit full decode — 150/150 frames, ordered PTS, exit 0
- real AV1 Main10 full decode — 417/417 frames, ordered PTS, exit 0
- forced FFmpeg AMF AV1 Main10 P010 download — baseline exit `-22`, confirming the hardware-transfer failure
- full 8192x4096 VR/SBS HEVC Main10 pipeline on the aggregate branch — 634/634 video frames, 497/497 AAC frames, Main10 preserved, strict FFmpeg decode exit 0
- `python -m compileall -q jasna tests`
- `python -m pip check`
- `git diff --check`

The automatic workarounds emit explicit Windows AMD warnings that software decoding and ROCm upload are being used; neither route is a silent fallback.