### PR TITLE
fix(amf): ignore absent optional decoder timing

### DIFF
--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -363,8 +363,13 @@ class NvidiaVideoReader:
             decoder.height = source_ctx.height
             # PyAV 18 rejects assigning time_base on a decoder ("Cannot access
             # 'time_base' as a decoder"); decoders take timing from packets.
-            decoder.framerate = source_ctx.framerate
-            decoder.sample_aspect_ratio = source_ctx.sample_aspect_ratio
+            # Source contexts in the accepted runtime can legitimately omit
+            # container framerate/SAR. Packets carry timing; assigning None
+            # makes PyAV reject an otherwise valid decoder before it opens.
+            if source_ctx.framerate is not None:
+                decoder.framerate = source_ctx.framerate
+            if source_ctx.sample_aspect_ratio is not None:
+                decoder.sample_aspect_ratio = source_ctx.sample_aspect_ratio
             decoder.open(strict=False)
             self._decoder_ctx = decoder
             self._amd_hardware_decode = True

--- a/tests/test_amd_support.py
+++ b/tests/test_amd_support.py
@@ -346,6 +346,50 @@ def test_amf_decoder_survives_pyav18_time_base_regression(monkeypatch) -> None:
     assert reader._amd_hardware_decode is True
 
 
+def test_amf_decoder_ignores_missing_optional_timing_metadata(monkeypatch) -> None:
+    import jasna.media.video_decoder as module
+
+    class FakeDecoder:
+        def __init__(self):
+            object.__setattr__(self, "opened", False)
+
+        def __setattr__(self, name, value):
+            if name in {"framerate", "sample_aspect_ratio"}:
+                raise AssertionError(f"optional metadata was assigned: {name}={value!r}")
+            object.__setattr__(self, name, value)
+
+        def open(self, strict=False):
+            assert strict is False
+            object.__setattr__(self, "opened", True)
+
+    decoder = FakeDecoder()
+    monkeypatch.setattr(
+        module.av,
+        "CodecContext",
+        SimpleNamespace(create=MagicMock(return_value=decoder)),
+    )
+    reader = module.NvidiaVideoReader(
+        "input.mp4",
+        4,
+        torch.device("cuda:0"),
+        _metadata(),
+    )
+    source = SimpleNamespace(
+        name="h264",
+        extradata=b"header",
+        width=16,
+        height=16,
+        time_base=Fraction(1, 30),
+        framerate=None,
+        sample_aspect_ratio=None,
+        thread_type=None,
+    )
+    reader._setup_amf_decoder(source)
+    assert decoder.opened is True
+    assert reader._decoder_ctx is decoder
+    assert reader._amd_hardware_decode is True
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a GPU")
 def test_yuv_eager_converter_runs_on_gpu_planes(monkeypatch) -> None:
     import jasna.media.yuv_to_rgb as module


### PR DESCRIPTION
## Summary

- avoid assigning optional decoder framerate and sample-aspect-ratio fields when the source metadata omits them
- keep packet timing as the authoritative decoder timing source
- add a regression test for PyAV/AMF decoder setup with absent optional timing metadata

This is an independent root PR based directly on `main`.

## Validation

- `/home/latiao/vr_toolbox_jasna_linux/.venv/bin/python -m pytest -q tests/test_amd_support.py`
- Result: `26 passed`
- `git diff --check upstream/main...HEAD`
- Exactly one commit above upstream `main`

## Scope

This PR only hardens the existing AMF decoder setup against valid missing container metadata. It does not change decoder auto-selection, add new AMF interop, alter NVIDIA behavior, or introduce temporary rocDecode fallback logic.

## Follow-up PRs that depend on this PR

- **Unified AMF auto-decode rollout and media-format acceptance** — later product routing must be able to open valid H.264/HEVC sources whose container omits framerate or sample-aspect-ratio before AMF can replace legacy rocDecode selection broadly.

The AMF interop core and other independent root PRs do not depend on this fix and may be reviewed separately.
