### PR TITLE
build: add reproducible FFmpeg/PyAV artifact builders

### DIFF
--- a/docs/UNIFIED_BUILD_PIPELINE_CN.md
+++ b/docs/UNIFIED_BUILD_PIPELINE_CN.md
@@ -1,0 +1,152 @@
+# 统一 FFmpeg / PyAV 构建流水线
+
+更新时间：2026-08-29
+
+## 范围
+
+本页描述两个**显式运行**的构建器：
+
+- Linux：`scripts/build_unified_ffmpeg_pyav_ubuntu.sh`
+- Windows：`scripts/build_unified_ffmpeg_pyav_windows.ps1`
+
+它们只从固定源码构建一组共享 FFmpeg 库、`ffmpeg`/`ffprobe` 和 PyAV wheel，并写出
+`build-manifest.txt`。它们不会安装 runtime、不会改变默认解码/编码路由，也不会接入
+AMF bridge、MIGraphX、Smart Render 或 GUI。
+
+runtime 合同和安装器由后续独立 PR 提供：前者定义可接受 runtime，后者只安装已经通过其
+pin 与哈希检查的构建产物。本流水线与后续安装器之间唯一的预期交接物是构建目录及其中的
+`build-manifest.txt`；不要为了安装新构建而修改 runtime 合同或安装器。
+
+## 固定源码
+
+所有源码 checkout 必须恰好位于下表 commit。构建器在开始时验证 `HEAD`，不接受分支名、
+tag 或近似版本。
+
+| 组件 | 固定 commit | Linux | Windows |
+|---|---|:---:|:---:|
+| FFmpeg | `44d082edc87381d978e8588b148116b99fefdb43` | 是 | 是 |
+| PyAV | `7e3d950a8b72062502c1a60d672f8ca565313af5` | 是 | 是 |
+| AMF headers | `c35f613aea2e5057a688c979e75b1cf24253297e` | 是 | 是 |
+| dav1d | `b546257f770768b2c88258c533da38b91a06f737` | 否 | 是 |
+
+> 源码 checkout 必须可丢弃。两个构建器都会在 FFmpeg checkout 中应用所选补丁；Windows
+> 还会把补丁目标转换为 LF，并在固定的 `configure` 中做 MSVC 兼容性替换。请使用工作副本，
+> 不要指向唯一的干净源码树。
+
+## FFmpeg 补丁
+
+`0001` 总是应用。其余补丁全部需要明确选项，避免把研究性行为变成默认构建行为。
+
+| 补丁 | 作用 | 默认 |
+|---|---|---|
+| `0001-amf-transfer-use-context-sw-format.patch` | AMF transfer 仅声明当前 frames context 的 `sw_format` | 始终应用 |
+| `0002-amfdec-replace-stale-frames-context.patch` | 实际 surface 格式或尺寸与旧 context 不同时分配并替换 frames context | `--apply-frames-context-fix` / `-ApplyFramesContextFix` |
+| `0003-amfdec-fix-dynamic-resolution-reinit.patch` | 分辨率变化时 `Terminate()` 后以未知尺寸 `Init()`，并启用 HEVC Annex-B BSF | `--apply-dynamic-resolution-fix` / `-ApplyDynamicResolutionFix`；自动包含 `0002` |
+| `0004-matroska-projection-tag-spherical.patch` | 仅当 coded spherical side data 缺失时，从 `projection=equirectangular` metadata 回退 | `--apply-spherical-metadata-patch` / `-ApplySphericalMetadataPatch` |
+
+每个补丁均通过 `git apply --check` 处理；若已应用，构建器会用反向 check 接受它，而不是
+重复应用。若 checkout 既不匹配原始源码也不匹配已应用补丁，构建会停止。
+
+## Linux（Ubuntu）
+
+准备 Git、Bash、GNU Make、可用的 C/C++ 构建工具、Python/PyAV wheel 构建依赖，以及
+Vulkan headers。默认会查找 `/usr/include/vulkan/vulkan.h`；如 headers 在别处，显式传入
+`--vulkan-headers`。AMF checkout 可以是包含 `AMF/core/Factory.h` 的布局，也可以使用上游
+`amf/public/include` 布局。
+
+最小构建示例：
+
+```bash
+./scripts/build_unified_ffmpeg_pyav_ubuntu.sh \
+  --ffmpeg-source /work/src/ffmpeg \
+  --pyav-source /work/src/pyav \
+  --amf-source /work/src/AMF \
+  --output-root /work/out/unified-linux \
+  --python /work/venv/bin/python \
+  --jobs 16
+```
+
+要试验动态分辨率修复与 Matroska metadata 回退，额外加入：
+
+```bash
+  --apply-dynamic-resolution-fix \
+  --apply-spherical-metadata-patch
+```
+
+输出目录的稳定部分如下：
+
+```text
+unified-linux/
+├── build-manifest.txt
+├── ffmpeg-install/
+│   ├── bin/ffmpeg
+│   ├── bin/ffprobe
+│   └── lib/
+└── wheels/
+    └── av-*.whl
+```
+
+构建成功不等同于 runtime 已接受。只有当 runtime 合同与安装器的后续 PR 合入，且 wheel
+和 FFmpeg 文件哈希符合合同白名单时，才可把同一输出目录交给安装器，例如：
+
+```bash
+python3 scripts/install_unified_runtime.py \
+  --build-root /work/out/unified-linux \
+  --target-root /work/out/runtime-test
+```
+
+后续安装器会独立验证 manifest 中的固定 pin、wheel 和动态库；拒绝时应保留构建目录以便
+诊断，而不是放宽合同或静默使用系统 PyAV。
+
+## Windows
+
+Windows 构建需要：PowerShell、Git、Python（能够运行 `python -m mesonbuild.mesonmain`）、
+Ninja、Visual Studio 的 x64 MSVC 工具链与 `VsDevCmd.bat`、以及包含 `bash.exe` 和
+`cygpath.exe` 的 MSYS2。dav1d 会通过 Meson/Ninja 以 shared library 方式构建，之后
+`dav1d.dll` 会复制到 `ffmpeg-install\\bin`。
+
+使用 ASCII 路径的独立工作目录。当前脚本生成的 `.cmd` 文件使用 ASCII 编码，因此不声明
+非 ASCII 路径可用；如本机 VS 安装位置不同，请明确传入 `-VsDevCmd`。
+
+```powershell
+.\scripts\build_unified_ffmpeg_pyav_windows.ps1 `
+  -FfmpegSource D:\work\src\ffmpeg `
+  -PyAvSource D:\work\src\pyav `
+  -AmfSource D:\work\src\AMF `
+  -Dav1dSource D:\work\src\dav1d `
+  -OutputRoot D:\work\out\unified-windows `
+  -Python D:\work\venv\Scripts\python.exe `
+  -Ninja ninja `
+  -MsysRoot C:\msys64 `
+  -VsDevCmd 'C:\Program Files\Microsoft Visual Studio\18\Community\Common7\Tools\VsDevCmd.bat' `
+  -Jobs 16
+```
+
+可选修复使用 PowerShell switch，例如：
+
+```powershell
+  -ApplyFramesContextFix
+  -ApplyDynamicResolutionFix
+  -ApplySphericalMetadataPatch
+```
+
+Windows 输出与 Linux 同样包含 `build-manifest.txt`、`wheels\av-*.whl` 和
+`ffmpeg-install`；Windows DLL（包括 `dav1d.dll`）位于 `ffmpeg-install\bin`，FFmpeg
+import libraries 位于 `ffmpeg-install\lib`。后续安装器合入后，将其安装到测试 runtime
+时必须传入 `--platform win32`：
+
+```powershell
+D:\work\venv\Scripts\python.exe scripts\install_unified_runtime.py `
+  --build-root D:\work\out\unified-windows `
+  --target-root D:\work\out\runtime-test `
+  --platform win32
+```
+
+## 当前验证边界
+
+本轮已在 Linux 上进行脚本静态测试、Ubuntu Bash 语法/帮助检查，以及针对固定 FFmpeg
+commit 的四个补丁应用检查。它不是 AMD 实机视频验收。
+
+Windows 的真实构建、生成 DLL 的加载/ABI 验证、以及 PowerShell parser/static-analyzer
+验证仍必须在 Windows 环境完成；在完成前，不应把 Windows 产物或这组可选补丁宣称为已通过
+Windows 实机验收。

--- a/patches/ffmpeg/0001-amf-transfer-use-context-sw-format.patch
+++ b/patches/ffmpeg/0001-amf-transfer-use-context-sw-format.patch
@@ -1,0 +1,37 @@
+From: Jasna Phase 0 research <research@jasna.local>
+Subject: [PATCH] avutil/hwcontext_amf: advertise the context transfer format
+
+AMF transfer_data_to() and transfer_data_from() both require the software
+frame format to equal AVHWFramesContext.sw_format.  Advertising every AMF
+software format makes generic callers select NV12 for a P010 context and then
+fail with EINVAL.
+
+Keep the existing transfer whitelist as validation, but advertise only the
+single format that the initialized frame context can actually transfer.
+---
+ libavutil/hwcontext_amf.c | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/libavutil/hwcontext_amf.c b/libavutil/hwcontext_amf.c
+index 754b1c6..592fcc4 100644
+--- a/libavutil/hwcontext_amf.c
++++ b/libavutil/hwcontext_amf.c
+@@ -424,8 +424,15 @@ static int amf_transfer_get_formats(AVHWFramesContext *ctx,
+
+-    fmts = av_malloc_array(FF_ARRAY_ELEMS(supported_transfer_formats), sizeof(*fmts));
++    for (i = 0; supported_transfer_formats[i] != AV_PIX_FMT_NONE; i++) {
++        if (ctx->sw_format == supported_transfer_formats[i])
++            break;
++    }
++    if (supported_transfer_formats[i] == AV_PIX_FMT_NONE)
++        return AVERROR(ENOSYS);
++
++    fmts = av_malloc_array(2, sizeof(*fmts));
+     if (!fmts)
+         return AVERROR(ENOMEM);
+-    for (i = 0; i < FF_ARRAY_ELEMS(supported_transfer_formats); i++)
+-        fmts[i] = supported_transfer_formats[i];
+
++    fmts[0] = ctx->sw_format;
++    fmts[1] = AV_PIX_FMT_NONE;
+     *formats = fmts;

--- a/patches/ffmpeg/0002-amfdec-replace-stale-frames-context.patch
+++ b/patches/ffmpeg/0002-amfdec-replace-stale-frames-context.patch
@@ -1,0 +1,90 @@
+From: Jasna AMF research <research@jasna.local>
+Subject: [PATCH] avcodec/amfdec: replace stale frames context from actual surface
+
+Some decoders cannot report their output format before the first packet has
+been submitted.  In that case amf_decode_init() falls back to NV12 when it
+initializes AVCodecContext.hw_frames_ctx.  A Main10 AV1 decoder may then return
+a P010 AMFSurface, but amf_amfsurface_to_avframe() only updates sw_pix_fmt and
+attaches the stale NV12 frames context to the frame.  Hardware download copies
+the P010 surface with the NV12 layout and corrupts the result.
+
+Compare the initialized frames context with the actual surface format before
+attaching it.  Allocate and initialize a matching replacement instead of
+mutating the potentially shared old context; existing references can therefore
+keep the old context alive safely.
+---
+ libavcodec/amfdec.c | 52 +++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 52 insertions(+)
+
+diff --git a/libavcodec/amfdec.c b/libavcodec/amfdec.c
+index 38fae3f..d84cccd 100644
+--- a/libavcodec/amfdec.c
++++ b/libavcodec/amfdec.c
+@@ -240,6 +240,51 @@ static int amf_init_frames_context(AVCodecContext *avctx, int sw_format, int new
+     return 0;
+ }
+
++static int amf_replace_frames_context(AVCodecContext *avctx,
++                                      enum AVPixelFormat sw_format,
++                                      int new_width, int new_height)
++{
++    AVBufferRef *old_frames_ref = avctx->hw_frames_ctx;
++    AVBufferRef *new_frames_ref;
++    int ret;
++
++    if (!old_frames_ref || !avctx->hw_device_ctx)
++        return 0;
++
++    new_frames_ref = av_hwframe_ctx_alloc(avctx->hw_device_ctx);
++    if (!new_frames_ref)
++        return AVERROR(ENOMEM);
++
++    avctx->hw_frames_ctx = new_frames_ref;
++    ret = amf_init_frames_context(avctx, sw_format, new_width, new_height);
++    if (ret < 0) {
++        avctx->hw_frames_ctx = old_frames_ref;
++        return ret;
++    }
++
++    av_buffer_unref(&old_frames_ref);
++    return 0;
++}
++
++static int amf_ensure_frames_context(AVCodecContext *avctx,
++                                     enum AVPixelFormat sw_format,
++                                     int width, int height)
++{
++    AVHWFramesContext *frames_ctx;
++
++    if (!avctx->hw_frames_ctx)
++        return 0;
++    if (sw_format == AV_PIX_FMT_NONE)
++        return AVERROR(EINVAL);
++
++    frames_ctx = (AVHWFramesContext *)avctx->hw_frames_ctx->data;
++    if (frames_ctx->sw_format == sw_format &&
++        frames_ctx->width == width && frames_ctx->height == height)
++        return 0;
++
++    return amf_replace_frames_context(avctx, sw_format, width, height);
++}
++
+ static int amf_decode_init(AVCodecContext *avctx)
+ {
+     AMFDecoderContext *ctx = avctx->priv_data;
+@@ -374,8 +419,15 @@ static int amf_amfsurface_to_avframe(AVCodecContext *avctx, AMFSurface* surface,
+         frame->data[0] = (uint8_t *)surface;
+         frame->format =  AV_PIX_FMT_AMF_SURFACE;
+         format_amf = surface->pVtbl->GetFormat(surface);
++        ret = amf_ensure_frames_context(avctx,
++                                        av_amf_to_av_format(format_amf),
++                                        avctx->width, avctx->height);
++        if (ret < 0)
++            return ret;
+         avctx->sw_pix_fmt = av_amf_to_av_format(format_amf);
+         frame->hw_frames_ctx = av_buffer_ref(avctx->hw_frames_ctx);
++        AMF_RETURN_IF_FALSE(avctx, !!frame->hw_frames_ctx, AVERROR(ENOMEM),
++                            "av_buffer_ref for AMF frames context failed.");
+     } else {
+         ret = surface->pVtbl->Convert(surface, AMF_MEMORY_HOST);
+         AMF_RETURN_IF_FALSE(avctx, ret == AMF_OK, AVERROR_UNKNOWN, "Convert(amf::AMF_MEMORY_HOST) failed with error %d\n", ret);

--- a/patches/ffmpeg/0003-amfdec-fix-dynamic-resolution-reinit.patch
+++ b/patches/ffmpeg/0003-amfdec-fix-dynamic-resolution-reinit.patch
@@ -1,0 +1,85 @@
+From: Jasna AMF research <research@jasna.local>
+Subject: [PATCH] avcodec/amfdec: restart decoder with unknown dimensions
+
+AMF_RESOLUTION_CHANGED requires the client to drain, terminate, and initialize
+the decoder.  amfdec instead calls ReInit() with AMF's still-current old size,
+which pins the retained input packet to that size and can also leave
+libavcodec with simultaneous send/receive EAGAIN.
+
+Follow the AMF state-machine contract and initialize with unknown dimensions so
+the retained packet's new sequence header selects the new size and bit depth.
+Refresh AVCodecContext dimensions immediately after that packet is accepted;
+the frames-context fix then replaces the stale pool when the new surface is
+returned.
+
+Also pass HEVC through hevc_mp4toannexb, as the AMF parser loses the container
+extradata when it is terminated and must be able to parse the retained packet
+by itself.
+---
+ libavcodec/amfdec.c | 33 ++++++++++++++++-----------------
+ 1 file changed, 16 insertions(+), 17 deletions(-)
+
+diff --git a/libavcodec/amfdec.c b/libavcodec/amfdec.c
+index d84cccd..ee24cfc 100644
+--- a/libavcodec/amfdec.c
++++ b/libavcodec/amfdec.c
+@@ -634,6 +634,8 @@ static int amf_decode_frame(AVCodecContext *avctx, struct AVFrame *frame)
+             av_log(avctx, AV_LOG_ERROR, "SubmitInput() returned error %d\n", res);
+             return AVERROR(EINVAL);
+         }
++        if (!ctx->drain && !ctx->dimensions_initialized)
++            amf_init_dimensions(avctx);
+     }
+
+     res = amf_receive_frame(avctx, frame);
+@@ -649,29 +651,26 @@ static int amf_decode_frame(AVCodecContext *avctx, struct AVFrame *frame)
+         ctx->drain = 0;
+         if(ctx->resolution_changed){
+             // re-initialze decoder
+-            AMFVariantStruct    size_var = {0};
+-            AMFVariantStruct    format_var = {0};
+-            res = ctx->decoder->pVtbl->GetProperty(ctx->decoder, AMF_VIDEO_DECODER_CURRENT_SIZE, &size_var);
++            res = ctx->decoder->pVtbl->Terminate(ctx->decoder);
+             if (res != AMF_OK) {
++                av_log(avctx, AV_LOG_ERROR, "Terminate() returned %d during resolution change\n", res);
+                 return AVERROR(EINVAL);
+             }
+
+-            avctx->width = size_var.sizeValue.width;
+-            avctx->height = size_var.sizeValue.height;
+-            avctx->coded_width  = size_var.sizeValue.width;
+-            avctx->coded_height = size_var.sizeValue.height;
+-            res = ctx->decoder->pVtbl->ReInit(ctx->decoder, avctx->width, avctx->height);
+-            if (res != AMF_OK) {
+-                av_log(avctx, AV_LOG_ERROR, "ReInit() returned %d\n", res);
+-                return AVERROR(EINVAL);
+-            }
+-            res = ctx->decoder->pVtbl->GetProperty(ctx->decoder, AMF_VIDEO_DECODER_OUTPUT_FORMAT, &format_var);
++            /* The retained packet carries the new sequence header.  Passing
++             * the old dimensions to Init() pins the replacement sequence to
++             * the old size, so let AMF discover both dimensions from it. */
++            avctx->width = 0;
++            avctx->height = 0;
++            avctx->coded_width = 0;
++            avctx->coded_height = 0;
++            ctx->dimensions_initialized = 0;
++            res = ctx->decoder->pVtbl->Init(ctx->decoder, AMF_SURFACE_UNKNOWN,
++                                            0, 0);
+             if (res != AMF_OK) {
++                av_log(avctx, AV_LOG_ERROR, "Init() returned %d during resolution change\n", res);
+                 return AVERROR(EINVAL);
+             }
+-            int ret = amf_init_frames_context(avctx, av_amf_to_av_format(format_var.int64Value), avctx->coded_width, avctx->coded_height);
+-            if (ret < 0)
+-                return ret;
+         }else
+             return AVERROR_EOF;
+     } else {
+@@ -741,6 +740,6 @@ const FFCodec ff_##x##_amf_decoder = { \
+ }; \
+
+ DEFINE_AMF_DECODER(h264, H264, "h264_mp4toannexb")
+-DEFINE_AMF_DECODER(hevc, HEVC, NULL)
++DEFINE_AMF_DECODER(hevc, HEVC, "hevc_mp4toannexb")
+ DEFINE_AMF_DECODER(vp9, VP9, NULL)
+ DEFINE_AMF_DECODER(av1, AV1, NULL)

--- a/patches/ffmpeg/0004-matroska-projection-tag-spherical.patch
+++ b/patches/ffmpeg/0004-matroska-projection-tag-spherical.patch
@@ -1,0 +1,65 @@
+diff --git a/libavformat/matroskaenc.c b/libavformat/matroskaenc.c
+index c9386db6a0..1f1ee21e74 100644
+--- a/libavformat/matroskaenc.c
++++ b/libavformat/matroskaenc.c
+@@ -1508,18 +1508,27 @@ ignore:
+ }
+
+ static int mkv_handle_spherical(void *logctx, EbmlWriter *writer,
+-                                const AVCodecParameters *par, uint8_t private[],
++                                const AVCodecParameters *par,
++                                const AVDictionary *metadata, uint8_t private[],
+                                 double *yaw, double *pitch, double *roll)
+ {
+     const AVPacketSideData *sd = av_packet_side_data_get(par->coded_side_data,
+                                                          par->nb_coded_side_data,
+                                                          AV_PKT_DATA_SPHERICAL);
++    const AVDictionaryEntry *tag;
+     const AVSphericalMapping *spherical;
++    const AVSphericalMapping tag_spherical = {
++        .projection = AV_SPHERICAL_EQUIRECTANGULAR,
++    };
+
+-    if (!sd)
+-        return 0;
+-
+-    spherical = (const AVSphericalMapping *)sd->data;
++    if (sd) {
++        spherical = (const AVSphericalMapping *)sd->data;
++    } else {
++        tag = av_dict_get(metadata, "projection", NULL, 0);
++        if (!tag || av_strcasecmp(tag->value, "equirectangular"))
++            return 0;
++        spherical = &tag_spherical;
++    }
+     if (spherical->projection != AV_SPHERICAL_EQUIRECTANGULAR      &&
+         spherical->projection != AV_SPHERICAL_EQUIRECTANGULAR_TILE &&
+         spherical->projection != AV_SPHERICAL_CUBEMAP) {
+@@ -1569,6 +1578,7 @@ static int mkv_handle_spherical(void *logctx, EbmlWriter *writer,
+
+ static void mkv_write_video_projection(void *logctx, EbmlWriter *wr,
+                                        const AVCodecParameters *par,
++                                       const AVDictionary *metadata,
+                                        uint8_t private[])
+ {
+     double yaw = 0, pitch = 0, roll = 0;
+@@ -1576,7 +1586,8 @@ static void mkv_write_video_projection(void *logctx, EbmlWriter *wr,
+
+     ebml_writer_open_master(wr, MATROSKA_ID_VIDEOPROJECTION);
+
+-    ret = mkv_handle_spherical(logctx, wr, par, private, &yaw, &pitch, &roll);
++    ret = mkv_handle_spherical(logctx, wr, par, metadata, private,
++                               &yaw, &pitch, &roll);
+     if (!ret)
+         mkv_handle_rotation(logctx, par, &yaw, &roll);
+
+@@ -1925,7 +1936,8 @@ static int mkv_write_track_video(AVFormatContext *s, MatroskaMuxContext *mkv,
+                             color_space, sizeof(color_space));
+     }
+     mkv_write_video_color(&writer, st, par);
+-    mkv_write_video_projection(s, &writer, par, projection_private);
++    mkv_write_video_projection(s, &writer, par, st->metadata,
++                               projection_private);
+
+     return ebml_writer_write(&writer, pb);
+ }

--- a/scripts/build_unified_ffmpeg_pyav_ubuntu.sh
+++ b/scripts/build_unified_ffmpeg_pyav_ubuntu.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+
+# Build one Linux AMD FFmpeg/PyAV ABI unit from the accepted source pins.
+#
+# The output is deliberately only a build artifact. Installation and runtime
+# selection remain separate responsibilities of the existing installer and
+# runtime contract, respectively.
+
+set -euo pipefail
+
+export PATH=/usr/bin:/bin:${PATH:-}
+unset PKG_CONFIG_SYSROOT_DIR
+
+usage() {
+  cat <<'EOF'
+Usage:
+  build_unified_ffmpeg_pyav_ubuntu.sh \
+    --ffmpeg-source PATH --pyav-source PATH --amf-source PATH \
+    --output-root PATH [--python PYTHON] [--jobs N] \
+    [--vulkan-headers PATH] [--apply-frames-context-fix] \
+    [--apply-dynamic-resolution-fix] \
+    [--apply-spherical-metadata-patch]
+
+Build a shared FFmpeg and PyAV wheel from the accepted FFmpeg, PyAV, and AMF
+source commits. Source checkouts must be disposable: this script applies the
+selected FFmpeg patches in place, but accepts a patch that is already applied.
+
+--apply-dynamic-resolution-fix also applies the frames-context fix it depends
+on. The spherical metadata patch is opt-in and enables its Matroska metadata
+fallback without changing the default decoder-only patch set.
+EOF
+}
+
+require_option_value() {
+  if (($# < 2)); then
+    printf 'Option %s requires a value.\n' "$1" >&2
+    exit 2
+  fi
+}
+
+ffmpeg_source=
+pyav_source=
+amf_source=
+output_root=
+vulkan_headers=
+apply_frames_context_fix=false
+apply_dynamic_resolution_fix=false
+apply_spherical_metadata_patch=false
+python=python3
+jobs=1
+if command -v nproc >/dev/null 2>&1; then
+  jobs=$(nproc)
+elif command -v getconf >/dev/null 2>&1; then
+  jobs=$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '1')
+fi
+
+while (($#)); do
+  case "$1" in
+    --ffmpeg-source)
+      require_option_value "$@"
+      ffmpeg_source=$2
+      shift 2
+      ;;
+    --pyav-source)
+      require_option_value "$@"
+      pyav_source=$2
+      shift 2
+      ;;
+    --amf-source)
+      require_option_value "$@"
+      amf_source=$2
+      shift 2
+      ;;
+    --output-root)
+      require_option_value "$@"
+      output_root=$2
+      shift 2
+      ;;
+    --vulkan-headers)
+      require_option_value "$@"
+      vulkan_headers=$2
+      shift 2
+      ;;
+    --python)
+      require_option_value "$@"
+      python=$2
+      shift 2
+      ;;
+    --jobs)
+      require_option_value "$@"
+      jobs=$2
+      shift 2
+      ;;
+    --apply-frames-context-fix)
+      apply_frames_context_fix=true
+      shift
+      ;;
+    --apply-dynamic-resolution-fix)
+      apply_dynamic_resolution_fix=true
+      shift
+      ;;
+    --apply-spherical-metadata-patch)
+      apply_spherical_metadata_patch=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n $ffmpeg_source && -n $pyav_source && -n $amf_source && -n $output_root ]] || {
+  usage >&2
+  exit 2
+}
+[[ $jobs =~ ^[1-9][0-9]*$ ]] || {
+  printf '%s\n' '--jobs must be a positive integer.' >&2
+  exit 2
+}
+
+ffmpeg_source=$(realpath "$ffmpeg_source")
+pyav_source=$(realpath "$pyav_source")
+amf_source=$(realpath "$amf_source")
+mkdir -p "$output_root"
+output_root=$(realpath "$output_root")
+
+readonly expected_ffmpeg=44d082edc87381d978e8588b148116b99fefdb43
+readonly expected_pyav=7e3d950a8b72062502c1a60d672f8ca565313af5
+readonly expected_amf=c35f613aea2e5057a688c979e75b1cf24253297e
+readonly repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+readonly transfer_patch="$repo_root/patches/ffmpeg/0001-amf-transfer-use-context-sw-format.patch"
+readonly frames_context_patch="$repo_root/patches/ffmpeg/0002-amfdec-replace-stale-frames-context.patch"
+readonly dynamic_resolution_patch="$repo_root/patches/ffmpeg/0003-amfdec-fix-dynamic-resolution-reinit.patch"
+readonly spherical_metadata_patch="$repo_root/patches/ffmpeg/0004-matroska-projection-tag-spherical.patch"
+
+assert_pin() {
+  local path=$1 expected=$2 label=$3 actual
+  actual=$(git -C "$path" rev-parse HEAD)
+  [[ $actual == "$expected" ]] || {
+    printf '%s source must be pinned at %s; observed %s\n' \
+      "$label" "$expected" "$actual" >&2
+    exit 1
+  }
+}
+
+apply_patch_once() {
+  local patch_path=$1
+  if git -C "$ffmpeg_source" apply --check "$patch_path" 2>/dev/null; then
+    git -C "$ffmpeg_source" apply "$patch_path"
+  elif ! git -C "$ffmpeg_source" apply --reverse --check "$patch_path" 2>/dev/null; then
+    printf 'FFmpeg source is neither clean nor already patched for %s\n' \
+      "$patch_path" >&2
+    exit 1
+  fi
+}
+
+assert_pin "$ffmpeg_source" "$expected_ffmpeg" FFmpeg
+assert_pin "$pyav_source" "$expected_pyav" PyAV
+assert_pin "$amf_source" "$expected_amf" AMF
+
+if [[ $apply_dynamic_resolution_fix == true ]]; then
+  apply_frames_context_fix=true
+fi
+
+apply_patch_once "$transfer_patch"
+if [[ $apply_frames_context_fix == true ]]; then
+  apply_patch_once "$frames_context_patch"
+fi
+if [[ $apply_dynamic_resolution_fix == true ]]; then
+  apply_patch_once "$dynamic_resolution_patch"
+fi
+if [[ $apply_spherical_metadata_patch == true ]]; then
+  apply_patch_once "$spherical_metadata_patch"
+fi
+
+amf_include=$amf_source
+if [[ ! -f $amf_include/AMF/core/Factory.h ]]; then
+  published_headers=$amf_source/amf/public/include
+  [[ -f $published_headers/core/Factory.h ]] || {
+    printf 'AMF headers were not found below %s\n' "$amf_source" >&2
+    exit 1
+  }
+  amf_include=$output_root/amf-include
+  mkdir -p "$amf_include/AMF"
+  cp -a "$published_headers/." "$amf_include/AMF/"
+fi
+
+vulkan_include=
+if [[ -n $vulkan_headers ]]; then
+  vulkan_headers=$(realpath "$vulkan_headers")
+  if [[ -f $vulkan_headers/include/vulkan/vulkan.h ]]; then
+    vulkan_include=$vulkan_headers/include
+  elif [[ -f $vulkan_headers/vulkan/vulkan.h ]]; then
+    vulkan_include=$vulkan_headers
+  else
+    printf 'Vulkan headers were not found below %s\n' "$vulkan_headers" >&2
+    exit 1
+  fi
+elif [[ -f /usr/include/vulkan/vulkan.h ]]; then
+  vulkan_include=/usr/include
+fi
+[[ -n $vulkan_include ]] || {
+  printf '%s\n' 'Vulkan headers are required; pass --vulkan-headers PATH.' >&2
+  exit 1
+}
+
+extra_cflags="-I$amf_include -I$vulkan_include"
+build_dir=$output_root/ffmpeg-build
+install_dir=$output_root/ffmpeg-install
+wheel_dir=$output_root/wheels
+mkdir -p "$build_dir" "$install_dir" "$wheel_dir"
+
+configure_args=(
+  "--prefix=$install_dir"
+  --enable-shared
+  --disable-static
+  --disable-debug
+  --disable-doc
+  --disable-autodetect
+  --disable-everything
+  --enable-ffmpeg
+  --enable-ffprobe
+  --enable-avcodec
+  --enable-avformat
+  --enable-avfilter
+  --enable-avdevice
+  --enable-swscale
+  --enable-swresample
+  --enable-amf
+  --enable-vulkan
+  --enable-protocol=file
+  --enable-demuxer=matroska
+  --enable-muxer=matroska
+  --enable-muxer=null
+  --enable-decoder=h264_amf
+  --enable-decoder=hevc_amf
+  --enable-decoder=av1_amf
+  --enable-parser=h264
+  --enable-parser=hevc
+  --enable-parser=av1
+  --enable-bsf=h264_mp4toannexb
+  --enable-bsf=hevc_mp4toannexb
+  --enable-filter=hwdownload
+  --enable-filter=format
+  --enable-encoder=wrapped_avframe
+  "--extra-cflags=$extra_cflags"
+)
+
+cd "$build_dir"
+"$ffmpeg_source/configure" "${configure_args[@]}"
+make -j"$jobs"
+make install
+
+for required_output in "$install_dir/bin/ffmpeg" "$install_dir/bin/ffprobe"; do
+  [[ -x $required_output ]] || {
+    printf 'FFmpeg install did not produce %s\n' "$required_output" >&2
+    exit 1
+  }
+done
+
+export PKG_CONFIG_PATH="$install_dir/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+export LD_LIBRARY_PATH="$install_dir/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+cd "$pyav_source"
+"$python" setup.py bdist_wheel
+wheel=$(find "$pyav_source/dist" -maxdepth 1 -type f -name 'av-*.whl' \
+  -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)
+[[ -n $wheel ]] || {
+  printf '%s\n' 'PyAV build produced no wheel.' >&2
+  exit 1
+}
+cp -f "$wheel" "$wheel_dir/"
+copied_wheel=$wheel_dir/$(basename "$wheel")
+
+cat >"$output_root/build-manifest.txt" <<EOF
+FFMPEG_COMMIT=$expected_ffmpeg
+PYAV_COMMIT=$expected_pyav
+AMF_COMMIT=$expected_amf
+TRANSFER_PATCH_SHA256=$(sha256sum "$transfer_patch" | awk '{print $1}')
+FRAMES_CONTEXT_FIX_APPLIED=$apply_frames_context_fix
+FRAMES_CONTEXT_PATCH_SHA256=$(sha256sum "$frames_context_patch" | awk '{print $1}')
+DYNAMIC_RESOLUTION_FIX_APPLIED=$apply_dynamic_resolution_fix
+DYNAMIC_RESOLUTION_PATCH_SHA256=$(sha256sum "$dynamic_resolution_patch" | awk '{print $1}')
+SPHERICAL_METADATA_PATCH_APPLIED=$apply_spherical_metadata_patch
+SPHERICAL_METADATA_PATCH_SHA256=$(sha256sum "$spherical_metadata_patch" | awk '{print $1}')
+VULKAN_INCLUDE=$vulkan_include
+WHEEL=$copied_wheel
+WHEEL_SHA256=$(sha256sum "$copied_wheel" | awk '{print $1}')
+FFMPEG_BIN=$install_dir/bin
+FFMPEG_LIB=$install_dir/lib
+EOF
+
+printf 'FFmpeg SDK: %s\nPyAV wheel: %s\nManifest: %s\n' \
+  "$install_dir" "$copied_wheel" "$output_root/build-manifest.txt"

--- a/scripts/build_unified_ffmpeg_pyav_windows.ps1
+++ b/scripts/build_unified_ffmpeg_pyav_windows.ps1
@@ -1,0 +1,336 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $FfmpegSource,
+
+    [Parameter(Mandatory = $true)]
+    [string] $PyAvSource,
+
+    [Parameter(Mandatory = $true)]
+    [string] $AmfSource,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Dav1dSource,
+
+    [Parameter(Mandatory = $true)]
+    [string] $OutputRoot,
+
+    [string] $Python = "python",
+    [string] $Ninja = "ninja",
+    [string] $MsysRoot = "C:\msys64",
+    [string] $VsDevCmd = "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\Tools\VsDevCmd.bat",
+    [int] $Jobs = 16,
+    [switch] $ApplyFramesContextFix,
+    [switch] $ApplyDynamicResolutionFix,
+    [switch] $ApplySphericalMetadataPatch
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$expectedFfmpeg = "44d082edc87381d978e8588b148116b99fefdb43"
+$expectedPyAv = "7e3d950a8b72062502c1a60d672f8ca565313af5"
+$expectedAmf = "c35f613aea2e5057a688c979e75b1cf24253297e"
+$expectedDav1d = "b546257f770768b2c88258c533da38b91a06f737"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$transferPatch = Join-Path $repoRoot "patches\ffmpeg\0001-amf-transfer-use-context-sw-format.patch"
+$framesContextPatch = Join-Path $repoRoot "patches\ffmpeg\0002-amfdec-replace-stale-frames-context.patch"
+$dynamicResolutionPatch = Join-Path $repoRoot "patches\ffmpeg\0003-amfdec-fix-dynamic-resolution-reinit.patch"
+$sphericalMetadataPatch = Join-Path $repoRoot "patches\ffmpeg\0004-matroska-projection-tag-spherical.patch"
+
+function Resolve-ExistingPath([string] $Path, [string] $Label) {
+    $resolved = Resolve-Path -LiteralPath $Path -ErrorAction Stop
+    if (-not $resolved) {
+        throw "$Label does not exist: $Path"
+    }
+    return $resolved.Path
+}
+
+function Assert-GitPin([string] $Path, [string] $Expected, [string] $Label) {
+    $actual = (& git -C $Path rev-parse HEAD).Trim()
+    if ($LASTEXITCODE -ne 0 -or $actual -ne $Expected) {
+        throw "$Label source must be pinned at $Expected; observed $actual"
+    }
+}
+
+function Invoke-GitPatchOnce([string] $Source, [string] $Patch) {
+    & git -C $Source apply --check $Patch 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        & git -C $Source apply $Patch
+        if ($LASTEXITCODE -ne 0) {
+            throw "git apply failed: $Patch"
+        }
+        return
+    }
+    & git -C $Source apply --reverse --check $Patch 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "FFmpeg source is neither clean nor already patched for $Patch"
+    }
+}
+
+function Convert-FileToLf([string] $Path) {
+    $content = [IO.File]::ReadAllText($Path)
+    if ($content.Contains("`r`n")) {
+        [IO.File]::WriteAllText(
+            $Path,
+            $content.Replace("`r`n", "`n"),
+            [Text.UTF8Encoding]::new($false)
+        )
+    }
+}
+
+function Replace-Exact(
+    [string] $Path,
+    [string] $Old,
+    [string] $New,
+    [string] $Label
+) {
+    $content = [IO.File]::ReadAllText($Path)
+    if ($content.Contains($New)) {
+        return
+    }
+    if (-not $content.Contains($Old)) {
+        throw "Cannot apply localized MSVC compatibility edit: $Label"
+    }
+    [IO.File]::WriteAllText(
+        $Path,
+        $content.Replace($Old, $New),
+        [Text.UTF8Encoding]::new($false)
+    )
+}
+
+function Convert-ToMsysPath([string] $Path) {
+    $cygpath = Join-Path $MsysRoot "usr\bin\cygpath.exe"
+    $converted = (& $cygpath -a -u $Path).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $converted) {
+        throw "cygpath failed for $Path"
+    }
+    return $converted
+}
+
+if ($Jobs -lt 1) {
+    throw "Jobs must be a positive integer"
+}
+
+$FfmpegSource = Resolve-ExistingPath $FfmpegSource "FFmpeg source"
+$PyAvSource = Resolve-ExistingPath $PyAvSource "PyAV source"
+$AmfSource = Resolve-ExistingPath $AmfSource "AMF source"
+$Dav1dSource = Resolve-ExistingPath $Dav1dSource "dav1d source"
+$MsysRoot = Resolve-ExistingPath $MsysRoot "MSYS2 root"
+$VsDevCmd = Resolve-ExistingPath $VsDevCmd "VsDevCmd"
+$transferPatch = Resolve-ExistingPath $transferPatch "FFmpeg transfer patch"
+$framesContextPatch = Resolve-ExistingPath $framesContextPatch "FFmpeg frames-context patch"
+$dynamicResolutionPatch = Resolve-ExistingPath $dynamicResolutionPatch "FFmpeg dynamic-resolution patch"
+$sphericalMetadataPatch = Resolve-ExistingPath $sphericalMetadataPatch "FFmpeg spherical metadata patch"
+$Python = (& (Get-Command $Python -ErrorAction Stop).Source -c "import sys; print(sys.executable)").Trim()
+$Ninja = (Get-Command $Ninja -ErrorAction Stop).Source
+$mesonVersion = (& $Python -m mesonbuild.mesonmain --version).Trim()
+if ($LASTEXITCODE -ne 0 -or -not $mesonVersion) {
+    throw "Meson is required to build the pinned Windows dav1d runtime"
+}
+$ninjaVersion = (& $Ninja --version).Trim()
+if ($LASTEXITCODE -ne 0 -or -not $ninjaVersion) {
+    throw "Ninja is required to build the pinned Windows dav1d runtime"
+}
+
+$useFramesContextFix = [bool]$ApplyFramesContextFix -or [bool]$ApplyDynamicResolutionFix
+$useDynamicResolutionFix = [bool]$ApplyDynamicResolutionFix
+$useSphericalMetadataPatch = [bool]$ApplySphericalMetadataPatch
+
+Assert-GitPin $FfmpegSource $expectedFfmpeg "FFmpeg"
+Assert-GitPin $PyAvSource $expectedPyAv "PyAV"
+Assert-GitPin $AmfSource $expectedAmf "AMF"
+Assert-GitPin $Dav1dSource $expectedDav1d "dav1d"
+
+# git apply matches the LF patches literally. Normalize only the targets that
+# will be patched, preserving the rest of the pinned checkout unchanged.
+Convert-FileToLf (Join-Path $FfmpegSource "libavutil\hwcontext_amf.c")
+if ($useFramesContextFix) {
+    Convert-FileToLf (Join-Path $FfmpegSource "libavcodec\amfdec.c")
+}
+if ($useSphericalMetadataPatch) {
+    Convert-FileToLf (Join-Path $FfmpegSource "libavformat\matroskaenc.c")
+}
+
+New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+$OutputRoot = (Resolve-Path -LiteralPath $OutputRoot).Path
+$buildDir = Join-Path $OutputRoot "ffmpeg-build"
+$installDir = Join-Path $OutputRoot "ffmpeg-install"
+$wheelDir = Join-Path $OutputRoot "wheels"
+$dav1dBuildDir = Join-Path $OutputRoot "dav1d-build"
+$dav1dInstallDir = Join-Path $OutputRoot "dav1d-install"
+New-Item -ItemType Directory -Path `
+    $buildDir, $installDir, $wheelDir, $dav1dBuildDir, $dav1dInstallDir `
+    -Force | Out-Null
+
+$amfIncludeRoot = $AmfSource
+if (-not (Test-Path (Join-Path $amfIncludeRoot "AMF\core\Factory.h"))) {
+    $publishedHeaders = Join-Path $AmfSource "amf\public\include"
+    if (-not (Test-Path (Join-Path $publishedHeaders "core\Factory.h"))) {
+        throw "AMF headers were not found below $AmfSource"
+    }
+    $amfIncludeRoot = Join-Path $OutputRoot "amf-include"
+    $amfNamespace = Join-Path $amfIncludeRoot "AMF"
+    New-Item -ItemType Directory -Path $amfNamespace -Force | Out-Null
+    Copy-Item -Path (Join-Path $publishedHeaders "*") -Destination $amfNamespace -Recurse -Force
+}
+
+Invoke-GitPatchOnce $FfmpegSource $transferPatch
+if ($useFramesContextFix) {
+    Invoke-GitPatchOnce $FfmpegSource $framesContextPatch
+}
+if ($useDynamicResolutionFix) {
+    Invoke-GitPatchOnce $FfmpegSource $dynamicResolutionPatch
+}
+if ($useSphericalMetadataPatch) {
+    Invoke-GitPatchOnce $FfmpegSource $sphericalMetadataPatch
+}
+
+# FFmpeg's configure parser assumes English cl.exe/link.exe output. These
+# exact, source-pinned edits are intentionally separate from functional patches.
+$configure = Join-Path $FfmpegSource "configure"
+Replace-Exact $configure `
+    "cl_major_ver=`$(cl.exe 2>&1 | sed -n 's/.*Version \([[:digit:]]\{1,\}\)\..*/\1/p')" `
+    "cl_major_ver=`$(cl.exe 2>&1 | sed -n 's/.* \([[:digit:]][[:digit:]]\)\.[[:digit:]][[:digit:]]\..*/\1/p' | head -1)" `
+    "MSVC version parser"
+Replace-Exact $configure "grep -q ^Microsoft" "grep -q Microsoft" "MSVC probe"
+Replace-Exact $configure "grep ^Microsoft | head -n1" "grep Microsoft | head -n1" "MSVC identity"
+
+$ffmpegMsys = Convert-ToMsysPath $FfmpegSource
+$amfMsys = Convert-ToMsysPath $amfIncludeRoot
+$buildMsys = Convert-ToMsysPath $buildDir
+$installMsys = Convert-ToMsysPath $installDir
+$dav1dPkgConfigMsys = Convert-ToMsysPath (Join-Path $dav1dInstallDir "lib\pkgconfig")
+$dav1dBinMsys = Convert-ToMsysPath (Join-Path $dav1dInstallDir "bin")
+$buildScript = Join-Path $OutputRoot "build-ffmpeg-msvc.sh"
+$buildScriptMsys = Convert-ToMsysPath $buildScript
+$bash = Join-Path $MsysRoot "usr\bin\bash.exe"
+if (-not (Test-Path -LiteralPath $bash -PathType Leaf)) {
+    throw "MSYS2 bash is missing: $bash"
+}
+
+$bashBody = @"
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH='$dav1dBinMsys':/usr/bin:`$PATH
+export PKG_CONFIG_PATH='$dav1dPkgConfigMsys'
+export LC_ALL=C
+mkdir -p '$buildMsys' '$installMsys'
+cd '$buildMsys'
+'$ffmpegMsys/configure' \
+  --prefix='$installMsys' \
+  --toolchain=msvc --target-os=win64 --arch=x86_64 \
+  --enable-shared --disable-static --disable-debug --disable-doc \
+  --disable-autodetect --disable-everything \
+  --enable-ffmpeg --enable-ffprobe \
+  --enable-avcodec --enable-avformat --enable-avfilter --enable-avdevice \
+  --enable-swscale --enable-swresample \
+  --enable-libdav1d \
+  --enable-amf --enable-d3d11va --enable-dxva2 \
+  --enable-protocol=file --enable-demuxer=matroska \
+  --enable-muxer=matroska --enable-muxer=null \
+  --enable-decoder=h264 --enable-decoder=hevc --enable-decoder=libdav1d \
+  --enable-decoder=h264_amf --enable-decoder=hevc_amf --enable-decoder=av1_amf \
+  --enable-parser=h264 --enable-parser=hevc --enable-parser=av1 \
+  --enable-bsf=h264_mp4toannexb --enable-bsf=hevc_mp4toannexb \
+  --enable-filter=hwdownload --enable-filter=format --enable-filter=scale \
+  --enable-encoder=wrapped_avframe \
+  --extra-cflags='-I$amfMsys'
+# A localized compiler identity is valid C but invalid Windows RC input.
+sed -i 's/^#define CC_IDENT .*/#define CC_IDENT "Microsoft C\/C++ compiler (MSVC)"/' config.h
+make -j$Jobs
+make install
+# FFmpeg's MSVC install target emits .def files but does not install import libs.
+for lib in avcodec avdevice avfilter avformat avutil swresample swscale; do
+  cp "lib`$lib/`$lib.lib" '$installMsys/lib/'
+done
+"@
+[IO.File]::WriteAllText(
+    $buildScript,
+    $bashBody.Replace("`r`n", "`n"),
+    [Text.UTF8Encoding]::new($false)
+)
+
+$driver = Join-Path $OutputRoot "build-windows.cmd"
+$driverBody = @"
+@echo off
+setlocal
+call "$VsDevCmd" -arch=x64 -host_arch=x64 || exit /b 1
+set "PATH=%PATH%;$MsysRoot\usr\bin"
+"$Python" -m mesonbuild.mesonmain setup "$dav1dBuildDir" "$Dav1dSource" --prefix "$dav1dInstallDir" --backend ninja --buildtype release --default-library shared -Denable_tools=false -Denable_tests=false -Denable_examples=false -Denable_docs=false || exit /b 1
+"$Ninja" -C "$dav1dBuildDir" -j $Jobs install || exit /b 1
+"$bash" --noprofile --norc -lc "source '$buildScriptMsys'" || exit /b 1
+pushd "$PyAvSource" || exit /b 1
+"$Python" setup.py bdist_wheel --ffmpeg-dir="$installDir" || exit /b 1
+popd
+exit /b 0
+"@
+[IO.File]::WriteAllText($driver, $driverBody, [Text.ASCIIEncoding]::new())
+
+& cmd.exe /d /c $driver
+if ($LASTEXITCODE -ne 0) {
+    throw "Windows FFmpeg/PyAV build failed with exit $LASTEXITCODE"
+}
+
+$dav1dDll = Join-Path $dav1dInstallDir "bin\dav1d.dll"
+if (-not (Test-Path -LiteralPath $dav1dDll -PathType Leaf)) {
+    throw "Windows dav1d build did not produce $dav1dDll"
+}
+Copy-Item -LiteralPath $dav1dDll -Destination (Join-Path $installDir "bin") -Force
+
+$expectedBuildOutputs = @(
+    (Join-Path $installDir "bin\ffmpeg.exe"),
+    (Join-Path $installDir "bin\ffprobe.exe"),
+    (Join-Path $installDir "bin\dav1d.dll"),
+    (Join-Path $installDir "bin\avcodec-62.dll"),
+    (Join-Path $installDir "bin\avdevice-62.dll"),
+    (Join-Path $installDir "bin\avfilter-11.dll"),
+    (Join-Path $installDir "bin\avformat-62.dll"),
+    (Join-Path $installDir "bin\avutil-60.dll"),
+    (Join-Path $installDir "bin\swresample-6.dll"),
+    (Join-Path $installDir "bin\swscale-9.dll"),
+    (Join-Path $installDir "lib\avcodec.lib"),
+    (Join-Path $installDir "lib\avformat.lib"),
+    (Join-Path $installDir "lib\avutil.lib")
+)
+foreach ($expectedOutput in $expectedBuildOutputs) {
+    if (-not (Test-Path -LiteralPath $expectedOutput -PathType Leaf)) {
+        throw "Windows FFmpeg/PyAV build did not produce $expectedOutput"
+    }
+}
+
+$wheel = Get-ChildItem (Join-Path $PyAvSource "dist\av-*.whl") |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+if (-not $wheel) {
+    throw "PyAV build produced no wheel"
+}
+Copy-Item -LiteralPath $wheel.FullName -Destination $wheelDir -Force
+$copiedWheel = Join-Path $wheelDir $wheel.Name
+
+$manifest = @(
+    "FFMPEG_COMMIT=$expectedFfmpeg",
+    "PYAV_COMMIT=$expectedPyAv",
+    "AMF_COMMIT=$expectedAmf",
+    "DAV1D_COMMIT=$expectedDav1d",
+    "DAV1D_DLL_SHA256=$((Get-FileHash (Join-Path $installDir 'bin\dav1d.dll') -Algorithm SHA256).Hash.ToLower())",
+    "MESON_VERSION=$mesonVersion",
+    "NINJA_VERSION=$ninjaVersion",
+    "TRANSFER_PATCH_SHA256=$((Get-FileHash $transferPatch -Algorithm SHA256).Hash.ToLower())",
+    "FRAMES_CONTEXT_FIX_APPLIED=$($useFramesContextFix.ToString().ToLower())",
+    "FRAMES_CONTEXT_PATCH_SHA256=$((Get-FileHash $framesContextPatch -Algorithm SHA256).Hash.ToLower())",
+    "DYNAMIC_RESOLUTION_FIX_APPLIED=$($useDynamicResolutionFix.ToString().ToLower())",
+    "DYNAMIC_RESOLUTION_PATCH_SHA256=$((Get-FileHash $dynamicResolutionPatch -Algorithm SHA256).Hash.ToLower())",
+    "SPHERICAL_METADATA_PATCH_APPLIED=$($useSphericalMetadataPatch.ToString().ToLower())",
+    "SPHERICAL_METADATA_PATCH_SHA256=$((Get-FileHash $sphericalMetadataPatch -Algorithm SHA256).Hash.ToLower())",
+    "WINDOWS_SOFTWARE_FALLBACK_DECODERS_ENABLED=true",
+    "WINDOWS_AV1_SOFTWARE_DECODER=libdav1d",
+    "WHEEL=$copiedWheel",
+    "WHEEL_SHA256=$((Get-FileHash $copiedWheel -Algorithm SHA256).Hash.ToLower())",
+    "FFMPEG_BIN=$(Join-Path $installDir 'bin')"
+)
+$manifest | Set-Content -LiteralPath (Join-Path $OutputRoot "build-manifest.txt") -Encoding utf8
+
+Write-Host "FFmpeg SDK: $installDir"
+Write-Host "PyAV wheel: $copiedWheel"
+Write-Host "Manifest: $(Join-Path $OutputRoot 'build-manifest.txt')"

