### PR TITLE
test: isolate detection tests from host GPU vendor

### DIFF
--- a/docs/DETECTION_TEST_VENDOR_ISOLATION_CN.md
+++ b/docs/DETECTION_TEST_VENDOR_ISOLATION_CN.md
@@ -1,0 +1,18 @@
+# 检测测试的显卡厂商隔离
+
+更新时间：2026-08-29
+
+检测模型注册、权重发现和 TensorRT 预编译的 NVIDIA 单元测试现在显式模拟 NVIDIA 厂商，避免在 Linux AMD/ROCm
+开发机上根据本机显卡误走 `.pt` 权重或跳过 TensorRT 分支。RF-DETR 编译委派测试用本地假模块隔离可选
+TensorRT 依赖，因此无需在 AMD 开发环境安装 NVIDIA runtime。
+
+该改动只修正测试环境边界，不修改产品的 NVIDIA/AMD 路由、模型格式、检测阈值或运行时 fallback。聚焦验证：
+
+```bash
+python -m pytest -q \
+  tests/test_detection_registry.py \
+  tests/test_rfdetr_postprocess.py \
+  tests/test_model_weights_dir.py
+```
+
+当前 Linux AMD 环境结果：`61 passed`。

--- a/tests/test_detection_registry.py
+++ b/tests/test_detection_registry.py
@@ -22,13 +22,27 @@ from jasna.mosaic.detection_registry import (
 )
 
 
