### PR TITLE
test(media): gate CUDA fatbin kernels to NVIDIA

### DIFF
--- a/tests/test_lut_kernel.py
+++ b/tests/test_lut_kernel.py
@@ -4,9 +4,13 @@ import numpy as np
 import pytest
 import torch
 
+from jasna.accelerator import is_nvidia_device
 from jasna.media.lut import GpuLutApplier, parse_cube_text
 
-pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+requires_nvidia_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_nvidia_device(),
+    reason="needs NVIDIA CUDA",
+)
 
 
 def _cube_3d(size: int, transform, domain: tuple[float, float] | None = None) -> str:
@@ -101,6 +105,7 @@ def _codes(values: torch.Tensor) -> torch.Tensor:
     return (values * 255.0).round().clamp(0, 255).to(torch.int32)
 
 
+@requires_nvidia_cuda
 @pytest.mark.parametrize("name", sorted(CUBES))
 def test_kernel_is_at_least_as_accurate_as_the_torch_path(name):
     generator = torch.Generator(device="cuda").manual_seed(0)

--- a/tests/test_rgb_to_yuv_kernel.py
+++ b/tests/test_rgb_to_yuv_kernel.py
@@ -1,9 +1,13 @@
 import pytest
 import torch
 
+from jasna.accelerator import is_nvidia_device
 from jasna.media.rgb_to_yuv import _TORCH_CONVERTERS, RgbToYuvConverter
 
-pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+requires_nvidia_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_nvidia_device(),
+    reason="needs NVIDIA CUDA",
+)
 
 VARIANTS = sorted(_TORCH_CONVERTERS)
 
@@ -19,6 +23,7 @@ def _random_frame(height: int, width: int) -> torch.Tensor:
     )
 
 
+@requires_nvidia_cuda
 @pytest.mark.parametrize("variant", VARIANTS)
 def test_matches_the_torch_reference_within_one_code(variant):
     frame = _random_frame(64, 96)


### PR DESCRIPTION
## Summary
- classify CUDA fatbin accuracy assertions as NVIDIA-only
- keep generic LUT and RGB-to-YUV Torch fallback coverage running on AMD
- avoid treating Windows ROCm `torch.cuda.is_available()` as proof that NVIDIA fatbins can execute

## Windows AMD evidence
- baseline: 20 failed, 32 passed because NVIDIA fatbin assertions ran on AMD
- modified logic: 20 NVIDIA nodes skipped, 32 generic fallback nodes passed
- integration with independent teardown PR #343: natural exit 0, `32 passed, 20 skipped in 2.65s`
- rollback restores the original focused AMD assertion failure

The Windows ROCm interpreter-exit containment remains deliberately separate in #343.

Evidence: `D:\jasna_out\verification\nvidia_fatbin_test_gate_pr_20260818`