### PR TITLE
feat(runtime): enforce pinned PyAV FFmpeg contract

### DIFF
--- a/docs/UNIFIED_RUNTIME_CN.md
+++ b/docs/UNIFIED_RUNTIME_CN.md
@@ -1,0 +1,84 @@
+# Jasna 统一 PyAV/FFmpeg runtime 合同
+
+更新时间：2026-08-28
+
+## 目的
+
+PyAV wheel 与它加载的 FFmpeg 动态库必须作为一个 ABI 单元使用。普通开发虚拟环境仍负责
+PyTorch、GUI 和模型依赖；只有在显式使用本页启动器时，Jasna 才把固定的 PyAV、FFmpeg/
+FFprobe 和动态库放到子进程最前面，并在导入媒体模块前执行完整预检。
+
+本阶段只建立 runtime 校验与显式启动入口，不改变解码、编码、检测、修复或 GUI 路由。产品
+默认仍为 B4，`auto` 逻辑、NVIDIA 路线和 AMD 路线都保持 `v0.10.0` 行为。
+
+## 固定合同
+
+- FFmpeg commit：`44d082edc87381d978e8588b148116b99fefdb43`
+- PyAV commit：`7e3d950a8b72062502c1a60d672f8ca565313af5`
+- AMF headers commit：`c35f613aea2e5057a688c979e75b1cf24253297e`
+- PyAV：`18.1.0`
+- FFmpeg ABI：libavcodec 62、libavformat 62、libavutil 60，以及文件中列出的完整小版本
+
+Linux AMD 与 Windows AMD 各自有独立的文件哈希白名单。Windows runtime 另外固定 dav1d
+commit。校验失败时启动器直接退出，不回退到系统 PyAV、系统 FFmpeg 或 CPU 路线。
+
+## runtime 目录
+
+```text
+runtime-root/
+├── runtime.json
+├── site-packages/av/
+├── bin/ffmpeg[.exe]
+├── bin/ffprobe[.exe]
+└── lib/                 # Linux；Windows DLL 位于 bin/
+```
+
+`runtime.json` 至少包含：
+
+```json
+{
+  "schema_version": 1,
+  "platform": "linux-amd",
+  "wheel_sha256": "...",
+  "source_pins": {
+    "FFMPEG_COMMIT": "...",
+    "PYAV_COMMIT": "...",
+    "AMF_COMMIT": "..."
+  }
+}
+```
+
+构建器和安装器将在后续独立 PR 中加入；本 PR 不把未验收的构建流程混入启动合同。
+
+## 使用
+
+Linux：
+
+```bash
+scripts/run_jasna_unified.sh --preflight-only
+scripts/run_jasna_unified.sh -- <jasna 参数>
+```
+
+可用 `JASNA_PYTHON=/path/to/python` 选择开发环境，用
+`JASNA_UNIFIED_RUNTIME_ROOT=/path/to/runtime` 选择 runtime。没有显式 Python 时，启动器优先使用
+仓库 `.venv/bin/python`，再查找 `python3`。
+
+Windows PowerShell：
+
+```powershell
+scripts\run_jasna_unified_windows.ps1 -PreflightOnly
+scripts\run_jasna_unified_windows.ps1 -- <jasna 参数>
+```
+
+可用 `-Python` 与 `-RuntimeRoot` 覆盖默认位置。默认 runtime 位于
+`%LOCALAPPDATA%\Jasna\unified-runtime\windows-amd`。
+
+成功预检会在用户状态目录记录 `jasna/runtime-preflight.json`；状态目录不可写不会改变已通过的
+runtime 结论。
+
+## 边界与回滚
+
+- 不自动修改当前 shell 的 `PATH`、`PYTHONPATH` 或 `LD_LIBRARY_PATH`；只构造 Jasna 子进程环境。
+- 不接入 AMF Vulkan/HIP bridge、MIGraphX、rocDecode 或产品 GUI 自动启动。
+- 不修改 B4、CQ、codec、VR auto 或任何媒体路由默认值。
+- 回滚本功能只需停止使用 `scripts/run_jasna_unified*`；普通 `python -m jasna` 行为未改变。