+@pytest.fixture
+def nvidia_vendor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make NVIDIA-specific expectations independent of the host GPU."""
+
+    import jasna.mosaic.detection_registry as registry
+
+    monkeypatch.setattr(
+        registry, "is_amd_device", lambda *_args, **_kwargs: False
+    )
+    monkeypatch.setattr(
+        registry, "is_nvidia_device", lambda *_args, **_kwargs: True
+    )
+
+
 def test_default_detection_model_is_rfdetr_v6() -> None:
     assert DEFAULT_DETECTION_MODEL_NAME == "rfdetr-v6"
     assert "rfdetr-v6" in RFDETR_MODEL_NAMES
     assert "rfdetr-v6-large" in RFDETR_MODEL_NAMES
 
 
-def test_rfdetr_v6_weights_path() -> None:
+def test_rfdetr_v6_weights_path(nvidia_vendor: None) -> None:
     assert detection_model_weights_path("rfdetr-v6") == Path("model_weights/rfdetr-v6.onnx")
     assert coerce_detection_model_name("rfdetr-v6") == "rfdetr-v6"
 
@@ -142,7 +156,7 @@ def test_coerce_yolo_typo_raises_lists_valid_names() -> None:
 
 # --- detection_model_weights_path for dynamic rfdetr ---
 
-def test_dynamic_rfdetr_weights_path() -> None:
+def test_dynamic_rfdetr_weights_path(nvidia_vendor: None) -> None:
     assert detection_model_weights_path("rfdetr-v99") == Path("model_weights/rfdetr-v99.onnx")
 
 
@@ -156,14 +170,16 @@ def test_discover_nonexistent_dir(tmp_path: Path) -> None:
     assert discover_available_detection_models(tmp_path / "nope") == []
 
 
-def test_discover_rfdetr_only(tmp_path: Path) -> None:
+def test_discover_rfdetr_only(tmp_path: Path, nvidia_vendor: None) -> None:
     (tmp_path / "rfdetr-v5.onnx").touch()
     (tmp_path / "rfdetr-v3.onnx").touch()
     result = discover_available_detection_models(tmp_path)
     assert result == ["rfdetr-v5", "rfdetr-v3"]
 
 
-def test_discover_unknown_rfdetr_version(tmp_path: Path) -> None:
+def test_discover_unknown_rfdetr_version(
+    tmp_path: Path, nvidia_vendor: None
+) -> None:
     (tmp_path / "rfdetr-v99.onnx").touch()
     (tmp_path / "rfdetr-v5.onnx").touch()
     result = discover_available_detection_models(tmp_path)
@@ -193,7 +209,7 @@ def test_discover_bundled_vr_model(tmp_path: Path) -> None:
     ]
 
 
-def test_discover_mixed(tmp_path: Path) -> None:
+def test_discover_mixed(tmp_path: Path, nvidia_vendor: None) -> None:
     (tmp_path / "rfdetr-v5.onnx").touch()
     (tmp_path / "rfdetr-v3.onnx").touch()
     (tmp_path / "lada_mosaic_detection_model_v2.pt").touch()
@@ -230,7 +246,9 @@ def test_require_detection_model_weights_rejects_missing_path(tmp_path: Path) ->
         require_detection_model_weights("zelefans-vr-yolo-v2")
 
 
-def test_discover_ignores_non_matching_files(tmp_path: Path) -> None:
+def test_discover_ignores_non_matching_files(
+    tmp_path: Path, nvidia_vendor: None
+) -> None:
     (tmp_path / "rfdetr-v5.onnx").touch()
     (tmp_path / "some_random_model.onnx").touch()
     (tmp_path / "random.pt").touch()
@@ -244,17 +262,19 @@ def test_precompile_noop_on_cpu() -> None:
     precompile_detection_engine("rfdetr-v5", Path("m.onnx"), 1, torch.device("cpu"), True)
 
 
-def test_precompile_rfdetr_on_cuda() -> None:
-    with patch("jasna.trt.compile_onnx_to_tensorrt_engine") as mock_compile:
+def test_precompile_rfdetr_on_cuda(nvidia_vendor: None) -> None:
+    with patch("jasna.mosaic.rfdetr.compile_rfdetr_engine") as mock_compile:
         precompile_detection_engine("rfdetr-v5", Path("m.onnx"), 2, torch.device("cuda:0"), True)
         mock_compile.assert_called_once_with(
             Path("m.onnx"), torch.device("cuda:0"),
-            batch_size=4, fp16=True, workspace_gb=20, dynamic_batch=False,
+            batch_size=4, resolution=768, dynamic_batch=False, fp16=True,
         )
 
 
-def test_precompile_rfdetr_v6_uses_requested_dynamic_batch() -> None:
-    with patch("jasna.trt.compile_onnx_to_tensorrt_engine") as mock_compile:
+def test_precompile_rfdetr_v6_uses_requested_dynamic_batch(
+    nvidia_vendor: None,
+) -> None:
+    with patch("jasna.mosaic.rfdetr.compile_rfdetr_engine") as mock_compile:
         precompile_detection_engine(
             "rfdetr-v6",
             Path("m.onnx"),
@@ -264,11 +284,11 @@ def test_precompile_rfdetr_v6_uses_requested_dynamic_batch() -> None:
         )
         mock_compile.assert_called_once_with(
             Path("m.onnx"), torch.device("cuda:0"),
-            batch_size=8, fp16=True, workspace_gb=20, dynamic_batch=True,
+            batch_size=8, resolution=576, dynamic_batch=True, fp16=True,
         )
 
 
-def test_precompile_yolo_on_cuda() -> None:
+def test_precompile_yolo_on_cuda(nvidia_vendor: None) -> None:
     with (
         patch("jasna.mosaic.yolo_tensorrt_compilation.compile_yolo_to_tensorrt_engine") as mock_compile,
     ):
@@ -276,7 +296,7 @@ def test_precompile_yolo_on_cuda() -> None:
         mock_compile.assert_called_once()
 
 
-def test_precompile_zelefans_yolo_on_cuda() -> None:
+def test_precompile_zelefans_yolo_on_cuda(nvidia_vendor: None) -> None:
     with patch(
         "jasna.mosaic.yolo_tensorrt_compilation.compile_yolo_to_tensorrt_engine"
     ) as mock_compile:

--- a/tests/test_model_weights_dir.py
+++ b/tests/test_model_weights_dir.py
@@ -3,9 +3,23 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 import jasna.engine_paths as engine_paths
 from jasna.engine_paths import model_weights_dir
 from jasna.mosaic import detection_registry
+
+
+@pytest.fixture
+def nvidia_vendor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ONNX weight expectations independent of the host GPU."""
+
+    monkeypatch.setattr(
+        detection_registry, "is_amd_device", lambda *_args, **_kwargs: False
+    )
+    monkeypatch.setattr(
+        detection_registry, "is_nvidia_device", lambda *_args, **_kwargs: True
+    )
 
 
 def test_model_weights_dir_in_dev_is_cwd_relative(monkeypatch) -> None:
