### PR TITLE
feat(amd): add explicit RF-DETR MIGraphX artifact runner

### DIFF
--- a/docs/RFDETR_MIGRAPHX_CORE_CN.md
+++ b/docs/RFDETR_MIGRAPHX_CORE_CN.md
@@ -1,0 +1,90 @@
+# Linux AMD RF-DETR MIGraphX Core
+
+更新时间：2026-08-29
+
+## 范围与非目标
+
+本次只重建 RF-DETR 的 Linux AMD MIGraphX artifact/runner 核心，代码边界为：
+
+- `jasna/migraphx_artifact.py`：已编译 MXR 与 JSON sidecar 的严格验证和 pointer-only 执行器；
+- `jasna/mosaic/rfdetr_migraphx_runner.py`：RF-DETR v6 medium 的专用 host/model/tensor 合同；
+- `jasna/mosaic/rfdetr.py`：显式传入 sidecar 时的窄接入，以及静态 batch 的保序拆分；
+- `tests/test_migraphx_artifact.py`：上述合同的 mock/结构回归。
+
+它不是产品自动选择功能。没有恢复或新增 session factory/config/CLI/GUI 接线、artifact 自动发现、runtime 安装器、
+共享 Pipeline/Tracker、BasicVSR++、decoder/encoder、NVIDIA 或 VR/2D 逻辑。没有显式 sidecar 时，AMD 仍走既有
+`RfDetrTorchRunner`；该核心不主动改变任何默认路线。
+
+## 显式入口与 host 合同
+
+调用方只能通过 `RfDetrMosaicDetectionModel(..., amd_migraphx_manifest_path=Path(...))` 选择该核心。显式路径在
+非 Linux 或非 AMD 设备上会在导入 runner/MXR runtime 前拒绝；一旦进入 MIGraphX runner，失败不会回退到 PyTorch。
+
+接受范围固定为：Linux、PyTorch ROCm `cuda` device、可用 GPU、`gfx1100`、FP16、RF-DETR v6 `medium`、
+576×576。sidecar 还必须声明 purpose
+`jasna-rfdetr-v6-medium-segmentation`、`ihipStream_t` stream ABI，且逻辑输出顺序只能是
+`dets`、`labels`、`masks`。输入为 contiguous `float32` `(B, 3, 576, 576)`；三个输出分别为
+`(B, 200, 4)`、`(B, 200, 3)`、`(B, 200, 144, 144)`，stride、parameter name 和 dtype 都逐项精确比较。
+
+核心沿用 checkpoint `e49161f` 中已知的静态 batch 合同集合 `{1, 2}`，但本工作树安装并实测的 artifact 是 static
+B1。未来产品选择层若要限制为 B1，必须在那里以独立证据和测试明确收窄，不能由自动发现隐式改变本 core。
+
+## Sidecar、ABI 与失败语义
+
+sidecar 使用严格的 schema v1：未知键、空输出、重复逻辑/parameter 名称、无效 SHA-256、非正维度或 shape/stride
+rank 不一致都会被拒绝。加载前会验证 MXR 的存在、字节数与 SHA-256，并验证源 checkpoint SHA-256。加载后继续验证：
+
+- 当前平台、ROCm device architecture、PyTorch、HIP、MIGraphX、torch-migraphx 版本；
+- 已编译 program 的 parameter 集合、MIGraphX type、shape、stride、输出数量及顺序；
+- 运行输入的 device/dtype/shape/stride；
+- `run_async` 返回的每个输出必须是预先分配的自有 GPU buffer，禁止接受外部 pointer。
+
+`MigraphxArtifactRunner` 只将 input 的 data pointer 传给 `mgx_argument_from_ptr`，不复制输入，也没有 PyTorch
+或其他 backend fallback。`close()` 会清除 program、arguments 和输出 buffer；此后的推理立即报错。MIGraphX Python
+binding 若未在当前环境中安装，才只从带当前解释器 `EXT_SUFFIX` 的官方 ROCm `lib` 目录查找；导入 torch-migraphx
+pointer bridge 时仅临时把当前解释器的 `bin` 放到 `PATH` 首位，随后恢复原 `PATH`。
+
+## B4 到 static B1 的保序与所有权
+
+上游可以继续传 B4 tensor。若显式 artifact 是 static B1，model 内部将其拆为四个 B1 dispatch，并在每次下一次
+dispatch 前对有效输出 slice 立刻 `clone()`，最后按输入顺序 `cat()`。这一步不可省略：MXR 输出由 runner 持有的
+pointer-backed buffer 复用，延后复制会让早先 batch 的结果被后一次 dispatch 覆盖。该逻辑不修改 score threshold、
+postprocess、Tracker 或共享 Pipeline。
+
+## 来源与 artifact 证据
+
+实现以 checkpoint `e49161f` 的下列文件为重建参考，而不是整包 cherry-pick：
+
+- `jasna/migraphx_artifact.py`
+- `jasna/mosaic/rfdetr_migraphx_runner.py`
+- `jasna/mosaic/rfdetr.py`
+- `tests/test_migraphx_artifact.py`
+
+本独立 core 保留 2026-08-27 实机研究中已验收的 B1 artifact 兼容标识：`rfdetr-v6.pt` SHA-256
+`f10bedc4d105c2721e4259b8680203d51f344f73e55e85710d915619f5731b55`、MXR SHA-256
+`174a02d30ebff31956cc111a1ffbf2b5d399d5de92d5aba61ffac68a1b32fb88`、sidecar SHA-256
+`7c03e58f0406968ad3e3c1ac9e24e1e6f343f55dedc0de0afa3494bc3f60a076`。这些值是 artifact 兼容边界，不表示本 core
+已接入产品自动选择。
+
+## 本次验证与限制
+
+在当前 Linux ROCm `gfx1100`（Radeon RX 7900 XTX）环境完成：
+
+```bash
+/home/latiao/vr_toolbox_jasna_linux/.venv/bin/python -m pytest -q \
+  tests/test_migraphx_artifact.py
+/home/latiao/vr_toolbox_jasna_linux/.venv/bin/python -m compileall -q \
+  jasna/migraphx_artifact.py \
+  jasna/mosaic/rfdetr_migraphx_runner.py \
+  jasna/mosaic/rfdetr.py \
+  tests/test_migraphx_artifact.py
+git diff --check
+```
+
+结果为 `24 passed`，`compileall` 与 `git diff --check` 均通过。额外的真实 smoke 已验证安装 sidecar、MXR 与
+`rfdetr-v6.pt` 的 SHA/大小，成功加载 B1 MXR 并经 `MigraphxArtifactRunner` 和
+`RfDetrMigraphxRunner` 输出三组有限的 `cuda:0 float32` tensor。显式 model 的 B4 输入实际产生四次 B1 dispatch，
+marker 顺序为 `0, 1, 2, 3`，拼接后的三个输出均为 B4 且不再指向 runner 的自有输出 buffer。
+
+这不是完整产品验收：尚未在本次范围内接入 session/product 自动选择，也未运行真实视频的端到端质量、帧数/PTS、
+关闭/取消或性能对照。那些工作必须在后续独立接线任务中完成，并且不能把 artifact 加载失败静默降级为 PyTorch。

