### PR TITLE
fix(pipeline): propagate worker failures without deadlock

### DIFF
--- a/docs/PIPELINE_WORKER_FAILURE_PROPAGATION_CN.md
+++ b/docs/PIPELINE_WORKER_FAILURE_PROPAGATION_CN.md
@@ -1,0 +1,17 @@
+# Pipeline worker 失败传播
+
+更新时间：2026-08-29
+
+四段处理线程（decode/detect、primary、secondary、blend/encode）以及 async secondary
+现在使用同一失败合同：第一个真实异常被记录，并立即设置共享 cancel event；后续由取消
+产生的派生异常不会覆盖根因。
+
+主线程不再对每个 worker 做无期限阻塞 `join()`。等待期间若已取消，会持续清空四条有界
+队列，让可能卡在 `put()` 的生产者获得空间并退出；健康运行时完全不触碰队列。async
+secondary 的内部 pusher 改为有超时的 `get()`，因此失败/取消时不会永久等 sentinel。
+
+最终仍由主线程在完成资源回收后重新抛出第一个 worker 异常。用户主动 Stop 不会被记录成
+worker failure，也不会生成伪根因。
+
+验收覆盖首错优先、用户取消、健康 worker 不 drain、有界队列生产者释放、async secondary
+取消路径与 pipeline 异常回抛；Linux 聚焦回归 77 passed。

--- a/jasna/pipeline.py
+++ b/jasna/pipeline.py
@@ -34,7 +34,14 @@ from jasna.media.splice import (
 from jasna.mosaic.detection_registry import build_detection_model
 from jasna.pipeline_debug_logging import PipelineDebugMemoryLogger
 from jasna.pipeline_items import FrameMeta, PrimaryRestoreResult, SecondaryLoopStats, _SENTINEL
-from jasna.pipeline_threads import decode_detect_loop, primary_restore_loop, secondary_restore_loop, blend_encode_loop
+from jasna.pipeline_threads import (
+    blend_encode_loop,
+    decode_detect_loop,
+    primary_restore_loop,
+    record_worker_error,
+    secondary_restore_loop,
+    wait_for_worker_threads,
+)
 from jasna.progressbar import Progressbar
 from jasna.restorer import RestorationPipeline
 from jasna.restorer.secondary_restorer import AsyncSecondaryRestorer
@@ -205,6 +212,7 @@ class Pipeline:
         debug_memory: PipelineDebugMemoryLogger | None = None,
         clip_queue: FrameQueue | None = None,
         primary_idle_event: threading.Event | None = None,
+        cancel_event: threading.Event | None = None,
     ) -> SecondaryLoopStats:
         restorer: AsyncSecondaryRestorer = self.restoration_pipeline.secondary_restorer  # type: ignore[assignment]
         pending_prs: dict[int, PrimaryRestoreResult] = {}
@@ -220,7 +228,12 @@ class Pipeline:
             nonlocal last_push_time, flushed_since_last_push, pusher_stall_seconds, clips_pushed
             try:
                 while True:
-                    item = secondary_queue.get()
+                    if cancel_event is not None and cancel_event.is_set():
+                        break
+                    try:
+                        item = secondary_queue.get(timeout=self._ASYNC_POLL_TIMEOUT)
+                    except Empty:
+                        continue
                     if item is _SENTINEL:
                         break
                     pr: PrimaryRestoreResult = item  # type: ignore[assignment]
@@ -279,6 +292,8 @@ class Pipeline:
         starvation_start: float | None = None
 
         while not push_done.is_set():
+            if cancel_event is not None and cancel_event.is_set():
+                break
             if pusher_error:
                 raise pusher_error[0]
 
@@ -323,6 +338,14 @@ class Pipeline:
         pusher_thread.join()
         if pusher_error:
             raise pusher_error[0]
+        if cancel_event is not None and cancel_event.is_set():
+            return SecondaryLoopStats(
+                starvation_flushes=starvation_count,
+                starvation_seconds=starvation_seconds,
+                pusher_stall_seconds=pusher_stall_seconds,
+                clips_pushed=clips_pushed,
+                clips_popped=clips_popped,
+            )
         restorer.flush_all()
         for _ in range(100):
             if not pending_prs:
@@ -396,10 +419,21 @@ class Pipeline:
             nonlocal starvation_stats
             try:
                 torch.cuda.set_device(device)
-                starvation_stats = self._run_secondary_loop(secondary_queue, encode_queue, debug_memory, clip_queue, primary_idle_event)
+                starvation_stats = self._run_secondary_loop(
+                    secondary_queue,
+                    encode_queue,
+                    debug_memory,
+                    clip_queue,
+                    primary_idle_event,
+                    self._cancel_event,
+                )
             except BaseException as e:
-                log.exception("[secondary-async] thread crashed")
-                error_holder.append(e)
+                record_worker_error(
+                    "secondary-async",
+                    e,
+                    error_holder,
+                    self._cancel_event,
+                )
             finally:
                 encode_queue.put(_SENTINEL)
 
