### PR TITLE
Isolate NVENC encoder unit contracts from host GPU vendor

### DIFF
--- a/tests/test_video_encoder_unit.py
+++ b/tests/test_video_encoder_unit.py
@@ -61,6 +61,15 @@ def _make_encoder(tmp_path, encoder_settings=None, codec="hevc", **meta_override
     )
 
 
+@pytest.fixture
+def nvidia_encoder_vendor(monkeypatch):
+    monkeypatch.setattr(
+        video_encoder_module,
+        "vendor_for_device",
+        lambda _device: AcceleratorVendor.NVIDIA,
+    )
+
+
 # Measured hevc_nvenc configuration; the HEVC path must never drift from it.
 _HEVC_OPTIONS_SNAPSHOT = {
     "preset": "p5",
@@ -425,6 +434,7 @@ class TestSourceContainerPreservation:
         encoder._src.demux.assert_not_called()
 
 
+@pytest.mark.usefixtures("nvidia_encoder_vendor")
 class TestEncoderOptions:
     def test_smart_fragment_preserves_normal_closed_gop_settings(self, tmp_path):
         enc = NvidiaVideoEncoder(
@@ -652,7 +662,9 @@ class TestSharpening:
         assert eight_bit._cas.ten_bit is False
         assert eight_bit._cas.peak == 255.0
 
-    def test_zero_strength_leaves_the_converted_frame_untouched(self, tmp_path, monkeypatch):
+    def test_zero_strength_leaves_the_converted_frame_untouched(
+        self, tmp_path, monkeypatch, nvidia_encoder_vendor
+    ):
         enc = _make_encoder(tmp_path, codec="h264")  # nv12, so planes stay uint8
         packed = torch.arange(24, dtype=torch.uint8, device=enc.device).reshape(6, 4)
         enc._converter = SimpleNamespace(
@@ -683,7 +695,9 @@ class TestSharpening:
 
         assert torch.equal(torch.cat(seen[0]), packed)
 
-    def test_sharpening_runs_before_pitch_alignment(self, tmp_path, monkeypatch):
+    def test_sharpening_runs_before_pitch_alignment(
+        self, tmp_path, monkeypatch, nvidia_encoder_vendor
+    ):
         enc = NvidiaVideoEncoder(
             file=str(tmp_path / "result.mkv"),
             device=torch.device("cuda:0"),


### PR DESCRIPTION
## Summary
- bind NVENC option-contract tests to an explicit NVIDIA vendor fixture
- bind the two CUDA DLPack sharpening-path tests to the NVIDIA path
- preserve the explicit AMD H.264 bitrate-cap contract in the same suite

## Why
These tests assert NVENC-only option keys and CUDA DLPack behavior. On a Windows AMD host the production encoder correctly chooses AMF, so host-dependent vendor selection made 17 unit tests fail without indicating a product regression.

## Validation
- Windows AMD focused file: **111 passed**
- worker run: **111 passed**
- Sol independent acceptance: **111 passed**
- `git diff --check`: passed

## Base
`upstream/main` at `592472bda8aeb1fc0d5cea3d3ff6607add0ab0a7`