--- a/tests/test_unified_build_scripts.py
+++ b/tests/test_unified_build_scripts.py
@@ -1,0 +1,219 @@
+"""Static contract checks for the opt-in unified FFmpeg/PyAV builders.
+
+The builders require Windows toolchains and AMD hardware that CI does not
+provide.  These tests therefore protect the accepted pins, patch ordering,
+and artifact handoff rather than attempting a native build.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH_DIR = ROOT / "patches" / "ffmpeg"
+UBUNTU_SCRIPT = ROOT / "scripts" / "build_unified_ffmpeg_pyav_ubuntu.sh"
+WINDOWS_SCRIPT = ROOT / "scripts" / "build_unified_ffmpeg_pyav_windows.ps1"
+
+FFMPEG_COMMIT = "44d082edc87381d978e8588b148116b99fefdb43"
+PYAV_COMMIT = "7e3d950a8b72062502c1a60d672f8ca565313af5"
+AMF_COMMIT = "c35f613aea2e5057a688c979e75b1cf24253297e"
+DAV1D_COMMIT = "b546257f770768b2c88258c533da38b91a06f737"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_builders_use_the_runtime_contract_source_pins() -> None:
+    ubuntu = _read(UBUNTU_SCRIPT)
+    windows = _read(WINDOWS_SCRIPT)
+
+    for source_pin in (FFMPEG_COMMIT, PYAV_COMMIT, AMF_COMMIT):
+        assert source_pin in ubuntu
+        assert source_pin in windows
+    assert DAV1D_COMMIT not in ubuntu
+    assert DAV1D_COMMIT in windows
+
+
+def test_ubuntu_builder_keeps_patch_selection_narrow_and_idempotent() -> None:
+    script = _read(UBUNTU_SCRIPT)
+
+    assert "git -C \"$ffmpeg_source\" apply --check \"$patch_path\"" in script
+    assert "apply --reverse --check \"$patch_path\"" in script
+    assert "apply_dynamic_resolution_fix == true" in script
+    assert "apply_frames_context_fix=true" in script
+    assert 'apply_patch_once "$transfer_patch"' in script
+    assert 'apply_patch_once "$frames_context_patch"' in script
+    assert 'apply_patch_once "$dynamic_resolution_patch"' in script
+    assert 'apply_patch_once "$spherical_metadata_patch"' in script
+    assert "--apply-spherical-metadata-patch" in script
+    assert script.index('apply_patch_once "$transfer_patch"') < script.index(
+        'apply_patch_once "$frames_context_patch"'
+    ) < script.index('apply_patch_once "$dynamic_resolution_patch"') < script.index(
+        'apply_patch_once "$spherical_metadata_patch"'
+    )
+
+    for forbidden in (
+        "--enable-encode-probe",
+        "EnableEncodeProbe",
+        "build_amf_surface_probe.py",
+        "install_unified_runtime.py",
+    ):
+        assert forbidden not in script
+
+
+def test_ubuntu_builder_enables_the_limited_amf_decode_surface_and_manifest() -> None:
+    script = _read(UBUNTU_SCRIPT)
+
+    for configure_flag in (
+        "--enable-amf",
+        "--enable-vulkan",
+        "--enable-decoder=h264_amf",
+        "--enable-decoder=hevc_amf",
+        "--enable-decoder=av1_amf",
+        "--enable-parser=h264",
+        "--enable-parser=hevc",
+        "--enable-parser=av1",
+        "--enable-bsf=h264_mp4toannexb",
+        "--enable-bsf=hevc_mp4toannexb",
+        "--enable-demuxer=matroska",
+        "--enable-muxer=matroska",
+    ):
+        assert configure_flag in script
+
+    for manifest_field in (
+        "FFMPEG_COMMIT=$expected_ffmpeg",
+        "PYAV_COMMIT=$expected_pyav",
+        "AMF_COMMIT=$expected_amf",
+        "TRANSFER_PATCH_SHA256=",
+        "FRAMES_CONTEXT_FIX_APPLIED=$apply_frames_context_fix",
+        "DYNAMIC_RESOLUTION_FIX_APPLIED=$apply_dynamic_resolution_fix",
+        "SPHERICAL_METADATA_PATCH_APPLIED=$apply_spherical_metadata_patch",
+        "WHEEL_SHA256=",
+        "FFMPEG_BIN=$install_dir/bin",
+        "FFMPEG_LIB=$install_dir/lib",
+    ):
+        assert manifest_field in script
+
+
+def test_windows_builder_pins_and_packages_dav1d() -> None:
+    script = _read(WINDOWS_SCRIPT)
+
+    assert "[string] $Dav1dSource" in script
+    assert DAV1D_COMMIT in script
+    assert 'Assert-GitPin $Dav1dSource $expectedDav1d "dav1d"' in script
+    assert "-m mesonbuild.mesonmain setup" in script
+    assert "-Denable_tools=false" in script
+    assert "-Denable_tests=false" in script
+    assert "-Denable_examples=false" in script
+    assert "Copy-Item -LiteralPath $dav1dDll" in script
+    assert '"DAV1D_DLL_SHA256=' in script
+
+
+def test_windows_builder_applies_conditional_patches_and_normalizes_targets() -> None:
+    script = _read(WINDOWS_SCRIPT)
+
+    assert "$useFramesContextFix = [bool]$ApplyFramesContextFix -or [bool]$ApplyDynamicResolutionFix" in script
+    assert "$useDynamicResolutionFix = [bool]$ApplyDynamicResolutionFix" in script
+    assert "$useSphericalMetadataPatch = [bool]$ApplySphericalMetadataPatch" in script
+    assert "Invoke-GitPatchOnce $FfmpegSource $transferPatch" in script
+    assert "Invoke-GitPatchOnce $FfmpegSource $framesContextPatch" in script
+    assert "Invoke-GitPatchOnce $FfmpegSource $dynamicResolutionPatch" in script
+    assert "Invoke-GitPatchOnce $FfmpegSource $sphericalMetadataPatch" in script
+    assert "libavutil\\hwcontext_amf.c" in script
+    assert "libavcodec\\amfdec.c" in script
+    assert "libavformat\\matroskaenc.c" in script
+    assert script.index("Invoke-GitPatchOnce $FfmpegSource $transferPatch") < script.index(
+        "Invoke-GitPatchOnce $FfmpegSource $framesContextPatch"
+    ) < script.index("Invoke-GitPatchOnce $FfmpegSource $dynamicResolutionPatch") < script.index(
+        "Invoke-GitPatchOnce $FfmpegSource $sphericalMetadataPatch"
+    )
+
+    for forbidden in (
+        "EnableEncodeProbe",
+        "build_amf_surface_probe.py",
+        "install_unified_runtime.py",
+    ):
+        assert forbidden not in script
+
+
+def test_windows_builder_keeps_expected_decode_configuration_and_manifest() -> None:
+    script = _read(WINDOWS_SCRIPT)
+
+    for configure_flag in (
+        "--enable-libdav1d",
+        "--enable-decoder=h264 --enable-decoder=hevc --enable-decoder=libdav1d",
+        "--enable-decoder=h264_amf --enable-decoder=hevc_amf --enable-decoder=av1_amf",
+        "--enable-parser=h264 --enable-parser=hevc --enable-parser=av1",
+        "--enable-bsf=h264_mp4toannexb --enable-bsf=hevc_mp4toannexb",
+        "--enable-filter=hwdownload --enable-filter=format --enable-filter=scale",
+    ):
+        assert configure_flag in script
+    assert "--enable-decoder=av1 " not in script
+
+    for manifest_field in (
+        '"FFMPEG_COMMIT=$expectedFfmpeg"',
+        '"PYAV_COMMIT=$expectedPyAv"',
+        '"AMF_COMMIT=$expectedAmf"',
+        '"DAV1D_COMMIT=$expectedDav1d"',
+        '"FRAMES_CONTEXT_FIX_APPLIED=$($useFramesContextFix.ToString().ToLower())"',
+        '"DYNAMIC_RESOLUTION_FIX_APPLIED=$($useDynamicResolutionFix.ToString().ToLower())"',
+        '"SPHERICAL_METADATA_PATCH_APPLIED=$($useSphericalMetadataPatch.ToString().ToLower())"',
+        '"WINDOWS_SOFTWARE_FALLBACK_DECODERS_ENABLED=true"',
+        '"WINDOWS_AV1_SOFTWARE_DECODER=libdav1d"',
+        '"WHEEL_SHA256=',
+        '"FFMPEG_BIN=$(Join-Path $installDir',
+    ):
+        assert manifest_field in script
+
+
+def test_transfer_patch_advertises_only_the_active_context_format() -> None:
+    patch = _read(PATCH_DIR / "0001-amf-transfer-use-context-sw-format.patch")
+
+    assert "fmts = av_malloc_array(2, sizeof(*fmts));" in patch
+    assert "fmts[0] = ctx->sw_format;" in patch
+    assert "fmts[1] = AV_PIX_FMT_NONE;" in patch
+    assert "if (ctx->sw_format == supported_transfer_formats[i])" in patch
+    assert "-        fmts[i] = supported_transfer_formats[i];" in patch
+
+
+def test_frames_context_patch_replaces_the_reference_instead_of_mutating_it() -> None:
+    patch = _read(PATCH_DIR / "0002-amfdec-replace-stale-frames-context.patch")
+
+    for required in (
+        "amf_replace_frames_context",
+        "av_hwframe_ctx_alloc(avctx->hw_device_ctx)",
+        "avctx->hw_frames_ctx = new_frames_ref;",
+        "av_buffer_unref(&old_frames_ref);",
+        "amf_ensure_frames_context",
+        "frame->hw_frames_ctx = av_buffer_ref(avctx->hw_frames_ctx);",
+    ):
+        assert required in patch
+
+
+def test_dynamic_resolution_patch_restarts_from_unknown_dimensions_and_annex_b() -> None:
+    patch = _read(PATCH_DIR / "0003-amfdec-fix-dynamic-resolution-reinit.patch")
+
+    for added_line in (
+        "+            res = ctx->decoder->pVtbl->Terminate(ctx->decoder);",
+        "+            avctx->width = 0;",
+        "+            avctx->height = 0;",
+        "+            ctx->dimensions_initialized = 0;",
+        "+            res = ctx->decoder->pVtbl->Init(ctx->decoder, AMF_SURFACE_UNKNOWN,",
+        "+DEFINE_AMF_DECODER(hevc, HEVC, \"hevc_mp4toannexb\")",
+    ):
+        assert added_line in patch
+
+
+def test_spherical_metadata_patch_prefers_coded_side_data_before_tag_fallback() -> None:
+    patch = _read(PATCH_DIR / "0004-matroska-projection-tag-spherical.patch")
+
+    assert "if (sd) {" in patch
+    assert 'av_dict_get(metadata, "projection", NULL, 0)' in patch
+    assert 'av_strcasecmp(tag->value, "equirectangular")' in patch
+    assert "spherical = &tag_spherical;" in patch
+    assert "projection=equirectangular" not in patch
+    assert patch.index("if (sd) {") < patch.index(
+        'av_dict_get(metadata, "projection", NULL, 0)'
+    )


### PR DESCRIPTION
## Summary

- add pinned Linux and Windows builders for unified FFmpeg/PyAV artifacts
- verify exact upstream source commits and emit a reproducible build manifest
- carry explicit, opt-in FFmpeg patch sets without changing product defaults
- keep building separate from runtime acceptance and installation

This is an independent root PR based directly on `main`. It provides artifact builders only; the runtime contract and installer remain separate PRs.

## Validation

- `/home/latiao/vr_toolbox_jasna_linux/.venv/bin/python -m pytest -q tests/test_unified_build_scripts.py`
- Result: `10 passed`
- Exactly one commit above upstream `main`; `git diff --check` passed

## Scope

This PR does not install a runtime, change decode/encode selection, enable AMF patches by default, or alter NVIDIA/VR/2D product behavior.

## Follow-up PRs that depend on this PR

- **Unified runtime installer** — validates the builder manifest and hashes, then atomically installs an accepted artifact set; it also depends on runtime contract PR #370.
- **Linux AMF bridge packaging** — packages the native bridge into the accepted runtime; it also depends on PR #370, the installer, and the AMF interop core.
- **Smart Render CLI build capabilities** — exposes build-time capability metadata needed before Smart Render can select compatible native codec paths.

Independent runtime-contract and backend root PRs can be reviewed separately.
