### PR TITLE
fix(gui): dispatch worker callbacks on Tk thread

### DIFF
--- a/jasna/gui/app.py
+++ b/jasna/gui/app.py
@@ -29,6 +29,7 @@ from jasna.gui.control_bar import ControlBar
 from jasna.gui.log_panel import LogPanel
 from jasna.gui.log_filter import runtime_log_level_for_filter
 from jasna.gui.processor import Processor, ProgressUpdate
+from jasna.gui.thread_dispatch import GuiThreadDispatcher
 from jasna.gui.models import JobStatus, PresetManager
 from jasna.gui.locales import get_locale, t, LANGUAGE_NAMES
 from jasna.gui.font_backend import (
@@ -97,12 +98,16 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
         self._closing_after_player = False
         self._preset_manager = PresetManager()
 
+        self._gui_dispatcher = GuiThreadDispatcher()
+        self._gui_dispatch_after_id: str | None = None
+
         self._system_stats_stop = threading.Event()
         self._system_stats_thread: threading.Thread | None = None
         
         self._build_ui()
         self._t_ui_built = startup_timing.elapsed_ms()
         self._setup_processor()
+        self._start_gui_dispatcher()
         self._start_system_stats_poller()
 
         self.protocol("WM_DELETE_WINDOW", self._on_close)
@@ -392,6 +397,41 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
 
         threading.Thread(target=_run, daemon=True, name="cuda-warmup").start()
 
+    def _start_gui_dispatcher(self) -> None:
+        if self._gui_dispatch_after_id is None and not self._gui_dispatcher.closed:
+            self._gui_dispatch_after_id = self.after(0, self._drain_gui_dispatcher)
+
+    def _post_to_gui(self, callback, *args, **kwargs) -> bool:
+        """Queue a GUI callback without entering Tcl from the producer thread."""
+
+        return self._gui_dispatcher.post(callback, *args, **kwargs)
+
+    def _drain_gui_dispatcher(self) -> None:
+        self._gui_dispatch_after_id = None
+        if self._gui_dispatcher.closed:
+            return
+        for call in self._gui_dispatcher.take():
+            try:
+                call.callback(*call.args, **call.kwargs)
+            except Exception:
+                logger.warning("GUI callback failed", exc_info=True)
+        delay_ms = 0 if self._gui_dispatcher.has_pending() else 20
+        if not self._gui_dispatcher.closed:
+            self._gui_dispatch_after_id = self.after(
+                delay_ms,
+                self._drain_gui_dispatcher,
+            )
+
+    def _stop_gui_dispatcher(self) -> None:
+        self._gui_dispatcher.close()
+        after_id = self._gui_dispatch_after_id
+        self._gui_dispatch_after_id = None
+        if after_id is not None:
+            try:
+                self.after_cancel(after_id)
+            except (tk.TclError, RuntimeError):
+                pass
+
     def _start_system_stats_poller(self):
         if self._system_stats_thread and self._system_stats_thread.is_alive():
             return
@@ -402,10 +442,7 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
             from jasna.gui.system_stats import read_system_stats
             while not self._system_stats_stop.is_set():
                 stats = read_system_stats()
-                try:
-                    self.after(0, lambda s=stats: self._control_bar.set_system_stats(s))
-                except Exception:
-                    logger.debug("System stats poller stopping (widget gone)", exc_info=True)
+                if not self._post_to_gui(self._control_bar.set_system_stats, stats):
                     return
                 self._system_stats_stop.wait(1.5)
 
@@ -424,6 +461,7 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
             self._video_player_dialog.request_close()
             return
         try:
+            self._stop_gui_dispatcher()
             if self._processor:
                 self._processor.stop()
                 self._processor.join(timeout=5.0)
@@ -525,7 +563,7 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
         self._set_preview_gpu_busy(False)
         if self._closing_after_player:
             self._closing_after_player = False
-            self.after(0, self._on_close)
+            self._post_to_gui(self._on_close)
         
     def _update_start_button_state(self):
         jobs = self._queue_panel.get_jobs()
@@ -551,11 +589,11 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
         )
 
     def _set_preview_gpu_busy(self, busy: bool) -> None:
-        self._preview_gpu_busy = bool(busy)
-        try:
-            self.after(0, self._update_start_button_state)
-        except (tk.TclError, RuntimeError):
-            pass
+        self._post_to_gui(self._apply_preview_gpu_busy, bool(busy))
+
+    def _apply_preview_gpu_busy(self, busy: bool) -> None:
+        self._preview_gpu_busy = busy
+        self._update_start_button_state()
         
     def _show_toast(self, message: str, type_: str = "info"):
         """Show a toast notification."""
@@ -665,8 +703,7 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
             self._log_panel.pack_forget()
             
     def _on_processor_progress(self, update: ProgressUpdate):