--- a/jasna/migraphx_artifact.py
+++ b/jasna/migraphx_artifact.py
@@ -1,0 +1,604 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.metadata
+import json
+import os
+import re
+import sys
+import sysconfig
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import torch
+
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_DTYPE_NAMES = {
+    "float16": torch.float16,
+    "float32": torch.float32,
+}
+_MIGRAPHX_TYPE_NAMES = {
+    "float16": "half_type",
+    "float32": "float_type",
+}
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def migraphx_manifest_sha256(path: str | Path) -> str:
+    """Return a sidecar digest for callers that pin an explicit artifact."""
+
+    manifest_path = Path(path)
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"MIGraphX artifact manifest not found: {manifest_path}")
+    return _file_sha256(manifest_path)
+
+
+def _mapping(value: object, label: str) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise RuntimeError(f"MIGraphX manifest {label} must be an object")
+    return value
+
+
+def _exact_keys(value: Mapping[str, object], expected: set[str], label: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise RuntimeError(
+            f"MIGraphX manifest {label} keys mismatch: "
+            f"expected {sorted(expected)}, got {sorted(actual)}"
+        )
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"MIGraphX manifest {label} must be a non-empty string")
+    return value
+
+
+def _sha256_text(value: object, label: str) -> str:
+    result = _text(value, label)
+    if not _SHA256_RE.fullmatch(result):
+        raise RuntimeError(f"MIGraphX manifest {label} must be lowercase SHA256")
+    return result
+
+
+def _positive_int(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise RuntimeError(f"MIGraphX manifest {label} must be a positive integer")
+    return value
+
+
+def _integer_tuple(value: object, label: str, *, positive: bool) -> tuple[int, ...]:
+    if not isinstance(value, list) or not value:
+        raise RuntimeError(f"MIGraphX manifest {label} must be a non-empty integer list")
+    result: list[int] = []
+    for item in value:
+        if isinstance(item, bool) or not isinstance(item, int):
+            raise RuntimeError(f"MIGraphX manifest {label} must contain only integers")
+        if positive and item <= 0:
+            raise RuntimeError(f"MIGraphX manifest {label} must contain only positive integers")
+        if not positive and item < 0:
+            raise RuntimeError(f"MIGraphX manifest {label} cannot contain negative integers")
+        result.append(item)
+    return tuple(result)
+
+
+@dataclass(frozen=True)
+class MigraphxTensorContract:
+    logical_name: str
+    parameter_name: str
+    dtype_name: str
+    shape: tuple[int, ...]
+    strides: tuple[int, ...]
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return _DTYPE_NAMES[self.dtype_name]
+
+    @property
+    def ndim(self) -> int:
+        return len(self.shape)
+
+    @classmethod
+    def from_json(cls, value: object, label: str) -> "MigraphxTensorContract":
+        data = _mapping(value, label)
+        _exact_keys(
+            data,
+            {"logical_name", "parameter_name", "dtype", "shape", "strides"},
+            label,
+        )
+        dtype_name = _text(data["dtype"], f"{label}.dtype")
+        if dtype_name not in _DTYPE_NAMES:
+            raise RuntimeError(
+                f"MIGraphX manifest {label}.dtype is unsupported: {dtype_name!r}"
+            )
+        shape = _integer_tuple(data["shape"], f"{label}.shape", positive=True)
+        strides = _integer_tuple(data["strides"], f"{label}.strides", positive=False)
+        if len(shape) != len(strides):
+            raise RuntimeError(
+                f"MIGraphX manifest {label} shape/stride rank mismatch: "
+                f"{len(shape)} != {len(strides)}"
+            )
+        return cls(
+            logical_name=_text(data["logical_name"], f"{label}.logical_name"),
+            parameter_name=_text(data["parameter_name"], f"{label}.parameter_name"),
+            dtype_name=dtype_name,
+            shape=shape,
+            strides=strides,
+        )
+
+
+@dataclass(frozen=True)
+class MigraphxArtifactManifest:
+    """Immutable sidecar contract for one already-compiled MXR program."""
+
+    manifest_path: Path
+    purpose: str
+    artifact_path: Path
+    artifact_sha256: str
+    artifact_size_bytes: int
+    source_sha256: str
+    platform: str
+    device_arch: str
+    torch_version: str
+    torch_hip_version: str
+    migraphx_version: str
+    torch_migraphx_version: str
+    internal_precision: str
+    stream_type: str
+    inputs: tuple[MigraphxTensorContract, ...]
+    outputs: tuple[MigraphxTensorContract, ...]
+
+    def validate_files(self, source_path: str | Path) -> None:
+        artifact = self.artifact_path
+        if not artifact.is_file():
+            raise FileNotFoundError(f"MIGraphX artifact not found: {artifact}")
+        if artifact.stat().st_size != self.artifact_size_bytes:
+            raise RuntimeError(
+                f"MIGraphX artifact size mismatch: {artifact.stat().st_size} "
+                f"!= {self.artifact_size_bytes}"
+            )
+        actual_artifact_sha = _file_sha256(artifact)
+        if actual_artifact_sha != self.artifact_sha256:
+            raise RuntimeError(
+                f"MIGraphX artifact SHA256 mismatch: {actual_artifact_sha} "
+                f"!= {self.artifact_sha256}"
+            )
+        source = Path(source_path)
+        if not source.is_file():
+            raise FileNotFoundError(f"MIGraphX source model not found: {source}")
+        actual_source_sha = _file_sha256(source)
+        if actual_source_sha != self.source_sha256:
+            raise RuntimeError(
+                f"MIGraphX source model SHA256 mismatch: {actual_source_sha} "
+                f"!= {self.source_sha256}"
+            )
+
+    @classmethod
+    def load(cls, path: str | Path) -> "MigraphxArtifactManifest":
+        manifest_path = Path(path)
+        if not manifest_path.is_file():
+            raise FileNotFoundError(f"MIGraphX artifact manifest not found: {manifest_path}")
+        try:
+            root = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError(
+                f"Could not read MIGraphX artifact manifest: {manifest_path}"
+            ) from exc
+        data = _mapping(root, "root")
+        _exact_keys(
+            data,
+            {"schema_version", "backend", "purpose", "artifact", "source", "target", "program"},
+            "root",
+        )
+        if data["schema_version"] != 1:
+            raise RuntimeError(
+                f"Unsupported MIGraphX manifest schema_version: {data['schema_version']!r}"
+            )
+        if data["backend"] != "migraphx":
+            raise RuntimeError(
+                f"MIGraphX manifest backend must be 'migraphx', got {data['backend']!r}"
+            )
+
+        artifact = _mapping(data["artifact"], "artifact")
+        _exact_keys(artifact, {"path", "sha256", "size_bytes"}, "artifact")
+        artifact_path = Path(_text(artifact["path"], "artifact.path"))
+        if not artifact_path.is_absolute():
+            artifact_path = manifest_path.parent / artifact_path
+
+        source = _mapping(data["source"], "source")
+        _exact_keys(source, {"sha256"}, "source")
+        target = _mapping(data["target"], "target")
+        _exact_keys(
+            target,
+            {
+                "platform",
+                "device_arch",
+                "torch_version",
+                "torch_hip_version",
+                "migraphx_version",
+                "torch_migraphx_version",
+            },
+            "target",
+        )
+        program = _mapping(data["program"], "program")
+        _exact_keys(
+            program,
+            {"internal_precision", "stream_type", "inputs", "outputs"},
+            "program",
+        )
+        raw_inputs = program["inputs"]
+        raw_outputs = program["outputs"]
+        if not isinstance(raw_inputs, list) or not isinstance(raw_outputs, list):
+            raise RuntimeError("MIGraphX manifest program inputs/outputs must be lists")
+        inputs = tuple(
+            MigraphxTensorContract.from_json(value, f"program.inputs[{index}]")
+            for index, value in enumerate(raw_inputs)
+        )
+        outputs = tuple(
+            MigraphxTensorContract.from_json(value, f"program.outputs[{index}]")
+            for index, value in enumerate(raw_outputs)
+        )
+        if len(inputs) != 1:
+            raise RuntimeError(
+                f"MIGraphX pointer runner requires exactly one input, got {len(inputs)}"
+            )
+        if not outputs:
+            raise RuntimeError("MIGraphX pointer runner requires at least one output")
+        logical_names = [item.logical_name for item in (*inputs, *outputs)]
+        parameter_names = [item.parameter_name for item in (*inputs, *outputs)]
+        if len(logical_names) != len(set(logical_names)):
+            raise RuntimeError("MIGraphX manifest logical tensor names must be unique")
+        if len(parameter_names) != len(set(parameter_names)):
+            raise RuntimeError("MIGraphX manifest parameter tensor names must be unique")
+
+        return cls(
+            manifest_path=manifest_path,
+            purpose=_text(data["purpose"], "purpose"),
+            artifact_path=artifact_path,
+            artifact_sha256=_sha256_text(artifact["sha256"], "artifact.sha256"),
+            artifact_size_bytes=_positive_int(artifact["size_bytes"], "artifact.size_bytes"),
+            source_sha256=_sha256_text(source["sha256"], "source.sha256"),
+            platform=_text(target["platform"], "target.platform"),
+            device_arch=_text(target["device_arch"], "target.device_arch"),
+            torch_version=_text(target["torch_version"], "target.torch_version"),
+            torch_hip_version=_text(target["torch_hip_version"], "target.torch_hip_version"),
+            migraphx_version=_text(target["migraphx_version"], "target.migraphx_version"),
+            torch_migraphx_version=_text(
+                target["torch_migraphx_version"], "target.torch_migraphx_version"
+            ),
+            internal_precision=_text(program["internal_precision"], "program.internal_precision"),
+            stream_type=_text(program["stream_type"], "program.stream_type"),
+            inputs=inputs,
+            outputs=outputs,
+        )
+
+
+@dataclass(frozen=True)
+class _RuntimeBindings:
+    migraphx: Any
+    mgx_argument_from_ptr: Any
+    tensors_from_mgx_arguments: Any
+    migraphx_version: str
+    torch_migraphx_version: str
+
+
+def _package_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise RuntimeError(f"Required MIGraphX runtime package is missing: {name}") from exc
+
+
+def _migraphx_python_search_dirs() -> tuple[Path, ...]:
+    """Find only official ROCm libraries built for this Python ABI."""
+
+    roots: list[Path] = []
+    configured_root = os.environ.get("ROCM_PATH", "").strip()
+    if configured_root:
+        roots.append(Path(configured_root))
+    roots.append(Path("/opt/rocm"))
+    opt = Path("/opt")
+    if opt.is_dir():
+        roots.extend(sorted(opt.glob("rocm-*"), reverse=True))
+
+    extension_suffix = str(sysconfig.get_config_var("EXT_SUFFIX") or "")
+    candidates: list[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        library_dir = root / "lib"
+        key = str(library_dir.resolve(strict=False))
+        if key in seen:
+            continue
+        seen.add(key)
+        if extension_suffix and (library_dir / f"migraphx{extension_suffix}").is_file():
+            candidates.append(library_dir)
+    return tuple(candidates)
+
+
+def _import_migraphx() -> Any:
+    try:
+        return importlib.import_module("migraphx")
+    except ModuleNotFoundError as exc:
+        if exc.name != "migraphx":
+            raise
+
+    searched: list[str] = []
+    for library_dir in _migraphx_python_search_dirs():
+        searched.append(str(library_dir))
+        sys.path.insert(0, str(library_dir))
+        try:
+            importlib.invalidate_caches()
+            return importlib.import_module("migraphx")
+        except ModuleNotFoundError as exc:
+            if exc.name != "migraphx":
+                raise
+        finally:
+            try:
+                sys.path.remove(str(library_dir))
+            except ValueError:
+                pass
+    raise RuntimeError(
+        "The AMD MIGraphX artifact backend requires the official MIGraphX "
+        "Python bindings for this interpreter ABI. Searched ROCm library "
+        f"directories: {searched!r}"
+    )
+
+
+def _load_runtime_bindings() -> _RuntimeBindings:
+    migraphx = _import_migraphx()
+    original_path = os.environ.get("PATH")
+    interpreter_bin = str(Path(sys.executable).parent)
+    os.environ["PATH"] = os.pathsep.join(
+        part for part in (interpreter_bin, original_path or "") if part
+    )
+    try:
+        # The supported upstream package owns the pointer bridge/JIT lifecycle.
+        # Only the active interpreter's bin is temporarily prepended so a shell
+        # PATH or external research environment cannot change that dependency.
+        importlib.import_module("torch_migraphx")
+        utils = importlib.import_module("torch_migraphx.fx.utils")
+        mgx_argument_from_ptr = utils.mgx_argument_from_ptr
+        tensors_from_mgx_arguments = utils.tensors_from_mgx_arguments
+    except (ImportError, RuntimeError) as exc:
+        raise RuntimeError(
+            "The AMD MIGraphX artifact backend requires the product-provisioned "
+            "MIGraphX and torch-migraphx runtimes"
+        ) from exc
+    finally:
+        if original_path is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = original_path
+    migraphx_version = getattr(migraphx, "__version__", None)
+    if not isinstance(migraphx_version, str) or not migraphx_version:
+        migraphx_version = _package_version("migraphx")
+    return _RuntimeBindings(
+        migraphx=migraphx,
+        mgx_argument_from_ptr=mgx_argument_from_ptr,
+        tensors_from_mgx_arguments=tensors_from_mgx_arguments,
+        migraphx_version=migraphx_version,
+        torch_migraphx_version=_package_version("torch-migraphx"),
+    )
+
+
+def _shape_contract(shape: object) -> tuple[str, tuple[int, ...], tuple[int, ...]]:
+    return (
+        str(shape.type_string()),
+        tuple(int(value) for value in shape.lens()),
+        tuple(int(value) for value in shape.strides()),
+    )
+
+
+class MigraphxArtifactRunner:
+    """Fail-closed GPU-pointer runner for an explicitly supplied MXR artifact.
+
+    The sidecar is the compatibility boundary. A missing dependency, changed
+    source/artifact digest, platform/runtime/architecture mismatch, tensor ABI
+    mismatch, or invalid pointer result raises immediately. This class never
+    copies the input or falls back to PyTorch/another backend.
+    """
+
+    def __init__(
+        self,
+        manifest_path: str | Path,
+        *,
+        source_path: str | Path,
+        device: torch.device,
+        expected_purpose: str,
+    ) -> None:
+        self._program = None
+        self._bindings: _RuntimeBindings | None = None
+        self._arguments: dict[str, object] = {}
+        self._output_buffers: dict[str, torch.Tensor] = {}
+        self.manifest = MigraphxArtifactManifest.load(manifest_path)
+        if self.manifest.purpose != expected_purpose:
+            raise RuntimeError(
+                f"MIGraphX artifact purpose mismatch: {self.manifest.purpose!r} "
+                f"!= {expected_purpose!r}"
+            )
+        self.device = torch.device(device)
+        self._validate_files(Path(source_path))
+        bindings = _load_runtime_bindings()
+        self._validate_runtime(bindings)
+        program = bindings.migraphx.load(str(self.manifest.artifact_path))
+        if not program.is_compiled():
+            raise RuntimeError("MIGraphX artifact is not a compiled program")
+        self._validate_program(program)
+
+        self.input_names = [item.logical_name for item in self.manifest.inputs]
+        self.input_dtypes = {item.logical_name: item.dtype for item in self.manifest.inputs}
+        self.output_names = [item.logical_name for item in self.manifest.outputs]
+        self.outputs = {item.logical_name: item for item in self.manifest.outputs}
+        self.artifact_path = self.manifest.artifact_path
+        self.batch_size = int(self.manifest.inputs[0].shape[0])
+        self._output_shapes = tuple(program.get_output_shapes())
+        for contract in self.manifest.outputs:
+            buffer = torch.empty_strided(
+                contract.shape,
+                contract.strides,
+                dtype=contract.dtype,
+                device=self.device,
+            )
+            self._output_buffers[contract.parameter_name] = buffer
+            self._arguments[contract.parameter_name] = bindings.mgx_argument_from_ptr(
+                buffer.data_ptr(), program.get_parameter_shapes()[contract.parameter_name]
+            )
+        self._bindings = bindings
+        self._program = program
+
+    def _validate_files(self, source_path: Path) -> None:
+        self.manifest.validate_files(source_path)
+
+    def _validate_runtime(self, bindings: _RuntimeBindings) -> None:
+        if self.device.type != "cuda" or torch.version.hip is None:
+            raise RuntimeError("MIGraphX artifact backend requires a ROCm CUDA device")
+        if not torch.cuda.is_available():
+            raise RuntimeError("MIGraphX artifact backend requires an available ROCm GPU")
+        if self.manifest.platform != sys.platform:
+            raise RuntimeError(
+                f"MIGraphX platform mismatch: {sys.platform!r} != {self.manifest.platform!r}"
+            )
+        versions = {
+            "torch": str(torch.__version__),
+            "torch_hip": str(torch.version.hip),
+            "migraphx": bindings.migraphx_version,
+            "torch_migraphx": bindings.torch_migraphx_version,
+        }
+        expected = {
+            "torch": self.manifest.torch_version,
+            "torch_hip": self.manifest.torch_hip_version,
+            "migraphx": self.manifest.migraphx_version,
+            "torch_migraphx": self.manifest.torch_migraphx_version,
+        }
+        if versions != expected:
+            raise RuntimeError(
+                f"MIGraphX runtime version mismatch: actual={versions!r}, expected={expected!r}"
+            )
+        properties = torch.cuda.get_device_properties(self.device)
+        actual_arch = getattr(properties, "gcnArchName", None)
+        if actual_arch != self.manifest.device_arch:
+            raise RuntimeError(
+                f"MIGraphX device architecture mismatch: {actual_arch!r} "
+                f"!= {self.manifest.device_arch!r}"
+            )
+
+    def _validate_program(self, program: object) -> None:
+        parameters = program.get_parameter_shapes()
+        expected_names = {
+            item.parameter_name for item in (*self.manifest.inputs, *self.manifest.outputs)
+        }
+        if set(parameters) != expected_names:
+            raise RuntimeError(
+                "MIGraphX program parameter names mismatch: "
+                f"{sorted(parameters)} != {sorted(expected_names)}"
+            )
+        for contract in (*self.manifest.inputs, *self.manifest.outputs):
+            actual = _shape_contract(parameters[contract.parameter_name])
+            expected = (
+                _MIGRAPHX_TYPE_NAMES[contract.dtype_name],
+                contract.shape,
+                contract.strides,
+            )
+            if actual != expected:
+                raise RuntimeError(
+                    f"MIGraphX tensor ABI mismatch for {contract.parameter_name!r}: "
+                    f"{actual!r} != {expected!r}"
+                )
+        output_shapes = tuple(program.get_output_shapes())
+        if len(output_shapes) != len(self.manifest.outputs):
+            raise RuntimeError(
+                f"MIGraphX output count mismatch: {len(output_shapes)} "
+                f"!= {len(self.manifest.outputs)}"
+            )
+        for index, (shape, contract) in enumerate(zip(output_shapes, self.manifest.outputs)):
+            actual = _shape_contract(shape)
+            expected = (
+                _MIGRAPHX_TYPE_NAMES[contract.dtype_name],
+                contract.shape,
+                contract.strides,
+            )
+            if actual != expected:
+                raise RuntimeError(
+                    f"MIGraphX output ABI mismatch at index {index}: "
+                    f"{actual!r} != {expected!r}"
+                )
+
+    def close(self) -> None:
+        self._arguments.clear()
+        self._output_buffers.clear()
+        self._output_shapes = ()
+        self._program = None
+        self._bindings = None
+
+    def infer(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        if self._program is None or self._bindings is None:
+            raise RuntimeError("MIGraphX artifact runner is closed")
+        if set(inputs) != set(self.input_names):
+            raise RuntimeError(
+                f"MIGraphX input names mismatch: {sorted(inputs)} != {sorted(self.input_names)}"
+            )
+        contract = self.manifest.inputs[0]
+        value = inputs[contract.logical_name]
+        if value.device != self.device:
+            raise RuntimeError(
+                f"MIGraphX input device mismatch: {value.device} != {self.device}"
+            )
+        if value.dtype != contract.dtype:
+            raise RuntimeError(
+                f"MIGraphX input dtype mismatch: {value.dtype} != {contract.dtype}"
+            )
+        if tuple(value.shape) != contract.shape or tuple(value.stride()) != contract.strides:
+            raise RuntimeError(
+                f"MIGraphX input ABI mismatch: shape={tuple(value.shape)}, "
+                f"strides={tuple(value.stride())}; expected shape={contract.shape}, "
+                f"strides={contract.strides}"
+            )
+        parameter_shape = self._program.get_parameter_shapes()[contract.parameter_name]
+        self._arguments[contract.parameter_name] = self._bindings.mgx_argument_from_ptr(
+            value.data_ptr(), parameter_shape
+        )
+        stream = torch.cuda.current_stream(self.device)
+        raw_outputs = self._program.run_async(
+            self._arguments,
+            stream.cuda_stream,
+            self.manifest.stream_type,
+        )
+        output_tensors = self._bindings.tensors_from_mgx_arguments(
+            raw_outputs, self._output_shapes
+        )
+        if len(output_tensors) != len(self.manifest.outputs):
+            raise RuntimeError(
+                f"MIGraphX runtime output count mismatch: {len(output_tensors)} "
+                f"!= {len(self.manifest.outputs)}"
+            )
+        result: dict[str, torch.Tensor] = {}
+        for value, output_contract in zip(output_tensors, self.manifest.outputs):
+            if (
+                value.device != self.device
+                or value.dtype != output_contract.dtype
+                or tuple(value.shape) != output_contract.shape
+                or tuple(value.stride()) != output_contract.strides
+            ):
+                raise RuntimeError(
+                    f"MIGraphX runtime output ABI mismatch for "
+                    f"{output_contract.logical_name!r}"
+                )
+            owned_buffer = self._output_buffers[output_contract.parameter_name]
+            if value.data_ptr() != owned_buffer.data_ptr():
+                raise RuntimeError(
+                    "MIGraphX runtime output pointer mismatch for "
+                    f"{output_contract.logical_name!r}: {value.data_ptr()} != "
+                    f"owned {owned_buffer.data_ptr()}"
+                )
+            result[output_contract.logical_name] = value
+        return result

--- a/jasna/mosaic/rfdetr.py
+++ b/jasna/mosaic/rfdetr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -71,12 +72,21 @@ class RfDetrMosaicDetectionModel:
         score_threshold: float = DEFAULT_SCORE_THRESHOLD,
         max_select: int = DEFAULT_MAX_SELECT,
         fp16: bool = True,
+        amd_migraphx_manifest_path: Path | None = None,
     ) -> None:
         self.weights_path = weights_path
         self.batch_size = int(batch_size)
         self.device = device
         self.resolution = int(resolution)
         self.dynamic_batch = bool(dynamic_batch)
+        amd_device = is_amd_device(self.device)
+        if amd_migraphx_manifest_path is not None and (
+            not amd_device or sys.platform != "linux"
+        ):
+            raise RuntimeError(
+                "The experimental RF-DETR MIGraphX manifest requires a Linux "
+                "AMD/ROCm device"
+            )
         self.score_threshold = float(score_threshold)
         self.max_select = int(max_select)
         self._normalization_cache: dict[
@@ -85,24 +95,42 @@ class RfDetrMosaicDetectionModel:
         if self.batch_size <= 0:
             raise ValueError(f"batch_size must be > 0, got {batch_size}")
 
-        if is_amd_device(self.device):
+        if amd_device:
             if torch_variant is None:
                 raise RuntimeError(
                     f"RF-DETR on AMD requires a torch variant for {weights_path.name}"
                 )
-            from jasna.mosaic.rfdetr_torch_runner import RfDetrTorchRunner
+            if amd_migraphx_manifest_path is not None:
+                from jasna.mosaic.rfdetr_migraphx_runner import RfDetrMigraphxRunner
 
-            self.runner = RfDetrTorchRunner(
-                self.weights_path,
-                input_shapes=[
-                    (self.batch_size, 3, self.resolution, self.resolution)
-                ],
-                device=self.device,
-                fp16=bool(fp16),
-                resolution=self.resolution,
-                variant=torch_variant,
-            )
-            self.engine_path = self.weights_path
+                self.runner = RfDetrMigraphxRunner(
+                    Path(amd_migraphx_manifest_path),
+                    weights_path=self.weights_path,
+                    device=self.device,
+                    fp16=bool(fp16),
+                    resolution=self.resolution,
+                    variant=torch_variant,
+                )
+                # The accepted MXR is static. Keep the external Pipeline batch
+                # unchanged; _infer below preserves order while dispatching the
+                # runner's own static batch and cloning its pointer-backed outputs.
+                self.batch_size = int(self.runner.batch_size)
+                self.dynamic_batch = False
+                self.engine_path = self.runner.artifact_path
+            else:
+                from jasna.mosaic.rfdetr_torch_runner import RfDetrTorchRunner
+
+                self.runner = RfDetrTorchRunner(
+                    self.weights_path,
+                    input_shapes=[
+                        (self.batch_size, 3, self.resolution, self.resolution)
+                    ],
+                    device=self.device,
+                    fp16=bool(fp16),
+                    resolution=self.resolution,
+                    variant=torch_variant,
+                )
+                self.engine_path = self.weights_path
         elif is_nvidia_device(self.device):
             self.engine_path = get_onnx_tensorrt_engine_path(
                 self.weights_path, batch_size=self.batch_size, fp16=bool(fp16),
@@ -189,6 +217,9 @@ class RfDetrMosaicDetectionModel:
             outputs = self.runner.infer({self._input_name: padded})
             for name in output_parts:
                 output_parts[name].append(
+                    # Direct MIGraphX outputs are pointer-backed and can be
+                    # overwritten by the next static dispatch. Clone every
+                    # effective slice before that dispatch is issued.
                     outputs[name][:effective_batch_size].clone()
                 )
         return {

--- a/jasna/mosaic/rfdetr_migraphx_runner.py
+++ b/jasna/mosaic/rfdetr_migraphx_runner.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import torch
+
+from jasna.accelerator import is_amd_device
+from jasna.migraphx_artifact import MigraphxArtifactRunner
+
+
+logger = logging.getLogger(__name__)
+
+_PURPOSE = "jasna-rfdetr-v6-medium-segmentation"
+_PLATFORM = "linux"
+_DEVICE_ARCH = "gfx1100"
+_SUPPORTED_STATIC_BATCHES = frozenset({1, 2})
+_SUPPORTED_INTERNAL_PRECISIONS = frozenset(
+    {
+        "fp16",
+        "mixed-convolution-dot-fp16",
+        "mixed-dot-projector-convolution-fp16",
+    }
+)
+_INPUT_SHAPE_TAIL = (3, 576, 576)
+_INPUT_STRIDES = (995328, 331776, 576, 1)
+_OUTPUT_CONTRACTS = {
+    "dets": {
+        "parameter_name": "main:#output_0",
+        "shape_tail": (200, 4),
+        "strides": (800, 4, 1),
+    },
+    "labels": {
+        "parameter_name": "main:#output_1",
+        "shape_tail": (200, 3),
+        "strides": (600, 3, 1),
+    },
+    "masks": {
+        "parameter_name": "main:#output_2",
+        "shape_tail": (200, 144, 144),
+        "strides": (4147200, 20736, 144, 1),
+    },
+}
+
+
+class RfDetrMigraphxRunner:
+    """Linux gfx1100 AMD RF-DETR runner backed by a verified MXR sidecar.
+
+    Selection is deliberately outside this module. Once an explicit sidecar
+    reaches this runner, every validation or execution failure is terminal and
+    must not fall back to the PyTorch detector.
+    """
+
+    def __init__(
+        self,
+        manifest_path: Path,
+        *,
+        weights_path: Path,
+        device: torch.device,
+        fp16: bool,
+        resolution: int,
+        variant: str | None,
+    ) -> None:
+        if not fp16:
+            raise RuntimeError(
+                "The experimental RF-DETR MIGraphX artifact requires "
+                "FP16-enabled execution; --no-fp16 is incompatible"
+            )
+        if int(resolution) != 576 or variant != "medium":
+            raise RuntimeError(
+                "The experimental RF-DETR MIGraphX artifact only supports "
+                "rfdetr-v6 medium at 576x576"
+            )
+        self._validate_host(device)
+        runner = MigraphxArtifactRunner(
+            manifest_path,
+            source_path=weights_path,
+            device=device,
+            expected_purpose=_PURPOSE,
+        )
+        try:
+            self._validate_contract(runner)
+        except BaseException:
+            runner.close()
+            raise
+        self._runner = runner
+        self.input_names = runner.input_names
+        self.input_dtypes = runner.input_dtypes
+        self.output_names = runner.output_names
+        self.outputs = runner.outputs
+        self.batch_size = runner.batch_size
+        self.artifact_path = runner.artifact_path
+        logger.info(
+            "AMD RF-DETR direct MIGraphX artifact loaded: %s "
+            "(static_batch=%d, internal_precision=%s, fallback=False)",
+            self.artifact_path,
+            self.batch_size,
+            runner.manifest.internal_precision,
+        )
+
+    @staticmethod
+    def _validate_host(device: torch.device) -> None:
+        """Reject ineligible hosts before importing/loading an MXR runtime."""
+
+        resolved = torch.device(device)
+        if sys.platform != _PLATFORM:
+            raise RuntimeError("RF-DETR MIGraphX artifacts are supported on Linux only")
+        if not is_amd_device(resolved):
+            raise RuntimeError("RF-DETR MIGraphX artifacts require an AMD/ROCm device")
+        if resolved.type != "cuda" or getattr(torch.version, "hip", None) is None:
+            raise RuntimeError("RF-DETR MIGraphX artifacts require a ROCm CUDA device")
+        if not torch.cuda.is_available():
+            raise RuntimeError("RF-DETR MIGraphX artifacts require an available ROCm GPU")
+        properties = torch.cuda.get_device_properties(resolved)
+        if getattr(properties, "gcnArchName", None) != _DEVICE_ARCH:
+            raise RuntimeError(
+                "RF-DETR MIGraphX artifacts require "
+                f"{_DEVICE_ARCH}, got {getattr(properties, 'gcnArchName', None)!r}"
+            )
+
+    @staticmethod
+    def _validate_contract(runner: MigraphxArtifactRunner) -> None:
+        manifest = runner.manifest
+        if manifest.platform != _PLATFORM or manifest.device_arch != _DEVICE_ARCH:
+            raise RuntimeError(
+                "RF-DETR MIGraphX target mismatch: "
+                f"platform={manifest.platform!r}, device_arch={manifest.device_arch!r}; "
+                f"expected {_PLATFORM!r}/{_DEVICE_ARCH!r}"
+            )
+        if manifest.internal_precision not in _SUPPORTED_INTERNAL_PRECISIONS:
+            raise RuntimeError(
+                "RF-DETR MIGraphX internal precision is outside the proven set: "
+                f"{manifest.internal_precision!r}; expected one of "
+                f"{sorted(_SUPPORTED_INTERNAL_PRECISIONS)!r}"
+            )
+        if manifest.stream_type != "ihipStream_t":
+            raise RuntimeError(
+                f"RF-DETR MIGraphX stream ABI mismatch: {manifest.stream_type!r}"
+            )
+        if len(manifest.inputs) != 1:
+            raise RuntimeError("RF-DETR MIGraphX requires exactly one input contract")
+        input_contract = manifest.inputs[0]
+        if len(input_contract.shape) != 4:
+            raise RuntimeError(
+                "RF-DETR MIGraphX input contract must have rank 4: "
+                f"{input_contract!r}"
+            )
+        batch_size = int(input_contract.shape[0])
+        if batch_size not in _SUPPORTED_STATIC_BATCHES:
+            raise RuntimeError(
+                "RF-DETR MIGraphX static batch is outside the proven set: "
+                f"{batch_size}; expected one of {sorted(_SUPPORTED_STATIC_BATCHES)}"
+            )
+        expected_input = {
+            "logical_name": "input",
+            "parameter_name": "input",
+            "dtype_name": "float32",
+            "shape": (batch_size, *_INPUT_SHAPE_TAIL),
+            "strides": _INPUT_STRIDES,
+        }
+        actual_input = {
+            "logical_name": input_contract.logical_name,
+            "parameter_name": input_contract.parameter_name,
+            "dtype_name": input_contract.dtype_name,
+            "shape": input_contract.shape,
+            "strides": input_contract.strides,
+        }
+        if actual_input != expected_input:
+            raise RuntimeError(
+                "RF-DETR MIGraphX input contract mismatch: "
+                f"{actual_input!r} != {expected_input!r}"
+            )
+        if [item.logical_name for item in manifest.outputs] != list(_OUTPUT_CONTRACTS):
+            raise RuntimeError(
+                "RF-DETR MIGraphX logical output names/order must be "
+                "['dets', 'labels', 'masks']"
+            )
+        for contract in manifest.outputs:
+            expected = _OUTPUT_CONTRACTS[contract.logical_name]
+            if (
+                contract.dtype_name != "float32"
+                or contract.parameter_name != expected["parameter_name"]
+                or contract.shape != (batch_size, *expected["shape_tail"])
+                or contract.strides != expected["strides"]
+            ):
+                raise RuntimeError(
+                    f"RF-DETR MIGraphX output contract mismatch: {contract!r}"
+                )
+
+    def close(self) -> None:
+        if self._runner is not None:
+            self._runner.close()
+            self._runner = None
+
+    def infer(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        if self._runner is None:
+            raise RuntimeError("RF-DETR MIGraphX runner is closed")
+        return self._runner.infer(inputs)

--- a/tests/test_migraphx_artifact.py
+++ b/tests/test_migraphx_artifact.py
@@ -1,0 +1,695 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from jasna.migraphx_artifact import (
+    MigraphxArtifactManifest,
+    MigraphxArtifactRunner,
+    MigraphxTensorContract,
+    _RuntimeBindings,
+    migraphx_manifest_sha256,
+)
+from jasna.mosaic.rfdetr_migraphx_runner import RfDetrMigraphxRunner
+
+
+class _FakeShape:
+    def __init__(
+        self,
+        shape: tuple[int, ...],
+        strides: tuple[int, ...],
+        dtype: str = "float_type",
+    ) -> None:
+        self._shape = shape
+        self._strides = strides
+        self._dtype = dtype
+
+    def lens(self):
+        return self._shape
+
+    def strides(self):
+        return self._strides
+
+    def type_string(self):
+        return self._dtype
+
+
+class _FakeProgram:
+    def __init__(self, parameters: dict[str, _FakeShape], outputs: list[_FakeShape]) -> None:
+        self.parameters = parameters
+        self.outputs = outputs
+        self.run_calls: list[tuple[dict[str, object], int, str]] = []
+
+    def is_compiled(self) -> bool:
+        return True
+
+    def get_parameter_shapes(self):
+        return self.parameters
+
+    def get_output_shapes(self):
+        return self.outputs
+
+    def run_async(self, arguments, stream, stream_type):
+        self.run_calls.append((dict(arguments), stream, stream_type))
+        return object()
+
+
+class _FakeDevice:
+    type = "cuda"
+    index = 0
+
+    def __str__(self) -> str:
+        return "cuda:0"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _FakeDevice)
+
+
+class _FakeTensor:
+    _next_pointer = 100
+
+    def __init__(
+        self,
+        shape: tuple[int, ...],
+        strides: tuple[int, ...],
+        dtype: torch.dtype,
+        device: _FakeDevice,
+    ) -> None:
+        self.shape = shape
+        self._strides = strides
+        self.dtype = dtype
+        self.device = device
+        self._pointer = _FakeTensor._next_pointer
+        _FakeTensor._next_pointer += 1
+
+    def stride(self):
+        return self._strides
+
+    def data_ptr(self) -> int:
+        return self._pointer
+
+
+class _FakeTorch:
+    float16 = torch.float16
+    float32 = torch.float32
+    __version__ = "torch-test"
+    version = SimpleNamespace(hip="hip-test")
+
+    def __init__(self) -> None:
+        self.device_value = _FakeDevice()
+        self.allocations: list[_FakeTensor] = []
+        self.cuda = SimpleNamespace(
+            is_available=lambda: True,
+            get_device_properties=lambda _device: SimpleNamespace(gcnArchName="gfx-test"),
+            current_stream=lambda _device: SimpleNamespace(cuda_stream=1234),
+        )
+
+    def device(self, _value) -> _FakeDevice:
+        return self.device_value
+
+    def empty_strided(self, shape, strides, *, dtype, device) -> _FakeTensor:
+        tensor = _FakeTensor(tuple(shape), tuple(strides), dtype, device)
+        self.allocations.append(tensor)
+        return tensor
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _manifest_dict(
+    artifact: Path,
+    source: Path,
+    *,
+    artifact_sha256: str | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "backend": "migraphx",
+        "purpose": "test-purpose",
+        "artifact": {
+            "path": artifact.name,
+            "sha256": artifact_sha256 or _sha256(artifact),
+            "size_bytes": artifact.stat().st_size,
+        },
+        "source": {"sha256": _sha256(source)},
+        "target": {
+            "platform": "linux",
+            "device_arch": "gfx-test",
+            "torch_version": "torch-test",
+            "torch_hip_version": "hip-test",
+            "migraphx_version": "migraphx-test",
+            "torch_migraphx_version": "torch-migraphx-test",
+        },
+        "program": {
+            "internal_precision": "fp16",
+            "stream_type": "ihipStream_t",
+            "inputs": [
+                {
+                    "logical_name": "input",
+                    "parameter_name": "input",
+                    "dtype": "float32",
+                    "shape": [2, 3, 4, 4],
+                    "strides": [48, 16, 4, 1],
+                }
+            ],
+            "outputs": [
+                {
+                    "logical_name": "dets",
+                    "parameter_name": "main:#output_0",
+                    "dtype": "float32",
+                    "shape": [2, 2, 4],
+                    "strides": [8, 4, 1],
+                },
+                {
+                    "logical_name": "labels",
+                    "parameter_name": "main:#output_1",
+                    "dtype": "float32",
+                    "shape": [2, 2, 3],
+                    "strides": [6, 3, 1],
+                },
+                {
+                    "logical_name": "masks",
+                    "parameter_name": "main:#output_2",
+                    "dtype": "float32",
+                    "shape": [2, 2, 2, 2],
+                    "strides": [8, 4, 2, 1],
+                },
+            ],
+        },
+    }
+
+
+def _write_fixture(tmp_path: Path):
+    artifact = tmp_path / "model.mxr"
+    source = tmp_path / "model.pt"
+    artifact.write_bytes(b"compiled")
+    source.write_bytes(b"weights")
+    payload = _manifest_dict(artifact, source)
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+    return manifest, artifact, source, payload
+
+
+def _fake_program(payload: dict[str, object]) -> _FakeProgram:
+    program = payload["program"]
+    contracts = [*program["inputs"], *program["outputs"]]
+    parameters = {
+        item["parameter_name"]: _FakeShape(tuple(item["shape"]), tuple(item["strides"]))
+        for item in contracts
+    }
+    outputs = [parameters[item["parameter_name"]] for item in program["outputs"]]
+    return _FakeProgram(parameters, outputs)
+
+
+def _fake_bindings(program: _FakeProgram, fake_torch: _FakeTorch) -> _RuntimeBindings:
+    def argument_from_ptr(pointer, shape):
+        return (pointer, tuple(shape.lens()), tuple(shape.strides()))
+
+    return _RuntimeBindings(
+        migraphx=SimpleNamespace(load=lambda _path: program),
+        mgx_argument_from_ptr=argument_from_ptr,
+        tensors_from_mgx_arguments=lambda _raw, _shapes: tuple(fake_torch.allocations),
+        migraphx_version="migraphx-test",
+        torch_migraphx_version="torch-migraphx-test",
+    )
+
+
+def _install_fake_artifact_runtime(monkeypatch, payload: dict[str, object]) -> tuple[_FakeTorch, _FakeProgram]:
+    import jasna.migraphx_artifact as module
+
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    fake_torch = _FakeTorch()
+    program = _fake_program(payload)
+    monkeypatch.setattr(module, "torch", fake_torch)
+    monkeypatch.setattr(module, "_load_runtime_bindings", lambda: _fake_bindings(program, fake_torch))
+    return fake_torch, program
+
+
+def test_manifest_is_strict_and_exposes_sidecar_digest(tmp_path: Path) -> None:
+    manifest_path, artifact, _source, payload = _write_fixture(tmp_path)
+
+    manifest = MigraphxArtifactManifest.load(manifest_path)
+
+    assert manifest.artifact_path == artifact
+    assert manifest.inputs[0].shape == (2, 3, 4, 4)
+    assert migraphx_manifest_sha256(manifest_path) == _sha256(manifest_path)
+
+    payload["unexpected"] = True
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="root keys mismatch"):
+        MigraphxArtifactManifest.load(manifest_path)
+
+
+def test_manifest_rejects_invalid_hash_rank_and_empty_outputs(tmp_path: Path) -> None:
+    manifest_path, _artifact, _source, payload = _write_fixture(tmp_path)
+    payload["artifact"]["sha256"] = "not-a-sha"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="lowercase SHA256"):
+        MigraphxArtifactManifest.load(manifest_path)
+
+    payload["artifact"]["sha256"] = "0" * 64
+    payload["program"]["inputs"][0]["strides"] = [1]
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="shape/stride rank mismatch"):
+        MigraphxArtifactManifest.load(manifest_path)
+
+    payload["program"]["inputs"][0]["strides"] = [48, 16, 4, 1]
+    payload["program"]["outputs"] = []
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="at least one output"):
+        MigraphxArtifactManifest.load(manifest_path)
+
+
+def test_runtime_loader_discovers_abi_matched_official_rocm_binding(monkeypatch, tmp_path: Path) -> None:
+    import jasna.migraphx_artifact as module
+
+    rocm = tmp_path / "rocm"
+    library_dir = rocm / "lib"
+    library_dir.mkdir(parents=True)
+    suffix = str(module.sysconfig.get_config_var("EXT_SUFFIX"))
+    (library_dir / f"migraphx{suffix}").touch()
+    monkeypatch.setenv("ROCM_PATH", str(rocm))
+
+    fake_migraphx = SimpleNamespace(__version__="migraphx-test")
+    fake_utils = SimpleNamespace(
+        mgx_argument_from_ptr=object(),
+        tensors_from_mgx_arguments=object(),
+    )
+    calls: list[tuple[str, str]] = []
+
+    def import_module(name: str):
+        calls.append((name, module.os.environ.get("PATH", "")))
+        if name == "migraphx":
+            if str(library_dir) not in module.sys.path:
+                error = ModuleNotFoundError("missing migraphx")
+                error.name = "migraphx"
+                raise error
+            return fake_migraphx
+        if name == "torch_migraphx":
+            return SimpleNamespace()
+        if name == "torch_migraphx.fx.utils":
+            return fake_utils
+        raise AssertionError(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", import_module)
+    monkeypatch.setattr(
+        module,
+        "_package_version",
+        lambda name: "torch-migraphx-test" if name == "torch-migraphx" else "unused",
+    )
+
+    bindings = module._load_runtime_bindings()
+
+    assert bindings.migraphx is fake_migraphx
+    assert bindings.mgx_argument_from_ptr is fake_utils.mgx_argument_from_ptr
+    assert bindings.tensors_from_mgx_arguments is fake_utils.tensors_from_mgx_arguments
+    assert calls[0][0] == "migraphx"
+    assert calls[1][0] == "migraphx"
+    expected_bin = str(Path(module.sys.executable).parent)
+    torch_calls = [path for name, path in calls if name.startswith("torch_migraphx")]
+    assert torch_calls and all(path.split(module.os.pathsep)[0] == expected_bin for path in torch_calls)
+
+
+def test_pointer_runner_uses_owned_output_buffers_and_closes_fail_closed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    manifest_path, _artifact, source, payload = _write_fixture(tmp_path)
+    fake_torch, program = _install_fake_artifact_runtime(monkeypatch, payload)
+    runner = MigraphxArtifactRunner(
+        manifest_path,
+        source_path=source,
+        device=_FakeDevice(),
+        expected_purpose="test-purpose",
+    )
+    input_tensor = _FakeTensor(
+        (2, 3, 4, 4),
+        (48, 16, 4, 1),
+        torch.float32,
+        fake_torch.device_value,
+    )
+
+    outputs = runner.infer({"input": input_tensor})
+
+    assert list(outputs) == ["dets", "labels", "masks"]
+    assert program.run_calls[0][1:] == (1234, "ihipStream_t")
+    assert program.run_calls[0][0]["input"][0] == input_tensor.data_ptr()
+    runner.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        runner.infer({"input": input_tensor})
+
+
+def test_pointer_runner_rejects_foreign_output_and_input_dtype(tmp_path: Path, monkeypatch) -> None:
+    import jasna.migraphx_artifact as module
+
+    manifest_path, _artifact, source, payload = _write_fixture(tmp_path)
+    fake_torch, program = _install_fake_artifact_runtime(monkeypatch, payload)
+
+    def foreign_outputs(_raw, _shapes):
+        return tuple(
+            _FakeTensor(
+                tuple(contract["shape"]),
+                tuple(contract["strides"]),
+                torch.float32,
+                fake_torch.device_value,
+            )
+            for contract in payload["program"]["outputs"]
+        )
+
+    bindings = _fake_bindings(program, fake_torch)
+    bindings = replace(bindings, tensors_from_mgx_arguments=foreign_outputs)
+    monkeypatch.setattr(module, "_load_runtime_bindings", lambda: bindings)
+    runner = MigraphxArtifactRunner(
+        manifest_path,
+        source_path=source,
+        device=_FakeDevice(),
+        expected_purpose="test-purpose",
+    )
+    wrong_dtype = _FakeTensor(
+        (2, 3, 4, 4),
+        (48, 16, 4, 1),
+        torch.float16,
+        fake_torch.device_value,
+    )
+    with pytest.raises(RuntimeError, match="input dtype mismatch"):
+        runner.infer({"input": wrong_dtype})
+
+    input_tensor = _FakeTensor(
+        (2, 3, 4, 4),
+        (48, 16, 4, 1),
+        torch.float32,
+        fake_torch.device_value,
+    )
+    with pytest.raises(RuntimeError, match="output pointer mismatch"):
+        runner.infer({"input": input_tensor})
+
+
+def test_pointer_runner_rejects_hash_source_runtime_and_program_abi(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    import jasna.migraphx_artifact as module
+
+    manifest_path, artifact, source, payload = _write_fixture(tmp_path)
+    artifact.write_bytes(b"tampered")
+    with pytest.raises(RuntimeError, match="SHA256 mismatch"):
+        MigraphxArtifactRunner(
+            manifest_path,
+            source_path=source,
+            device=torch.device("cpu"),
+            expected_purpose="test-purpose",
+        )
+
+    artifact.write_bytes(b"compiled")
+    source.write_bytes(b"different weights")
+    with pytest.raises(RuntimeError, match="source model SHA256 mismatch"):
+        MigraphxArtifactRunner(
+            manifest_path,
+            source_path=source,
+            device=torch.device("cpu"),
+            expected_purpose="test-purpose",
+        )
+
+    source.write_bytes(b"weights")
+    fake_torch, program = _install_fake_artifact_runtime(monkeypatch, payload)
+    bad_bindings = replace(
+        _fake_bindings(program, fake_torch),
+        migraphx_version="wrong-version",
+    )
+    monkeypatch.setattr(module, "_load_runtime_bindings", lambda: bad_bindings)
+    with pytest.raises(RuntimeError, match="runtime version mismatch"):
+        MigraphxArtifactRunner(
+            manifest_path,
+            source_path=source,
+            device=_FakeDevice(),
+            expected_purpose="test-purpose",
+        )
+
+    good_bindings = _fake_bindings(program, fake_torch)
+    program.parameters["input"] = _FakeShape((1, 3, 4, 4), (48, 16, 4, 1))
+    monkeypatch.setattr(module, "_load_runtime_bindings", lambda: good_bindings)
+    with pytest.raises(RuntimeError, match="tensor ABI mismatch"):
+        MigraphxArtifactRunner(
+            manifest_path,
+            source_path=source,
+            device=_FakeDevice(),
+            expected_purpose="test-purpose",
+        )
+
+    program.parameters["input"] = _FakeShape((2, 3, 4, 4), (48, 16, 4, 1))
+    program.outputs[0] = _FakeShape((2, 2, 4), (8, 1, 2))
+    with pytest.raises(RuntimeError, match="output ABI mismatch"):
+        MigraphxArtifactRunner(
+            manifest_path,
+            source_path=source,
+            device=_FakeDevice(),
+            expected_purpose="test-purpose",
+        )
+
+
+def _rfdetr_product_manifest(
+    *,
+    batch_size: int = 1,
+    internal_precision: str = "mixed-dot-projector-convolution-fp16",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        platform="linux",
+        device_arch="gfx1100",
+        internal_precision=internal_precision,
+        stream_type="ihipStream_t",
+        inputs=(
+            MigraphxTensorContract(
+                logical_name="input",
+                parameter_name="input",
+                dtype_name="float32",
+                shape=(batch_size, 3, 576, 576),
+                strides=(995328, 331776, 576, 1),
+            ),
+        ),
+        outputs=(
+            MigraphxTensorContract(
+                logical_name="dets",
+                parameter_name="main:#output_0",
+                dtype_name="float32",
+                shape=(batch_size, 200, 4),
+                strides=(800, 4, 1),
+            ),
+            MigraphxTensorContract(
+                logical_name="labels",
+                parameter_name="main:#output_1",
+                dtype_name="float32",
+                shape=(batch_size, 200, 3),
+                strides=(600, 3, 1),
+            ),
+            MigraphxTensorContract(
+                logical_name="masks",
+                parameter_name="main:#output_2",
+                dtype_name="float32",
+                shape=(batch_size, 200, 144, 144),
+                strides=(4147200, 20736, 144, 1),
+            ),
+        ),
+    )
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_rfdetr_runner_accepts_proven_static_contract(batch_size: int) -> None:
+    RfDetrMigraphxRunner._validate_contract(
+        SimpleNamespace(manifest=_rfdetr_product_manifest(batch_size=batch_size))
+    )
+
+
+@pytest.mark.parametrize(
+    "internal_precision",
+    [
+        "fp32",
+        "mixed-dot-fp16",
+        "mixed-convolution-fp16",
+        "mixed-backbone-linear-fp16",
+    ],
+)
+def test_rfdetr_runner_rejects_unproven_precision(internal_precision: str) -> None:
+    with pytest.raises(RuntimeError, match="outside the proven set"):
+        RfDetrMigraphxRunner._validate_contract(
+            SimpleNamespace(
+                manifest=_rfdetr_product_manifest(
+                    internal_precision=internal_precision
+                )
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "value"),
+    [
+        ("platform", "win32"),
+        ("device_arch", "gfx1151"),
+        ("input_parameter", "wrong_input"),
+        ("input_shape", (1, 3, 288, 1152)),
+        ("input_strides", (995328, 1, 1728, 3)),
+        ("output_parameter", "wrong_output"),
+        ("output_shape", (1, 200, 72, 288)),
+        ("output_strides", (4147200, 1, 28800, 200)),
+    ],
+)
+def test_rfdetr_runner_rejects_artifact_outside_proven_contract(
+    mutation: str,
+    value: object,
+) -> None:
+    manifest = _rfdetr_product_manifest()
+    if mutation in {"platform", "device_arch"}:
+        setattr(manifest, mutation, value)
+    elif mutation == "input_parameter":
+        manifest.inputs = (replace(manifest.inputs[0], parameter_name=value),)
+    elif mutation == "input_shape":
+        manifest.inputs = (replace(manifest.inputs[0], shape=value),)
+    elif mutation == "input_strides":
+        manifest.inputs = (replace(manifest.inputs[0], strides=value),)
+    elif mutation == "output_parameter":
+        manifest.outputs = (
+            *manifest.outputs[:2],
+            replace(manifest.outputs[2], parameter_name=value),
+        )
+    elif mutation == "output_shape":
+        manifest.outputs = (
+            *manifest.outputs[:2],
+            replace(manifest.outputs[2], shape=value),
+        )
+    elif mutation == "output_strides":
+        manifest.outputs = (
+            *manifest.outputs[:2],
+            replace(manifest.outputs[2], strides=value),
+        )
+    else:  # pragma: no cover - parametrization is exhaustive
+        raise AssertionError(mutation)
+
+    with pytest.raises(RuntimeError, match="RF-DETR MIGraphX"):
+        RfDetrMigraphxRunner._validate_contract(SimpleNamespace(manifest=manifest))
+
+
+def test_rfdetr_runner_rejects_windows_before_artifact_runtime_load(monkeypatch) -> None:
+    import jasna.mosaic.rfdetr_migraphx_runner as module
+
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    artifact_runner = MagicMock(side_effect=AssertionError("must not load artifact runtime"))
+    monkeypatch.setattr(module, "MigraphxArtifactRunner", artifact_runner)
+
+    with pytest.raises(RuntimeError, match="Linux only"):
+        RfDetrMigraphxRunner(
+            Path("manifest.json"),
+            weights_path=Path("rfdetr-v6.pt"),
+            device=torch.device("cuda:0"),
+            fp16=True,
+            resolution=576,
+            variant="medium",
+        )
+
+    artifact_runner.assert_not_called()
+
+
+def test_rfdetr_model_uses_explicit_artifact_runner_without_torch_fallback(monkeypatch) -> None:
+    import jasna.mosaic.rfdetr as module
+    import jasna.mosaic.rfdetr_migraphx_runner as migraphx_module
+    import jasna.mosaic.rfdetr_torch_runner as torch_module
+
+    runner = MagicMock()
+    runner.input_names = ["input"]
+    runner.input_dtypes = {"input": torch.float32}
+    runner.output_names = ["dets", "labels", "masks"]
+    runner.outputs = {
+        "dets": torch.empty((1, 200, 4)),
+        "labels": torch.empty((1, 200, 3)),
+        "masks": torch.empty((1, 200, 144, 144)),
+    }
+    runner.batch_size = 1
+    runner.artifact_path = Path("detector.mxr")
+    monkeypatch.setattr(module, "is_amd_device", lambda _device: True)
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    monkeypatch.setattr(module, "is_nvidia_device", lambda _device: False)
+    monkeypatch.setattr(migraphx_module, "RfDetrMigraphxRunner", lambda *args, **kwargs: runner)
+    monkeypatch.setattr(
+        torch_module,
+        "RfDetrTorchRunner",
+        lambda *args, **kwargs: pytest.fail("PyTorch fallback must not be constructed"),
+    )
+
+    model = module.RfDetrMosaicDetectionModel(
+        weights_path=Path("rfdetr-v6.pt"),
+        batch_size=4,
+        device=torch.device("cpu"),
+        resolution=576,
+        dynamic_batch=True,
+        torch_variant="medium",
+        fp16=True,
+        amd_migraphx_manifest_path=Path("manifest.json"),
+    )
+
+    assert model.runner is runner
+    assert model.batch_size == 1
+    assert model.dynamic_batch is False
+    assert model.engine_path == Path("detector.mxr")
+
+
+def test_rfdetr_model_rejects_windows_manifest_before_runner_import(monkeypatch) -> None:
+    import jasna.mosaic.rfdetr as module
+
+    monkeypatch.setattr(module, "is_amd_device", lambda _device: True)
+    monkeypatch.setattr(module.sys, "platform", "win32")
+
+    with pytest.raises(RuntimeError, match="Linux AMD/ROCm"):
+        module.RfDetrMosaicDetectionModel(
+            weights_path=Path("rfdetr-v6.pt"),
+            batch_size=4,
+            device=torch.device("cpu"),
+            resolution=576,
+            dynamic_batch=True,
+            torch_variant="medium",
+            fp16=True,
+            amd_migraphx_manifest_path=Path("manifest.json"),
+        )
+
+
+def test_b4_input_splits_static_b1_and_clones_reused_pointer_outputs() -> None:
+    from jasna.mosaic.rfdetr import RfDetrMosaicDetectionModel
+
+    model = object.__new__(RfDetrMosaicDetectionModel)
+    model.batch_size = 1
+    model.dynamic_batch = False
+    model._input_name = "input"
+
+    class ReusingRunner:
+        output_names = ["dets", "labels", "masks"]
+
+        def __init__(self) -> None:
+            self.buffers = {
+                "dets": torch.empty((1, 1, 4)),
+                "labels": torch.empty((1, 1, 1)),
+                "masks": torch.empty((1, 1, 1, 1)),
+            }
+            self.dispatches: list[float] = []
+
+        def infer(self, inputs):
+            value = float(inputs["input"][0, 0, 0, 0])
+            self.dispatches.append(value)
+            for buffer in self.buffers.values():
+                buffer.fill_(value)
+            return self.buffers
+
+    runner = ReusingRunner()
+    model.runner = runner
+    values = torch.arange(1, 5, dtype=torch.float32).reshape(4, 1, 1, 1)
+
+    outputs = model._infer(values)
+
+    assert runner.dispatches == [1.0, 2.0, 3.0, 4.0]
+    assert outputs["dets"][:, 0, 0].tolist() == [1.0, 2.0, 3.0, 4.0]
+    assert outputs["labels"][:, 0, 0].tolist() == [1.0, 2.0, 3.0, 4.0]
+    assert outputs["masks"][:, 0, 0, 0].tolist() == [1.0, 2.0, 3.0, 4.0]


### PR DESCRIPTION
## Summary

- add an explicit RF-DETR MIGraphX artifact/manifest loader
- add the Linux AMD MIGraphX runner boundary without changing automatic product routing
- fail closed when an explicitly requested artifact is invalid
- add focused artifact and runner tests

This is an independent root PR based directly on `main`. The existing Torch route remains the default unless a caller explicitly supplies a MIGraphX manifest.

## Validation

- Focused MIGraphX artifact/runner suite: `24 passed`
- Exactly one commit above upstream `main`; `git diff --check` passed

## Scope

This PR does not enable GUI/CLI auto-selection, change NVIDIA/TensorRT behavior, or add a silent Torch fallback for a failed explicit MIGraphX request.

## Follow-up PRs that depend on this PR

- **Linux AMD RF-DETR MIGraphX product selection** — selects the validated sidecar on supported Linux ROCm/gfx1100 systems, keeps unsupported hosts on the existing route, and preserves fail-closed behavior after explicit selection.

Detection-test vendor isolation is an independent test root, not a code dependency.