@@ -489,8 +523,11 @@ class Pipeline:
         vram_offloader.start()
         for t in threads:
             t.start()
-        for t in threads:
-            t.join()
+        wait_for_worker_threads(
+            threads,
+            (clip_queue, secondary_queue, encode_queue, metadata_queue),
+            self._cancel_event,
+        )
         vram_offloader.stop()
         frame_writer.close()
 

--- a/jasna/pipeline_threads.py
+++ b/jasna/pipeline_threads.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections.abc import Iterable, Sequence
 from queue import Empty, Queue
-from typing import Protocol
+from typing import Any, Protocol
 
 import torch
 
@@ -23,6 +24,47 @@ from jasna.tracking.scene_detector import SceneCutDetector
 
 log = logging.getLogger(__name__)
 
+def record_worker_error(
+    label: str,
+    error: BaseException,
+    error_holder: list[BaseException],
+    cancel_event: threading.Event | None,
+) -> None:
+    """Record the first worker failure and ask the other workers to stop."""
+    if cancel_event is not None and cancel_event.is_set():
+        return
+    log.exception("[%s] thread crashed", label)
+    error_holder.append(error)
+    if cancel_event is not None:
+        cancel_event.set()
+
+
+def _drain_pipeline_queues(queues: Iterable[Any]) -> None:
+    for pipeline_queue in queues:
+        while True:
+            try:
+                pipeline_queue.get_nowait()
+            except Empty:
+                break
+
+
+def wait_for_worker_threads(
+    threads: Sequence[threading.Thread],
+    queues: Iterable[Any],
+    cancel_event: threading.Event,
+    *,
+    poll_interval: float = 0.02,
+) -> None:
+    """Join workers while releasing blocked producers during cancellation."""
+    pipeline_queues = tuple(queues)
+    while True:
+        alive = [thread for thread in threads if thread.is_alive()]
+        if not alive:
+            return
+        if cancel_event.is_set():
+            _drain_pipeline_queues(pipeline_queues)
+        for thread in alive:
+            thread.join(timeout=poll_interval)
 
 class FrameWriter(Protocol):
     def write(self, frame: torch.Tensor, pts: int, *, apply_lut: bool = True) -> None: ...