--- a/jasna/runtime_contract.py
+++ b/jasna/runtime_contract.py
@@ -1,0 +1,335 @@
+"""Validation helpers for Jasna's pinned PyAV/FFmpeg runtime.
+
+PyAV and the FFmpeg libraries it loads form one native ABI unit.  A regular
+development environment may still provide the rest of Jasna's Python
+dependencies, but an explicitly selected unified runtime must not silently mix
+its PyAV wheel, command-line tools, or shared libraries with ambient copies.
+
+This module is deliberately independent from decoder and encoder routing.  It
+only validates and prepares a runtime; callers opt in through the launchers in
+``scripts/``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping
+
+
+RUNTIME_SCHEMA_VERSION = 1
+EXPECTED_SOURCE_PINS: Mapping[str, str] = {
+    "FFMPEG_COMMIT": "44d082edc87381d978e8588b148116b99fefdb43",
+    "PYAV_COMMIT": "7e3d950a8b72062502c1a60d672f8ca565313af5",
+    "AMF_COMMIT": "c35f613aea2e5057a688c979e75b1cf24253297e",
+}
+EXPECTED_AV_VERSION = "18.1.0"
+EXPECTED_AV_LIBRARY_VERSIONS: Mapping[str, tuple[int, int, int]] = {
+    "libavutil": (60, 33, 100),
+    "libavcodec": (62, 36, 101),
+    "libavformat": (62, 19, 101),
+    "libavdevice": (62, 4, 100),
+    "libavfilter": (11, 17, 100),
+    "libswscale": (9, 8, 100),
+    "libswresample": (6, 4, 100),
+}
+
+
+@dataclass(frozen=True)
+class RuntimePolicy:
+    """Immutable expected contents for one accepted runtime build."""
+
+    wheel_sha256: str
+    executables: Mapping[str, str]
+    libraries: Mapping[str, str]
+    library_directory: str
+    extra_source_pins: Mapping[str, str] = field(default_factory=dict)
+
+
+RUNTIME_POLICIES: dict[str, RuntimePolicy] = {
+    "linux-amd": RuntimePolicy(
+        wheel_sha256=(
+            "07851a963fb78f0b89d882c13e3c0ce2ebe5d7a1cb22bd156e48bed9f678d366"
+        ),
+        executables={
+            "ffmpeg": "6acef1c7180fcfa4c54c17bc9f111b22a0bd66cfa8d8ab553e4a5ad7e69377fb",
+            "ffprobe": "5a9d3c289ed82873dfe90d5f4ac74b4c8ceec05cfee7cf8b68802727ef862a53",
+        },
+        libraries={
+            "libavcodec.so.62.36.101": (
+                "09d7c68e08e31efd5b00fbee06564e85000fdc2191bcf17b9a3a11f5469d56c1"
+            ),
+            "libavdevice.so.62.4.100": (
+                "9e4763e9308e44089147d32b4f8f8b389ced02ca7a72354a4015cf94da9536db"
+            ),
+            "libavfilter.so.11.17.100": (
+                "8c77475e9c2bc67ba9d6ab0cf283cd747d8b83dd8452febd3572d27762888634"
+            ),
+            "libavformat.so.62.19.101": (
+                "92269b956d32d01bd70ce6c7541baee4a1fe6a8ca2f08b3e6f131b5e9d92a545"
+            ),
+            "libavutil.so.60.33.100": (
+                "6becf2a3addc306e78dcff8b188653240412f70d8c643e5408fdeebe2aeaf6a4"
+            ),
+            "libswresample.so.6.4.100": (
+                "14692f9ab2b3d837580bd229ed8bc272bb3a856a9e55de6b7f865b0f867caea2"
+            ),
+            "libswscale.so.9.8.100": (
+                "a869f237135fff5b21d7e18ba840b11570bcd248284c8d262b270367ea1c51da"
+            ),
+        },
+        library_directory="lib",
+    ),
+    "windows-amd": RuntimePolicy(
+        wheel_sha256=(
+            "a42b43e96d4087ea1df7c1effd141bc5368cfd95e121a655562af3d4027ae311"
+        ),
+        executables={
+            "ffmpeg.exe": (
+                "0145ec696983e59cb6ca0c2eed722d97b8cc5cedf0e71af5890e072bca4bdab1"
+            ),
+            "ffprobe.exe": (
+                "e348f4d90510101da03267dd4d271b56e5b3b06cd50044952073bd4b05b570b4"
+            ),
+            "dav1d.dll": (
+                "979293ada0eb0da21e92fec66882ba9a62b36637338c76ac2236319ac2d586ca"
+            ),
+        },
+        libraries={
+            "avcodec-62.dll": (
+                "0e11fea2cea5d20dc68ba483188ed468b86aa4844420c519cc69144205810646"
+            ),
+            "avdevice-62.dll": (
+                "285b3ee8ef3f9830a79ffca50bf7dc51b5209f5b133dd4c2cced554b390f056d"
+            ),
+            "avfilter-11.dll": (
+                "e0f878e600f5f82320b6f2a745d8615314b61a015539b976383fe98cd58dbb56"
+            ),
+            "avformat-62.dll": (
+                "134a43d2aeafbd61a7773f32ea4252f68fa9746800ad29344790da2685f8433b"
+            ),
+            "avutil-60.dll": (
+                "2e1bc7fefacf921539398a7bb8ff7ef7a5367da7dc5b6de6a2bfe3b1055d57de"
+            ),
+            "swresample-6.dll": (
+                "9d73ac10de44f6eb2b2ca55595f9b1ebe51554b738bb54c18f6c0e8b79049ff1"
+            ),
+            "swscale-9.dll": (
+                "691a813e451d4177e55bb8ebb140f25b001e2a225673a3f54e6bbbf9879dbb9a"
+            ),
+        },
+        library_directory="bin",
+        extra_source_pins={
+            "DAV1D_COMMIT": "b546257f770768b2c88258c533da38b91a06f737",
+        },
+    ),
+}
+
+
+class RuntimeContractError(RuntimeError):
+    """Raised when a selected native runtime is absent, mixed, or stale."""
+
+
+def runtime_platform_key(platform: str | None = None) -> str:
+    value = sys.platform if platform is None else str(platform)
+    if value.startswith("linux"):
+        return "linux-amd"
+    if value == "win32":
+        return "windows-amd"
+    raise RuntimeContractError(f"unsupported unified runtime platform: {value}")
+
+
+def default_runtime_root(platform: str | None = None) -> Path:
+    key = runtime_platform_key(platform)
+    override = os.environ.get("JASNA_UNIFIED_RUNTIME_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser()
+    if key == "windows-amd":
+        local_app_data = os.environ.get("LOCALAPPDATA", "").strip()
+        base = Path(local_app_data) if local_app_data else Path.home() / "AppData/Local"
+        return base / "Jasna/unified-runtime/windows-amd"
+    return Path.home() / ".local/share/jasna/unified-runtime/linux-amd"
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_build_manifest(path: str | Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in Path(path).read_text(encoding="utf-8-sig").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, separator, value = line.partition("=")
+        if not separator or not key.strip():
+            raise RuntimeContractError(f"invalid build manifest line: {raw_line!r}")
+        values[key.strip()] = value.strip()
+    return values
+
+
+def _require_equal(label: str, actual: object, expected: object) -> None:
+    if actual != expected:
+        raise RuntimeContractError(
+            f"{label}: expected {expected!r}, observed {actual!r}"
+        )
+
+
+def _require_file_hash(path: Path, expected: str, label: str) -> None:
+    if not path.is_file():
+        raise RuntimeContractError(f"{label} is missing: {path}")
+    _require_equal(f"{label} SHA256", sha256_file(path), expected)
+
+
+def load_runtime_manifest(runtime_root: str | Path) -> dict[str, object]:
+    root = Path(runtime_root).expanduser().resolve(strict=False)
+    manifest_path = root / "runtime.json"
+    if not manifest_path.is_file():
+        raise RuntimeContractError(
+            f"unified runtime is not installed at {root}; missing runtime.json"
+        )
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeContractError(f"cannot read unified runtime manifest: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RuntimeContractError("unified runtime manifest root must be an object")
+    return data
+
+
+def validate_runtime_layout(
+    runtime_root: str | Path,
+    *,
+    platform: str | None = None,
+) -> dict[str, object]:
+    """Validate immutable runtime files without importing native modules."""
+
+    root = Path(runtime_root).expanduser().resolve(strict=False)
+    key = runtime_platform_key(platform)
+    policy = RUNTIME_POLICIES[key]
+    data = load_runtime_manifest(root)
+
+    _require_equal("runtime schema", data.get("schema_version"), RUNTIME_SCHEMA_VERSION)
+    _require_equal("runtime platform", data.get("platform"), key)
+    _require_equal("PyAV wheel SHA256", data.get("wheel_sha256"), policy.wheel_sha256)
+
+    pins = data.get("source_pins")
+    if not isinstance(pins, dict):
+        raise RuntimeContractError("runtime source_pins must be an object")
+    for name, expected in {
+        **EXPECTED_SOURCE_PINS,
+        **policy.extra_source_pins,
+    }.items():
+        _require_equal(name, pins.get(name), expected)
+
+    site_packages = root / "site-packages"
+    if not (site_packages / "av/__init__.py").is_file():
+        raise RuntimeContractError(f"PyAV runtime is missing below {site_packages}")
+
+    for name, expected in policy.executables.items():
+        _require_file_hash(root / "bin" / name, expected, name)
+    library_root = root / policy.library_directory
+    for name, expected in policy.libraries.items():
+        _require_file_hash(library_root / name, expected, name)
+    return data
+
+
+def build_runtime_environment(
+    runtime_root: str | Path,
+    repo_root: str | Path,
+    *,
+    python_executable: str | Path,
+    platform: str | None = None,
+    base_environment: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return a child environment with only the selected native ABI first."""
+
+    root = Path(runtime_root).expanduser().resolve()
+    repo = Path(repo_root).expanduser().resolve()
+    key = runtime_platform_key(platform)
+    validate_runtime_layout(root, platform=platform)
+
+    environment = dict(os.environ if base_environment is None else base_environment)
+    python_dir = str(Path(python_executable).expanduser().resolve().parent)
+    environment["PYTHONPATH"] = os.pathsep.join((str(root / "site-packages"), str(repo)))
+
+    path_prefix = [str(root / "bin"), python_dir]
+    if key == "linux-amd":
+        path_prefix.append("/opt/rocm/bin")
+        environment["LD_LIBRARY_PATH"] = os.pathsep.join(
+            (str(root / "lib"), "/opt/amdgpu/lib/x86_64-linux-gnu", "/opt/rocm/lib")
+        )
+    environment["PATH"] = os.pathsep.join(
+        (*path_prefix, environment.get("PATH", ""))
+    )
+    environment["PYTHONNOUSERSITE"] = "1"
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONUNBUFFERED"] = "1"
+    environment["JASNA_UNIFIED_RUNTIME"] = "1"
+    environment["JASNA_UNIFIED_RUNTIME_ROOT"] = str(root)
+    environment["JASNA_REPO_ROOT"] = str(repo)
+    return environment
+
+
+def validate_loaded_runtime(
+    runtime_root: str | Path,
+    repo_root: str | Path,
+    *,
+    platform: str | None = None,
+) -> dict[str, object]:
+    """Validate native imports from inside the prepared child process."""
+
+    root = Path(runtime_root).expanduser().resolve()
+    repo = Path(repo_root).expanduser().resolve()
+    key = runtime_platform_key(platform)
+    validate_runtime_layout(root, platform=platform)
+
+    import av
+    import jasna
+
+    _require_equal("PyAV version", av.__version__, EXPECTED_AV_VERSION)
+    observed_versions = {
+        name: tuple(value) for name, value in av.library_versions.items()
+    }
+    _require_equal("FFmpeg ABI", observed_versions, EXPECTED_AV_LIBRARY_VERSIONS)
+
+    av_file = Path(av.__file__).resolve()
+    jasna_file = Path(jasna.__file__).resolve()
+    if not av_file.is_relative_to(root / "site-packages"):
+        raise RuntimeContractError(f"PyAV loaded outside unified runtime: {av_file}")
+    if not jasna_file.is_relative_to(repo):
+        raise RuntimeContractError(f"Jasna loaded outside selected repository: {jasna_file}")
+
+    loaded_ffmpeg_libraries: list[str] = []
+    maps = Path("/proc/self/maps")
+    if key == "linux-amd" and maps.is_file():
+        for line in maps.read_text(encoding="utf-8", errors="replace").splitlines():
+            mapped = line.rsplit(maxsplit=1)[-1]
+            if "/libav" not in mapped and "/libsw" not in mapped:
+                continue
+            mapped_path = Path(mapped).resolve(strict=False)
+            if not mapped_path.is_relative_to(root / "lib"):
+                raise RuntimeContractError(
+                    f"FFmpeg shared library loaded outside unified runtime: {mapped_path}"
+                )
+            loaded_ffmpeg_libraries.append(str(mapped_path))
+
+    return {
+        "status": "PASSED",
+        "platform": key,
+        "runtime_root": str(root),
+        "repo_root": str(repo),
+        "python": sys.executable,
+        "pyav_version": av.__version__,
+        "pyav_file": str(av_file),
+        "ffmpeg_abi": {name: list(value) for name, value in observed_versions.items()},
+        "loaded_ffmpeg_libraries": sorted(set(loaded_ffmpeg_libraries)),
+    }

