### PR TITLE
fix(amd): bound Windows HEVC Main10 decode threads

### DIFF
--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -57,6 +57,20 @@ def _decode_backend() -> str:
     return backend
 
 
+def _requires_single_slice_pyav_threads(
+    metadata: VideoMetadata,
+    vendor: AcceleratorVendor,
+) -> bool:
+    """Limit the problematic Windows AMD HEVC Main10 software decoder."""
+
+    return (
+        sys.platform == "win32"
+        and vendor is AcceleratorVendor.AMD
+        and str(metadata.codec_name).lower() == "hevc"
+        and bool(metadata.is_10bit)
+    )
+
+
 def _cuda_driver() -> ctypes.CDLL:
     global _libcuda
     if _libcuda is None:
@@ -309,7 +323,11 @@ class NvidiaVideoReader:
 
         ctx = self.video_stream.codec_context
         if software_only:
-            ctx.thread_type = "AUTO"
+            if _requires_single_slice_pyav_threads(self.metadata, self.vendor):
+                ctx.thread_count = 1
+                ctx.thread_type = "SLICE"
+            else:
+                ctx.thread_type = "AUTO"
         elif self.vendor is AcceleratorVendor.AMD:
             self._setup_amf_decoder(ctx)
         elif not ctx.is_hwaccel:

--- a/tests/test_video_decoder_backends.py
+++ b/tests/test_video_decoder_backends.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from dataclasses import replace
 from fractions import Fraction
 from pathlib import Path
 from types import SimpleNamespace
@@ -53,6 +54,7 @@ def _fake_container(is_hwaccel: bool) -> MagicMock:
         width=16,
         height=16,
         color_range=0,
+        thread_count=0,
         thread_type=None,
         name="h264",
     )
@@ -139,6 +141,46 @@ def test_pyav_sw_backend_skips_hwaccel_and_amf(monkeypatch) -> None:
         nvdec_setup.assert_not_called()
         assert module.av.open.call_args.kwargs == {}
         assert container.streams.video[0].codec_context.thread_type == "AUTO"
+
+
+@pytest.mark.parametrize(
+    ("platform", "vendor", "codec_name", "is_10bit", "thread_count", "thread_type"),
+    [
+        ("win32", AcceleratorVendor.AMD, "hevc", True, 1, "SLICE"),
+        ("win32", AcceleratorVendor.AMD, "hevc", False, 0, "AUTO"),
+        ("win32", AcceleratorVendor.AMD, "av1", True, 0, "AUTO"),
+        ("win32", AcceleratorVendor.NVIDIA, "hevc", True, 0, "AUTO"),
+        ("linux", AcceleratorVendor.AMD, "hevc", True, 0, "AUTO"),
+    ],
+)
+def test_pyav_sw_backend_limits_windows_amd_hevc_main10_threads(
+    monkeypatch,
+    platform: str,
+    vendor: AcceleratorVendor,
+    codec_name: str,
+    is_10bit: bool,
+    thread_count: int,
+    thread_type: str,
+) -> None:
+    monkeypatch.setattr(module, "DECODE_BACKEND", "pyav-sw")
+    monkeypatch.setattr(module.sys, "platform", platform)
+    container = _fake_container(False)
+    monkeypatch.setattr(module.av, "open", MagicMock(return_value=container))
+    metadata = replace(_metadata(), codec_name=codec_name, is_10bit=is_10bit)
+    monkeypatch.setattr(module, "vendor_for_device", lambda _device: vendor)
+    monkeypatch.setattr(module, "current_stream", lambda _device: None)
+    reader = module.NvidiaVideoReader(
+        "input.mp4",
+        4,
+        torch.device("cuda:0"),
+        metadata,
+    )
+
+    reader.__enter__()
+
+    context = container.streams.video[0].codec_context
+    assert context.thread_count == thread_count
+    assert context.thread_type == thread_type
 
 
 def test_unknown_backend_raises(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- bound FFmpeg/PyAV software decoding to one slice thread for Windows AMD HEVC Main10 inputs
- leave AV1, non-10-bit HEVC, NVIDIA, and non-Windows threading behavior unchanged
- cover the explicit `pyav-sw` route with a platform/vendor/codec/bit-depth matrix

## Context
This composes with the Windows AMD HEVC Main10 software fallback in PR #326. On the full integration branch that fallback reaches this same `pyav-sw` policy for both automatic routing and explicit `JASNA_DECODE_BACKEND=pyav-sw`.

## Validation
- PR branch: `python -m pytest tests/test_video_decoder_backends.py tests/test_video_decoder_amd_path.py -q`
  - `26 passed, 1 skipped`
- integration branch focused group, including the automatic fallback: `69 passed, 1 skipped`
- direct policy probe: `THREAD_COUNT=1`, `THREAD_TYPE=SLICE`
- rollback copy restored both original SHA256 values and the old `THREAD_COUNT=0`, `THREAD_TYPE=AUTO` behavior

### Native Windows AMD media A/B
Two production `python -m jasna` repetitions completed without any runtime wrapper or stream monkeypatch:

- run 1: exit `0`, `65.908s`
- run 2: exit `0`, `64.359s`
- both: copy -> render -> copy; 480 HEVC Main10 video frames; 376 AAC packets; exact seam keyframes; PTS/DTS monotonic; source/output metadata and chapters retained; strict source/output video and audio decode `0`

Evidence:
- `D:\jasna_out\verification\hevc_decoder_threading_native_pr341_20260818`
- `D:\jasna_out\verification\hevc_decoder_threading_pr_20260818`
