### PR TITLE
test(windows): synchronize ROCm before pytest teardown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Load NVIDIA TensorRT DLLs first when the active environment provides them."""
 from importlib.util import find_spec
+import sys
 
 import pytest
 
@@ -16,6 +17,19 @@ collect_ignore = [] if _HAS_TENSORRT else [
     "test_trt_utils.py",
     "test_unet4x_secondary_restorer.py",
 ]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def synchronize_windows_rocm_before_interpreter_teardown():
+    """Drain queued HIP work before CPython unloads the Windows ROCm runtime."""
+    yield
+    if sys.platform != "win32":
+        return
+
+    import torch
+
+    if getattr(torch.version, "hip", None) and torch.cuda.is_available():
+        torch.cuda.synchronize()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- add a Windows+ROCm pytest session teardown fixture
- synchronize queued HIP work before CPython unloads the ROCm runtime
- keep all non-Windows and non-ROCm test sessions unchanged

## Windows AMD evidence
- baseline isolated fallback node: test body passed, Python did not exit within 20s (controller status 124)
- modified isolated node: natural exit 0, `1 passed in 2.03s`
- modified LUT+RGB fallback pair: natural exit 0, `2 passed in 2.13s`
- factor matrix identified `torch.cuda.synchronize()` alone as sufficient twice
- rollback copy restored the original hash and reproduced the timeout

Evidence: `D:\jasna_out\verification\windows_amd_pytest_teardown_pr_20260818`