-        # Schedule UI update on main thread
-        self.after(0, lambda: self._handle_progress(update))
+        self._post_to_gui(self._handle_progress, update)
         
     def _handle_progress(self, update: ProgressUpdate):
         jobs = self._queue_panel.get_jobs()
@@ -713,10 +750,10 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
             logger.warning("Failed to update job status in queue panel", exc_info=True)
             
     def _on_processor_log(self, level: str, message: str):
-        self.after(0, lambda: self._log_panel.add_log(level, message))
+        self._post_to_gui(self._log_panel.add_log, level, message)
         
     def _on_processor_complete(self):
-        self.after(0, self._handle_complete)
+        self._post_to_gui(self._handle_complete)
         
     def _handle_complete(self):
         self._status_pill.set_status("IDLE", Colors.STATUS_PENDING)
@@ -825,15 +862,15 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
 class GUILogHandler(logging.Handler):
     """Custom logging handler that forwards logs to the GUI log panel."""
     
-    def __init__(self, log_panel: LogPanel):
+    def __init__(self, log_panel: LogPanel, post_to_gui):
         super().__init__()
         self._log_panel = log_panel
+        self._post_to_gui = post_to_gui
         
     def emit(self, record):
         try:
             msg = self.format(record)
-            # Use after_idle to thread-safely update GUI
-            self._log_panel.after_idle(self._log_panel.add_log, record.levelname, msg)
+            self._post_to_gui(self._log_panel.add_log, record.levelname, msg)
         except Exception:
             pass  # Ignore errors in log handler
 
@@ -869,7 +906,7 @@ def run_gui():
         return
     
     # Replace console handler with GUI handler for all jasna loggers
-    gui_handler = GUILogHandler(app._log_panel)
+    gui_handler = GUILogHandler(app._log_panel, app._post_to_gui)
     gui_handler.setFormatter(logging.Formatter('%(message)s'))
     
     # Set up root logger to capture all logs

--- a/jasna/gui/app.py
+++ b/jasna/gui/app.py
@@ -8,6 +8,7 @@ import sys
 import threading
 import time
 import tkinter as tk
+import traceback
 
 from tkinterdnd2 import TkinterDnD, DND_FILES
 
@@ -414,7 +415,8 @@ class JasnaApp(ctk.CTk, TkinterDnD.DnDWrapper):
             try:
                 call.callback(*call.args, **call.kwargs)
             except Exception:
-                logger.warning("GUI callback failed", exc_info=True)
+                print("GUI callback failed", file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
         delay_ms = 0 if self._gui_dispatcher.has_pending() else 20
         if not self._gui_dispatcher.closed:
             self._gui_dispatch_after_id = self.after(

--- a/jasna/gui/thread_dispatch.py
+++ b/jasna/gui/thread_dispatch.py
@@ -1,0 +1,64 @@
+"""Thread-safe delivery of background work to the Tk main thread."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+import threading
+from typing import Any
+
+
+@dataclass(frozen=True)
+class GuiCall:
+    """A callback that must be invoked by the GUI thread."""
+
+    callback: Callable[..., Any]
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+
+
+class GuiThreadDispatcher:
+    """Queue callbacks without making any Tk calls from producer threads."""
+
+    def __init__(self) -> None:
+        self._owner_thread_id = threading.get_ident()
+        self._lock = threading.Lock()
+        self._calls: deque[GuiCall] = deque()
+        self._closed = False
+
+    def post(self, callback: Callable[..., Any], *args: Any, **kwargs: Any) -> bool:
+        """Queue one callback, returning ``False`` after shutdown starts."""
+
+        with self._lock:
+            if self._closed:
+                return False
+            self._calls.append(GuiCall(callback, args, kwargs))
+            return True
+
+    def take(self, limit: int = 128) -> tuple[GuiCall, ...]:
+        """Take up to ``limit`` callbacks on the thread that created the queue."""
+
+        if threading.get_ident() != self._owner_thread_id:
+            raise RuntimeError("GUI callbacks may only be drained by the GUI thread")
+        if limit <= 0:
+            return ()
+        with self._lock:
+            count = min(limit, len(self._calls))
+            return tuple(self._calls.popleft() for _ in range(count))
+
+    def has_pending(self) -> bool:
+        with self._lock:
+            return bool(self._calls)
+
+    def close(self) -> None:
+        """Reject future callbacks and discard callbacks queued during shutdown."""
+
+        with self._lock:
+            self._closed = True
+            self._calls.clear()
+
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._closed

--- a/tests/test_gui_thread_dispatch.py
+++ b/tests/test_gui_thread_dispatch.py
@@ -1,0 +1,125 @@
+import logging
+import threading
+
+import pytest
+
+from jasna.gui.app import GUILogHandler, JasnaApp
+from jasna.gui.models import JobStatus
+from jasna.gui.processor import ProgressUpdate
+from jasna.gui.thread_dispatch import GuiThreadDispatcher
+
+
+def test_background_post_does_not_execute_until_gui_thread_drains():
+    dispatcher = GuiThreadDispatcher()
+    calls = []
+
+    worker = threading.Thread(
+        target=lambda: dispatcher.post(calls.append, (threading.get_ident(), "worker"))
+    )
+    worker.start()
+    worker.join()
+
+    assert calls == []
+    queued = dispatcher.take()
+    assert len(queued) == 1
+    queued[0].callback(*queued[0].args, **queued[0].kwargs)
+    assert calls[0][1] == "worker"
+
+
+def test_dispatcher_rejects_callbacks_and_discards_pending_work_after_close():
+    dispatcher = GuiThreadDispatcher()
+    dispatcher.post(lambda: None)
+
+    dispatcher.close()
+
+    assert dispatcher.take() == ()
+    assert dispatcher.post(lambda: None) is False
+
+
+def test_dispatcher_can_only_be_drained_by_its_owner_thread():
+    dispatcher = GuiThreadDispatcher()
+    errors = []
+
+    def drain_from_worker():
+        try:
+            dispatcher.take()
+        except Exception as error:
+            errors.append(error)
+
+    worker = threading.Thread(target=drain_from_worker)
+    worker.start()
+    worker.join()
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], RuntimeError)
+
+
+def test_gui_log_handler_posts_without_calling_tk_from_worker():
+    posted = []
+
+    class LogPanel:
+        def add_log(self, level, message):
+            raise AssertionError("callback must stay queued in this test")
+
+        def after_idle(self, *_args, **_kwargs):
+            raise AssertionError("worker thread entered Tk")
+
+    panel = LogPanel()
+    handler = GUILogHandler(
+        panel,
+        lambda callback, *args: posted.append((callback, args)),
+    )
+    record = logging.LogRecord(
+        "jasna.test",
+        logging.INFO,
+        __file__,
+        1,
+        "worker log",
+        (),
+        None,
+    )
+
+    worker = threading.Thread(target=handler.emit, args=(record,))
+    worker.start()
+    worker.join()
+
+    assert posted == [(panel.add_log, ("INFO", "worker log"))]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "target_name", "args"),
+    [
+        (
+            "_on_processor_progress",
+            "_handle_progress",
+            (ProgressUpdate(job_id=7, status=JobStatus.PROCESSING),),
+        ),
+        ("_on_processor_log", "_add_log", ("INFO", "message")),
+        ("_on_processor_complete", "_handle_complete", ()),
+    ],
+)
+def test_processor_callbacks_only_post_to_gui(method_name, target_name, args):
+    posted = []
+
+    class App:
+        def _post_to_gui(self, callback, *callback_args):
+            posted.append((callback, callback_args))
+
+        def _handle_progress(self, update):
+            raise AssertionError("callback must stay queued in this test")
+
+        def _add_log(self, level, message):
+            raise AssertionError("callback must stay queued in this test")
+
+        def _handle_complete(self):
+            raise AssertionError("callback must stay queued in this test")
+
+    app = App()
+    app._log_panel = type("Panel", (), {"add_log": app._add_log})()
+
+    getattr(JasnaApp, method_name)(app, *args)
+
+    target = getattr(app, target_name)
+    if method_name == "_on_processor_log":
+        target = app._log_panel.add_log
+    assert posted == [(target, args)]


### PR DESCRIPTION
## Summary
- route processor progress/log/completion and system-stat updates through a thread-safe callback queue
- drain that queue only from Tk's main-thread timer instead of calling `after`/`after_idle` from worker threads
- stop and discard queued callbacks before GUI destruction
- route the GUI logging handler and preview-worker completion through the same dispatcher

## Root cause
A Windows `py-spy dump --native` captured a live Stop hang with the Tk main thread inside `SettingsPanel.set_enabled()` while a `SecondaryRestore` worker was blocked in `GUILogHandler.emit()` -> `tkinter.after_idle()` -> `Tcl_ConditionWait`. Processor progress/log/completion and the system-stats poller had the same cross-thread Tk pattern.

## Validation
```text
python -m pytest -q -p no:cacheprovider tests/test_gui_thread_dispatch.py tests/test_gui_processor_stop.py tests/test_gui_close_shutdown.py
19 passed in 2.87s
```

The new tests verify that worker callbacks remain queued until the owner GUI thread drains them, shutdown rejects/discards callbacks, non-owner draining is rejected, and the logging/processor callback paths never enter Tk from producer threads.