--- a/scripts/run_jasna_unified.py
+++ b/scripts/run_jasna_unified.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Launch Jasna only after the selected native runtime passes preflight."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from jasna.runtime_contract import (  # noqa: E402
+    RuntimeContractError,
+    build_runtime_environment,
+    default_runtime_root,
+    validate_loaded_runtime,
+)
+
+
+def _preflight_child(runtime_root: Path, repo_root: Path) -> int:
+    try:
+        result = validate_loaded_runtime(runtime_root, repo_root)
+    except Exception as exc:
+        failure = {
+            "status": "FAILED",
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+        }
+        print(json.dumps(failure, ensure_ascii=False), file=sys.stderr)
+        return 1
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+def _write_preflight_record(stdout: str) -> None:
+    state_dir = Path(
+        os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local/state"))
+    ) / "jasna"
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "runtime-preflight.json").write_text(
+            stdout.strip() + "\n",
+            encoding="utf-8",
+        )
+    except OSError:
+        # A read-only state directory must not turn a passed runtime into a
+        # failed launch; the preflight output is still printed on request.
+        pass
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument("--runtime-root", default=str(default_runtime_root()))
+    parser.add_argument("--preflight-only", action="store_true")
+    parser.add_argument("--_preflight-child", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--repo-root", default=str(REPO_ROOT), help=argparse.SUPPRESS)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args, jasna_args = parser.parse_known_args()
+    runtime_root = Path(args.runtime_root).expanduser().resolve(strict=False)
+    repo_root = Path(args.repo_root).expanduser().resolve(strict=False)
+    if args._preflight_child:
+        return _preflight_child(runtime_root, repo_root)
+
+    if jasna_args[:1] == ["--"]:
+        jasna_args = jasna_args[1:]
+    try:
+        environment = build_runtime_environment(
+            runtime_root,
+            repo_root,
+            python_executable=sys.executable,
+        )
+    except (OSError, RuntimeContractError) as exc:
+        print(f"Jasna unified runtime preflight failed: {exc}", file=sys.stderr)
+        return 1
+
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--_preflight-child",
+        "--runtime-root",
+        str(runtime_root),
+        "--repo-root",
+        str(repo_root),
+    ]
+    completed = subprocess.run(
+        command,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        print(f"Jasna unified runtime preflight failed: {detail}", file=sys.stderr)
+        return completed.returncode or 1
+    _write_preflight_record(completed.stdout)
+    if args.preflight_only:
+        print(completed.stdout.strip())
+        return 0
+
+    os.chdir(repo_root)
+    os.execve(
+        sys.executable,
+        [sys.executable, "-m", "jasna", *jasna_args],
+        environment,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_jasna_unified.sh
+++ b/scripts/run_jasna_unified.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+
+if [[ -n ${JASNA_PYTHON:-} ]]; then
+  python_bin=$JASNA_PYTHON
+elif [[ -x $repo_root/.venv/bin/python ]]; then
+  python_bin=$repo_root/.venv/bin/python
+else
+  python_bin=$(command -v python3 || true)
+fi
+if [[ -z $python_bin || ! -x $python_bin ]]; then
+  printf 'Jasna Python environment not found; set JASNA_PYTHON explicitly.\n' >&2
+  exit 1
+fi
+
+exec "$python_bin" "$repo_root/scripts/run_jasna_unified.py" "$@"

--- a/scripts/run_jasna_unified_windows.ps1
+++ b/scripts/run_jasna_unified_windows.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding()]
+param(
+    [string] $Python = "",
+    [string] $RuntimeRoot = "",
+    [switch] $PreflightOnly,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $JasnaArgs = @()
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not $Python) {
+    $Python = Join-Path $repoRoot ".venv\Scripts\python.exe"
+}
+if (-not (Test-Path -LiteralPath $Python -PathType Leaf)) {
+    throw "Jasna Python environment not found: $Python"
+}
+
+$launcherArgs = @()
+if ($RuntimeRoot) {
+    $launcherArgs += @("--runtime-root", $RuntimeRoot)
+}
+if ($PreflightOnly) {
+    $launcherArgs += "--preflight-only"
+}
+if ($JasnaArgs.Count -gt 0) {
+    $launcherArgs += "--"
+    $launcherArgs += $JasnaArgs
+}
+
+& $Python (Join-Path $PSScriptRoot "run_jasna_unified.py") @launcherArgs
+exit $LASTEXITCODE

--- a/tests/test_runtime_contract.py
+++ b/tests/test_runtime_contract.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from jasna import runtime_contract
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def test_runtime_platform_keys_and_default_roots(monkeypatch, tmp_path: Path) -> None:
+    override = tmp_path / "accepted-runtime"
+    monkeypatch.setenv("JASNA_UNIFIED_RUNTIME_ROOT", str(override))
+
+    assert runtime_contract.runtime_platform_key("linux") == "linux-amd"
+    assert runtime_contract.runtime_platform_key("linux2") == "linux-amd"
+    assert runtime_contract.runtime_platform_key("win32") == "windows-amd"
+    assert runtime_contract.default_runtime_root("linux") == override
+
+    with pytest.raises(runtime_contract.RuntimeContractError, match="unsupported"):
+        runtime_contract.runtime_platform_key("darwin")
+
+
+def test_parse_build_manifest_ignores_comments_and_rejects_malformed_lines(
+    tmp_path: Path,
+) -> None:
+    manifest = tmp_path / "build-manifest.txt"
+    manifest.write_text(
+        "# accepted pins\nFFMPEG_COMMIT=abc\n\nPYAV_COMMIT=def\n",
+        encoding="utf-8",
+    )
+    assert runtime_contract.parse_build_manifest(manifest) == {
+        "FFMPEG_COMMIT": "abc",
+        "PYAV_COMMIT": "def",
+    }
+
+    manifest.write_text("missing separator\n", encoding="utf-8")
+    with pytest.raises(runtime_contract.RuntimeContractError, match="invalid build"):
+        runtime_contract.parse_build_manifest(manifest)
+
+
+def test_validate_runtime_layout_checks_pins_and_every_file_hash(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    executable_payload = b"ffmpeg"
+    library_payload = b"libavcodec"
+    wheel_hash = _sha256(b"wheel")
+    policy = runtime_contract.RuntimePolicy(
+        wheel_sha256=wheel_hash,
+        executables={"ffmpeg": _sha256(executable_payload)},
+        libraries={"libavcodec.so": _sha256(library_payload)},
+        library_directory="lib",
+    )
+    monkeypatch.setitem(runtime_contract.RUNTIME_POLICIES, "linux-amd", policy)
+
+    (runtime_root / "site-packages/av").mkdir(parents=True)
+    (runtime_root / "site-packages/av/__init__.py").write_text("", encoding="utf-8")
+    (runtime_root / "bin").mkdir()
+    (runtime_root / "bin/ffmpeg").write_bytes(executable_payload)
+    (runtime_root / "lib").mkdir()
+    (runtime_root / "lib/libavcodec.so").write_bytes(library_payload)
+    (runtime_root / "runtime.json").write_text(
+        json.dumps(
+            {
+                "schema_version": runtime_contract.RUNTIME_SCHEMA_VERSION,
+                "platform": "linux-amd",
+                "wheel_sha256": wheel_hash,
+                "source_pins": dict(runtime_contract.EXPECTED_SOURCE_PINS),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runtime_contract.validate_runtime_layout(runtime_root, platform="linux")
+    assert result["platform"] == "linux-amd"
+
+    (runtime_root / "bin/ffmpeg").write_bytes(b"changed")
+    with pytest.raises(runtime_contract.RuntimeContractError, match="ffmpeg SHA256"):
+        runtime_contract.validate_runtime_layout(runtime_root, platform="linux")
+
+
+def test_runtime_manifest_rejects_wrong_wheel_before_native_imports(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    (runtime_root / "runtime.json").write_text(
+        json.dumps(
+            {
+                "schema_version": runtime_contract.RUNTIME_SCHEMA_VERSION,
+                "platform": "linux-amd",
+                "wheel_sha256": "wrong",
+                "source_pins": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(runtime_contract.RuntimeContractError, match="PyAV wheel"):
+        runtime_contract.validate_runtime_layout(runtime_root, platform="linux")
+
+
+def test_build_runtime_environment_drops_ambient_native_python_paths(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    repo_root = tmp_path / "repo"
+    python = tmp_path / "venv/bin/python"
+    runtime_root.mkdir()
+    repo_root.mkdir()
+    python.parent.mkdir(parents=True)
+    python.touch()
+    monkeypatch.setattr(runtime_contract, "validate_runtime_layout", lambda *_a, **_k: {})
+
+    environment = runtime_contract.build_runtime_environment(
+        runtime_root,
+        repo_root,
+        python_executable=python,
+        platform="linux",
+        base_environment={
+            "PATH": "/ambient/bin",
+            "PYTHONPATH": "/stale/pyav",
+            "LD_LIBRARY_PATH": "/stale/ffmpeg",
+        },
+    )
+
+    assert environment["PYTHONPATH"].split(os.pathsep) == [
+        str(runtime_root / "site-packages"),
+        str(repo_root),
+    ]
+    assert "/stale/pyav" not in environment["PYTHONPATH"]
+    assert environment["PATH"].split(os.pathsep)[:3] == [
+        str(runtime_root / "bin"),
+        str(python.parent),
+        "/opt/rocm/bin",
+    ]
+    assert "/stale/ffmpeg" not in environment["LD_LIBRARY_PATH"]
+    assert environment["JASNA_UNIFIED_RUNTIME"] == "1"
+
+
+def test_launchers_preflight_without_changing_product_batch_defaults() -> None:
+    root = Path(__file__).resolve().parents[1]
+    launcher = (root / "scripts/run_jasna_unified.py").read_text(encoding="utf-8")
+    linux = (root / "scripts/run_jasna_unified.sh").read_text(encoding="utf-8")
+    windows = (root / "scripts/run_jasna_unified_windows.ps1").read_text(
+        encoding="utf-8"
+    )
+
+    assert "validate_loaded_runtime" in launcher
+    assert "os.execve(" in launcher
+    assert "--batch-size" not in launcher
+    assert "run_jasna_unified.py" in linux
+    assert "/home/" not in linux
+    assert "-n ${JASNA_PYTHON:-}" in linux
+    assert "run_jasna_unified.py" in windows
+    assert "amf-unified-work" not in windows
+
+    from jasna.gui.models import AppSettings
+
+    assert AppSettings().batch_size == 4


### PR DESCRIPTION
## Summary

- define a cross-platform unified-runtime contract for pinned PyAV and FFmpeg builds
- add Linux and Windows source launchers that validate the runtime before starting Jasna
- document installation, diagnostics, and reproducibility expectations
- add focused contract tests

This is an independent root PR in the replacement, function-split Linux/AMD unified-pipeline series. Independent root PRs are submitted separately against `main` without waiting for this PR. Only changes that actually consume this runtime contract are held until this PR merges.

## Validation

- `python -m pytest -q tests/test_runtime_contract.py`
- Result: `6 passed`
- Replayed cleanly on upstream `main` (`27c4b77`)

## Scope

This PR introduces only the runtime contract and launchers. It does not change decode selection, encoding defaults, VR/2D auto detection, NVIDIA behavior, or the product processing pipeline.

## Follow-up PRs that depend on this PR

- **Unified runtime installer** — installs and verifies the pinned PyAV/FFmpeg runtime described by this contract.
- **Linux AMF bridge packaging** — packages the native AMF bridge into the contracted Linux runtime; it also depends on the installer, unified build pipeline, and AMF interop core.
- **Windows DLL directory registration** — registers the contracted native runtime DLL directories before importing PyAV/native modules.
- **Windows symlink privilege test** — validates installer behavior when Windows symlink privileges are unavailable; it also depends on the runtime installer.
- **Runtime-metadata consumers** — any later build, launcher, or diagnostic change that reads the metadata introduced here must declare this PR as a dependency.

These follow-ups will be submitted only after their complete dependency set is available. Temporary rocDecode fallback code is not part of this series.
