### PR TITLE
fix(pipeline): avoid false encode-stall diagnostics

### DIFF
--- a/jasna/pipeline.py
+++ b/jasna/pipeline.py
@@ -60,14 +60,17 @@ class _OfflineFrameWriter:
         self._entered = False
 
     def write(self, frame: torch.Tensor, pts: int, *, apply_lut: bool = True) -> None:
-        if not self._entered:
-            # Slow detection/restoration before the first output frame is not an
-            # encoder stall. Arm the watchdog only when encoding is attempted.
-            self._encode_heartbeat[0] = time.monotonic()
-            self._encoder_ctx.__enter__()
-            self._entered = True
-        self._encoder_ctx.encode(frame, pts, apply_lut=apply_lut)
+        # The watchdog tracks an active encoder attempt, not time since the last
+        # completed write. Upstream restoration may legitimately produce no
+        # encodable frame for longer than the stall threshold.
         self._encode_heartbeat[0] = time.monotonic()
+        try:
+            if not self._entered:
+                self._encoder_ctx.__enter__()
+                self._entered = True
+            self._encoder_ctx.encode(frame, pts, apply_lut=apply_lut)
+        finally:
+            self._encode_heartbeat[0] = None
 
     def after_write(self, frames_written: int) -> None:
         pass

--- a/jasna/pipeline.py
+++ b/jasna/pipeline.py
@@ -50,13 +50,20 @@ log = logging.getLogger(__name__)
 
 
 class _OfflineFrameWriter:
-    def __init__(self, encoder_ctx: NvidiaVideoEncoder, encode_heartbeat: list[float]):
+    def __init__(
+        self,
+        encoder_ctx: NvidiaVideoEncoder,
+        encode_heartbeat: list[float | None],
+    ):
         self._encoder_ctx = encoder_ctx
         self._encode_heartbeat = encode_heartbeat
         self._entered = False
 
     def write(self, frame: torch.Tensor, pts: int, *, apply_lut: bool = True) -> None:
         if not self._entered:
+            # Slow detection/restoration before the first output frame is not an
+            # encoder stall. Arm the watchdog only when encoding is attempted.
+            self._encode_heartbeat[0] = time.monotonic()
             self._encoder_ctx.__enter__()
             self._entered = True
         self._encoder_ctx.encode(frame, pts, apply_lut=apply_lut)
@@ -371,7 +378,7 @@ class Pipeline:
         primary_idle_event = threading.Event()
         frame_shape: list[tuple[int, int]] = []
 
-        encode_heartbeat: list[float] = [time.monotonic()]
+        encode_heartbeat: list[float | None] = [None]
         frame_writer = _OfflineFrameWriter(encoder_ctx, encode_heartbeat)
         vram_offloader = VramOffloader(
             device=device,

--- a/jasna/vram_offloader.py
+++ b/jasna/vram_offloader.py
@@ -145,10 +145,14 @@ class VramOffloader:
 
     def _check_encode_stall(self) -> None:
         hb = self._last_encode_time
-        if hb is None or hb[0] is None or self._stall_check_paused:
+        if hb is None or self._stall_check_paused:
+            return
+        heartbeat = hb[0]
+        if heartbeat is None:
+            self._last_stall_warn_time = 0.0
             return
         now = time.monotonic()
-        elapsed = now - hb[0]
+        elapsed = now - heartbeat
         if elapsed > STALL_WARN_SECONDS:
             if now - self._last_stall_warn_time >= STALL_WARN_SECONDS:
                 _log.warning(

--- a/jasna/vram_offloader.py
+++ b/jasna/vram_offloader.py
@@ -83,7 +83,7 @@ class VramOffloader:
         self.stats = VramStats()
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, name="VramOffloader", daemon=True)
-        self._last_encode_time: list[float] | None = None
+        self._last_encode_time: list[float | None] | None = None
         self._last_stall_warn_time: float = 0.0
         self._stall_check_paused = False
         self._pipeline_queues: dict[str, object] | None = None
@@ -96,7 +96,7 @@ class VramOffloader:
             safetynet // _MIB,
         )
 