@@ -217,9 +259,7 @@ def decode_detect_loop(
                 if progress is not None and close_progress:
                     progress.close(ensure_completed_bar=True)
     except BaseException as e:
-        if cancel_event is None or not cancel_event.is_set():
-            log.exception("[decode] thread crashed")
-            error_holder.append(e)
+        record_worker_error("decode", e, error_holder, cancel_event)
     finally:
         log.info(timer.summary())
         log.debug("[decode] thread exiting")
@@ -278,9 +318,7 @@ def primary_restore_loop(
                     f"clip={clip_item.clip.track_id} frames={len(clip_item.raw_crops)}",
                 )
     except BaseException as e:
-        if cancel_event is None or not cancel_event.is_set():
-            log.exception("[primary] thread crashed")
-            error_holder.append(e)
+        record_worker_error("primary", e, error_holder, cancel_event)
     finally:
         log.info(timer.summary())
         log.debug("[primary] thread exiting")
@@ -332,9 +370,7 @@ def secondary_restore_loop(
                     f"clip={pr.track_id} frames={sr.frame_count}",
                 )
     except BaseException as e:
-        if cancel_event is None or not cancel_event.is_set():
-            log.exception("[secondary] thread crashed")
-            error_holder.append(e)
+        record_worker_error("secondary", e, error_holder, cancel_event)
     finally:
         log.info(timer.summary())
         log.debug("[secondary] thread exiting")
@@ -442,9 +478,7 @@ def blend_encode_loop(
                 vram_offloader.pause_stall_check()
 
     except BaseException as e:
-        if cancel_event is None or not cancel_event.is_set():
-            log.exception("[blend-encode] thread crashed")
-            error_holder.append(e)
+        record_worker_error("blend-encode", e, error_holder, cancel_event)
     finally:
         log.info(timer.summary())
 

--- a/tests/test_pipeline_run.py
+++ b/tests/test_pipeline_run.py
@@ -525,6 +525,7 @@ class TestPipelineRun:
         ):
             with pytest.raises(RuntimeError, match="secondary boom"):
                 p.run()
+        assert p.cancel_requested
 
     def test_run_secondary_loop(self):
         """Cover _run_secondary_loop: push_clip → flush → pop_completed → build_secondary_result."""

--- a/tests/test_pipeline_threads.py
+++ b/tests/test_pipeline_threads.py
@@ -22,9 +22,11 @@ from jasna.pipeline_threads import (
     FrameWriter,
     decode_detect_loop,
     primary_restore_loop,
+    record_worker_error,
     secondary_restore_loop,
     blend_encode_loop,
     _estimate_start_frame,
+    wait_for_worker_threads,
 )
 from jasna.tracking.clip_tracker import TrackedClip
 
@@ -84,6 +86,119 @@ class TestEstimateStartFrame:
     def test_zero(self):
         meta = _fake_metadata(fps=24.0)
         assert _estimate_start_frame(meta, 0.0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Worker failure shutdown
+# ---------------------------------------------------------------------------
+
+class TestWorkerFailureShutdown:
+    def test_record_worker_error_keeps_first_failure_and_cancels_peers(self):
+        cancel_event = threading.Event()
+        error_holder: list[BaseException] = []
+        first_error = RuntimeError("first worker failure")
+        try:
+            raise first_error
+        except RuntimeError as error:
+            record_worker_error("primary", error, error_holder, cancel_event)
+        try:
+            raise RuntimeError("second worker failure")
+        except RuntimeError as error:
+            record_worker_error("secondary", error, error_holder, cancel_event)
+        assert error_holder == [first_error]
+        assert cancel_event.is_set()
+
+    def test_record_worker_error_ignores_user_initiated_cancellation(self):
+        cancel_event = threading.Event()
+        cancel_event.set()
+        error_holder: list[BaseException] = []
+        try:
+            raise RuntimeError("cancelled worker")
+        except RuntimeError as error:
+            record_worker_error("decode", error, error_holder, cancel_event)
+        assert not error_holder
+
+    def test_wait_for_worker_threads_drains_queue_and_joins_cancelled_workers(self):
+        class TrackingFrameQueue:
+            def __init__(self):
+                self._queue = FrameQueue(max_frames=1)
+                self.drain_calls = 0
+
+            def put(self, item, frame_count=0):
+                self._queue.put(item, frame_count=frame_count)
+
+            def get_nowait(self):
+                self.drain_calls += 1
+                return self._queue.get_nowait()
+
+        cancel_event = threading.Event()
+        pipeline_queue = TrackingFrameQueue()
+        pipeline_queue.put("occupied", frame_count=1)
+        producer_entered = threading.Event()
+        producer_released = threading.Event()
+        peer_entered = threading.Event()
+        peer_released = threading.Event()
+
+        def blocked_producer():
+            producer_entered.set()
+            pipeline_queue.put("released", frame_count=1)
+            producer_released.set()
+
+        def peer_worker():
+            peer_entered.set()
+            cancel_event.wait(timeout=2)
+            peer_released.set()
+
+        threads = [
+            threading.Thread(target=blocked_producer),
+            threading.Thread(target=peer_worker),
+        ]
+        for thread in threads:
+            thread.start()
+        assert producer_entered.wait(timeout=1)
+        assert peer_entered.wait(timeout=1)
+        cancel_event.set()
+        wait_for_worker_threads(
+            threads,
+            (pipeline_queue,),
+            cancel_event,
+            poll_interval=0.001,
+        )
+        assert pipeline_queue.drain_calls >= 1
+        assert producer_released.is_set()
+        assert peer_released.is_set()
+        assert all(not thread.is_alive() for thread in threads)
+
+    def test_wait_for_worker_threads_does_not_drain_healthy_workers(self):
+        class NoDrainQueue:
+            def __init__(self):
+                self.drain_calls = 0
+
+            def get_nowait(self):
+                self.drain_calls += 1
+                raise AssertionError("healthy queues must not be drained")
+
+        worker_started = threading.Event()
+        worker_finished = threading.Event()
+
+        def healthy_worker():
+            worker_started.set()
+            time.sleep(0.03)
+            worker_finished.set()
+
+        thread = threading.Thread(target=healthy_worker)
+        thread.start()
+        assert worker_started.wait(timeout=1)
+        pipeline_queue = NoDrainQueue()
+        wait_for_worker_threads(
+            [thread],
+            (pipeline_queue,),
+            threading.Event(),
+            poll_interval=0.001,
+        )
+        assert worker_finished.is_set()
+        assert pipeline_queue.drain_calls == 0
+        assert not thread.is_alive()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- propagate the first pipeline worker exception back to the main processing thread
- cancel peer workers and drain bounded queues so producer failures cannot deadlock shutdown
- preserve user-initiated cancellation semantics
- add focused worker-failure and shutdown tests

This is an independent root PR in the replacement function-split series and is based directly on `main`.

## Validation

- `/home/latiao/vr_toolbox_jasna_linux/.venv/bin/python -m pytest -q tests/test_pipeline_run.py tests/test_pipeline_threads.py`
- Result: `69 passed`
- `git diff --check upstream/main...HEAD`
- Exactly one commit above upstream `main`

## Scope

This PR changes only generic pipeline worker failure propagation and bounded-queue shutdown. It does not include Smart Render PTS recovery, decoder selection, AMF interop, encoding changes, or temporary rocDecode fallback logic.

## Follow-up PRs that depend on this PR

- **TVAI bounded cancellation** — forwards the shared `cancel_event` through TVAI subprocess/model operations so a worker failure or user cancellation terminates that bounded workload without leaving the pipeline blocked.
- **Durable final-output Stop/cancel integration** — publishes or cleans final outputs only after every worker has converged, so a failed worker cannot leave the GUI waiting or expose an incomplete result; Smart Render variants also depend on the separate timestamp/seam root.

Other independent root PRs do not depend on this PR and may be reviewed or merged separately.
