### PR TITLE
test(yolo): isolate mocked TensorRT branch

### DIFF
--- a/tests/test_yolo_call.py
+++ b/tests/test_yolo_call.py
@@ -27,6 +27,7 @@ def _build_yolo_model(*, batch_size=2, imgsz=640):
     mock_runner.outputs = outs
 
     with (
+        patch("jasna.mosaic.yolo.is_nvidia_device", return_value=True),
         patch("jasna.mosaic.yolo.get_yolo_tensorrt_engine_path", return_value=_mock_engine_path()),
         patch("jasna.mosaic.yolo.TrtRunner", return_value=mock_runner),
     ):
@@ -54,6 +55,7 @@ class TestYoloInit:
         engine = _mock_engine_path()
 
         with (
+            patch("jasna.mosaic.yolo.is_nvidia_device", return_value=True),
             patch("jasna.mosaic.yolo.get_yolo_tensorrt_engine_path", return_value=engine),
             patch("jasna.mosaic.yolo.TrtRunner", mock_runner_cls),
         ):


### PR DESCRIPTION
## Summary
- force the NVIDIA predicate only in mocked TensorRT unit paths
- keep engine and runner mocked on AMD hosts
- leave production YOLO backend selection unchanged

## Validation
- baseline focused: `4 failed` (exit 1)
- modified focused with accepted Windows ROCm teardown fixture: `4 passed in 2.13s` (exit 0)
- full file: `17 passed in 2.20s` (exit 0)

Evidence: `D:\jasna_out\verification\yolo_trt_fixture_pr_20260818`