-    def set_encode_heartbeat(self, shared_time: list[float]) -> None:
+    def set_encode_heartbeat(self, shared_time: list[float | None]) -> None:
         self._last_encode_time = shared_time
 
     def set_pipeline_queues(
@@ -145,7 +145,7 @@ class VramOffloader:
 
     def _check_encode_stall(self) -> None:
         hb = self._last_encode_time
-        if hb is None or self._stall_check_paused:
+        if hb is None or hb[0] is None or self._stall_check_paused:
             return
         now = time.monotonic()
         elapsed = now - hb[0]

--- a/tests/test_pipeline_threads.py
+++ b/tests/test_pipeline_threads.py
@@ -656,7 +656,11 @@ class TestOfflineFrameWriter:
             assert heartbeat[0] is not None
             return mock_enc
 
+        def encode_frame(*_args, **_kwargs):
+            assert heartbeat[0] is not None
+
         mock_enc.__enter__ = MagicMock(side_effect=enter_encoder)
+        mock_enc.encode = MagicMock(side_effect=encode_frame)
         mock_enc.__exit__ = MagicMock(return_value=False)
 
         writer = _OfflineFrameWriter(mock_enc, heartbeat)
@@ -667,7 +671,69 @@ class TestOfflineFrameWriter:
 
         mock_enc.__enter__.assert_called_once()
         assert mock_enc.encode.call_count == 2
-        assert heartbeat[0] > 0
+        assert heartbeat[0] is None
+
+    def test_write_clears_heartbeat_after_encode_error(self):
+        from jasna.pipeline import _OfflineFrameWriter
+
+        heartbeat: list[float | None] = [None]
+        mock_enc = MagicMock()
+        mock_enc.__enter__ = MagicMock(return_value=mock_enc)
+
+        def fail_encode(*_args, **_kwargs):
+            assert heartbeat[0] is not None
+            raise RuntimeError("encode failed")
+
+        mock_enc.encode = MagicMock(side_effect=fail_encode)
+        writer = _OfflineFrameWriter(mock_enc, heartbeat)
+
+        with pytest.raises(RuntimeError, match="encode failed"):
+            writer.write(torch.zeros(3, 8, 8), pts=0)
+
+        assert heartbeat[0] is None
+
+    def test_write_keeps_heartbeat_armed_while_encode_is_blocked(self):
+        from jasna.pipeline import _OfflineFrameWriter
+
+        heartbeat: list[float | None] = [None]
+        encode_started = threading.Event()
+        release_encode = threading.Event()
+        mock_enc = MagicMock()
+        mock_enc.__enter__ = MagicMock(return_value=mock_enc)
+
+        def block_encode(*_args, **_kwargs):
+            encode_started.set()
+            assert release_encode.wait(timeout=2.0)
+
+        mock_enc.encode = MagicMock(side_effect=block_encode)
+        writer = _OfflineFrameWriter(mock_enc, heartbeat)
+        worker = threading.Thread(
+            target=writer.write,
+            args=(torch.zeros(3, 8, 8), 0),
+        )
+
+        worker.start()
+        assert encode_started.wait(timeout=2.0)
+        assert heartbeat[0] is not None
+        release_encode.set()
+        worker.join(timeout=2.0)
+
+        assert not worker.is_alive()
+        assert heartbeat[0] is None
+
+    def test_write_clears_heartbeat_after_enter_error(self):
+        from jasna.pipeline import _OfflineFrameWriter
+
+        heartbeat: list[float | None] = [None]
+        mock_enc = MagicMock()
+        mock_enc.__enter__ = MagicMock(side_effect=RuntimeError("enter failed"))
+        writer = _OfflineFrameWriter(mock_enc, heartbeat)
+
+        with pytest.raises(RuntimeError, match="enter failed"):
+            writer.write(torch.zeros(3, 8, 8), pts=0)
+
+        assert heartbeat[0] is None
+        mock_enc.encode.assert_not_called()
 
     def test_after_write_is_noop(self):
         from jasna.pipeline import _OfflineFrameWriter

--- a/tests/test_pipeline_threads.py
+++ b/tests/test_pipeline_threads.py
@@ -650,10 +650,15 @@ class TestOfflineFrameWriter:
     def test_write_enters_ctx_once_and_encodes(self):
         from jasna.pipeline import _OfflineFrameWriter
         mock_enc = MagicMock()
-        mock_enc.__enter__ = MagicMock(return_value=mock_enc)
+        heartbeat: list[float | None] = [None]
+
+        def enter_encoder():
+            assert heartbeat[0] is not None
+            return mock_enc
+
+        mock_enc.__enter__ = MagicMock(side_effect=enter_encoder)
         mock_enc.__exit__ = MagicMock(return_value=False)
 
-        heartbeat = [0.0]
         writer = _OfflineFrameWriter(mock_enc, heartbeat)
 
         frame = torch.zeros(3, 8, 8)

--- a/tests/test_vram_offloader.py
+++ b/tests/test_vram_offloader.py
@@ -270,6 +270,23 @@ class TestEncodeStallDetection:
         offloader._check_encode_stall()
         assert offloader._last_stall_warn_time == 0.0
 
+    def test_no_warning_before_first_encode_attempt(self):
+        offloader = VramOffloader(
+            device=torch.device("cpu"),
+            blend_buffer=BlendBuffer(device=torch.device("cpu")),
+            crop_buffers={},
+            crop_lock=threading.Lock(),
+            vram_limit=0.001,
+            safetynet=0,
+        )
+        offloader.set_encode_heartbeat([None])
+
+        with patch.object(offloader, "_dump_stall_diagnostics") as diagnostics:
+            offloader._check_encode_stall()
+
+        assert offloader._last_stall_warn_time == 0.0
+        diagnostics.assert_not_called()
+
     def test_no_warning_when_recent(self):
         import time
         offloader = VramOffloader(

--- a/tests/test_vram_offloader.py
+++ b/tests/test_vram_offloader.py
@@ -287,6 +287,54 @@ class TestEncodeStallDetection:
         assert offloader._last_stall_warn_time == 0.0
         diagnostics.assert_not_called()
 
+    def test_unarmed_heartbeat_resets_warning_cooldown(self):
+        offloader = VramOffloader(
+            device=torch.device("cpu"),
+            blend_buffer=BlendBuffer(device=torch.device("cpu")),
+            crop_buffers={},
+            crop_lock=threading.Lock(),
+            vram_limit=0.001,
+            safetynet=0,
+        )
+        offloader.set_encode_heartbeat([None])
+        offloader._last_stall_warn_time = 123.0
+
+        with patch.object(offloader, "_dump_stall_diagnostics") as diagnostics:
+            offloader._check_encode_stall()
+
+        assert offloader._last_stall_warn_time == 0.0
+        diagnostics.assert_not_called()
+
+    def test_reads_active_heartbeat_once_per_check(self):
+        import time
+
+        class ChangingHeartbeat(list):
+            def __init__(self):
+                super().__init__([time.monotonic()])
+                self.reads = 0
+
+            def __getitem__(self, index):
+                self.reads += 1
+                if self.reads > 1:
+                    raise AssertionError("heartbeat must be snapshotted")
+                return super().__getitem__(index)
+
+        offloader = VramOffloader(
+            device=torch.device("cpu"),
+            blend_buffer=BlendBuffer(device=torch.device("cpu")),
+            crop_buffers={},
+            crop_lock=threading.Lock(),
+            vram_limit=0.001,
+            safetynet=0,
+        )
+        heartbeat = ChangingHeartbeat()
+        offloader.set_encode_heartbeat(heartbeat)
+
+        offloader._check_encode_stall()
+
+        assert heartbeat.reads == 1
+        assert offloader._last_stall_warn_time == 0.0
+
     def test_no_warning_when_recent(self):
         import time
         offloader = VramOffloader(


### PR DESCRIPTION
## Summary

- keep the full-render encode watchdog unarmed before the first output frame;
- track only an active encoder context/submit attempt, rather than time since the
  last completed write;
- clear the marker in `finally` after success or error and reset the warning
  cooldown while no encode attempt is active;
- snapshot the shared marker once per watchdog check so a concurrent clear cannot
  race with elapsed-time calculation.

## Root cause

The startup fix correctly deferred arming until the first encoder attempt, but a
successful write left its completion timestamp armed. A later BasicVSR++ gap
longer than 30 seconds therefore looked like an encoder stall even while the
native encoder worker and pipeline encode queue were idle.

A 51.5-second 8192x4096 HEVC Main10 Windows AMD run reproduced two such warnings.
Both diagnostics showed `BlendEncode` waiting for upstream restoration,
BasicVSR++ actively running, and the native encoder worker blocked on its empty
input queue. The run still completed with exit 0, 3,085 frames, and 32 restored
tracks.

## Behavior contract

- startup and upstream restoration gaps do not emit encoder-stall diagnostics;
- encoder context entry or producer submission that blocks keeps the marker
  armed, so the existing 30-second diagnostics still fire;
- success, entry failure, and encode failure clear the marker;
- an unarmed interval resets warning cooldown before a later independent attempt;
- shutdown/drain pause behavior and streaming behavior are unchanged.

## Validation

- baseline probe: `post_write_heartbeat_is_none=false`, cooldown stayed `123.0`;
- modified probe: `post_write_heartbeat_is_none=true`, cooldown reset to `0.0`;
- `tests/test_vram_offloader.py`: 25 passed;
- focused watchdog/writer/blend tests: 22 passed (8 + 14);
- deterministic blocked-encode test confirms heartbeat remains armed until the
  producer call returns;
- first-enter and encode-error tests confirm `finally` cleanup;
- product modules compile and `git diff --check` passes.

The PR-base checkout still needs the small test-only `RestorationPipeline` export
shim to collect `test_pipeline_threads.py`; the focused writer/blend tests were
run with that shim. The integrated collection is run again after merging the
updated PR into the integration branch.