@@ -22,7 +36,9 @@ def test_model_weights_dir_when_frozen_is_next_to_executable(monkeypatch, tmp_pa
     assert model_weights_dir() == tmp_path / "model_weights"
 
 
-def test_detection_model_weights_path_uses_helper(monkeypatch, tmp_path: Path) -> None:
+def test_detection_model_weights_path_uses_helper(
+    monkeypatch, tmp_path: Path, nvidia_vendor: None
+) -> None:
     fake_exe = tmp_path / "jasna-cli.exe"
     fake_exe.touch()
     monkeypatch.setattr(sys, "frozen", True, raising=False)
@@ -32,7 +48,9 @@ def test_detection_model_weights_path_uses_helper(monkeypatch, tmp_path: Path) -
     assert p == tmp_path / "model_weights" / "rfdetr-v5.onnx"
 
 
-def test_discover_available_detection_models_uses_helper(monkeypatch, tmp_path: Path) -> None:
+def test_discover_available_detection_models_uses_helper(
+    monkeypatch, tmp_path: Path, nvidia_vendor: None
+) -> None:
     weights_dir = tmp_path / "model_weights"
     weights_dir.mkdir()
     (weights_dir / "rfdetr-v5.onnx").touch()
@@ -48,7 +66,9 @@ def test_discover_available_detection_models_uses_helper(monkeypatch, tmp_path: 
     assert "lada-yolo-v4" in names
 
 
-def test_discover_available_detection_models_explicit_dir_overrides(tmp_path: Path) -> None:
+def test_discover_available_detection_models_explicit_dir_overrides(
+    tmp_path: Path, nvidia_vendor: None
+) -> None:
     weights_dir = tmp_path / "weights"
     weights_dir.mkdir()
     (weights_dir / "rfdetr-v3.onnx").touch()

--- a/tests/test_rfdetr_postprocess.py
+++ b/tests/test_rfdetr_postprocess.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -298,8 +300,16 @@ class TestRfDetrCall:
 
 
 class TestCompileRfdetrEngine:
-    def test_delegates_to_compile_onnx(self):
-        with patch("jasna.trt.compile_onnx_to_tensorrt_engine", return_value=Path("out.engine")) as mock_compile:
+    def test_delegates_to_compile_onnx(self, monkeypatch):
+        import jasna.mosaic.rfdetr as module
+
+        mock_compile = MagicMock(return_value=Path("out.engine"))
+        monkeypatch.setattr(module, "is_amd_device", lambda _device: False)
+        monkeypatch.setattr(module, "is_nvidia_device", lambda _device: True)
+        with patch.dict(
+            sys.modules,
+            {"jasna.trt": SimpleNamespace(compile_onnx_to_tensorrt_engine=mock_compile)},
+        ):
             result = compile_rfdetr_engine(
                 Path("model.onnx"),
                 torch.device("cuda:0"),


### PR DESCRIPTION
## Summary

- isolate detection tests from the GPU vendor of the machine running pytest
- replace host-dependent accelerator assumptions with explicit test fixtures
- keep production detection routing unchanged

This is an independent, test-only root PR based directly on `main`.

## Validation

- Focused detection suite: `61 passed`
- Exactly one commit above upstream `main`; `git diff --check` passed

## Scope

No product code, model selection, inference output, NVIDIA route, or AMD route changes are included.

## Follow-up PRs that depend on this PR

- **RF-DETR MIGraphX product-selection acceptance** — uses these host-independent fixtures to verify Linux AMD selection and vendor-independent fallback behavior after the separate MIGraphX core lands.

There is no hard runtime-code dependency; this PR is the reusable acceptance gate for that follow-up.
