### PR TITLE
test: isolate media tests from vendor and lazy-import state

### DIFF
--- a/docs/MEDIA_TEST_ENVIRONMENT_ISOLATION_CN.md
+++ b/docs/MEDIA_TEST_ENVIRONMENT_ISOLATION_CN.md
@@ -1,0 +1,21 @@
+# 媒体单测环境隔离
+
+统一 AMD 产品路线让 encoder 设置校验和 `NvidiaVideoEncoder` 的内部 vendor 选择真正跟随
+当前 PyTorch runtime。旧 NVENC 单测此前依赖“测试机默认是 NVIDIA”的隐含前提，因此在
+ROCm 主机上会错误装配 AMF 默认值，造成与产品行为无关的失败。
+
+本阶段只修正测试边界，不修改产品代码：
+
+- 旧 NVENC encoder/settings 测试默认显式固定 `AcceleratorVendor.NVIDIA`；原有 AMD 用例
+  仍在单个测试内显式覆盖为 AMD，因此两类合同不会互相污染。
+- session factory 测试只导入可用的 primary/pipeline 模块；三个 secondary heavy module
+  由测试专用 `ModuleType` stub 通过 `sys.modules` 临时注入。它不再要求
+  `jasna.restorer.__init__` 为仅供测试的模块名增加伪导出，也不会为了创建 mock 先加载
+  TensorRT/protection 等产品依赖，因此不破坏产品启动时的 lazy import。
+- GUI job ordering 与 Stop 同步测试屏蔽每个伪 job 结束后的 GPU cache/synchronize 清理。
+  这些测试不验证 GPU 回收；如果继承完整测试进程已加载的 ROCm 状态，5 秒 join 会把正常
+  cleanup 延迟误判为只处理了第一个 job，或误判 Stop worker 没有退出。
+
+验收要求是在同一 Linux ROCm 环境中完整通过 `test_media_init.py`、
+`test_video_encoder_unit.py`、`test_session_factory.py`、`test_gui_job_ordering.py` 和
+`test_gui_processor_stop.py`，同时保留 AMD 专属用例覆盖。

--- a/tests/test_gui_job_ordering.py
+++ b/tests/test_gui_job_ordering.py
@@ -4,9 +4,18 @@ import threading
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from jasna.gui.processor import Processor, ProgressUpdate
 from jasna.gui.models import JobItem, JobStatus, AppSettings
 from jasna.post_export_action import PostExportVideoCommandError
+
+
+@pytest.fixture(autouse=True)
+def _skip_gpu_cleanup_for_ordering_tests(monkeypatch) -> None:
+    """Ordering tests must not inherit full-suite GPU synchronization cost."""
+
+    monkeypatch.setattr("jasna.gui.processor._cleanup_torch", lambda _torch: None)
 
 
 def _make_jobs(*names: str) -> list[JobItem]:

--- a/tests/test_gui_processor_stop.py
+++ b/tests/test_gui_processor_stop.py
@@ -6,6 +6,13 @@ from jasna.gui.models import AppSettings, JobItem, JobStatus
 from jasna.gui.processor import Processor, ProgressUpdate
 
 
+@pytest.fixture(autouse=True)
+def _skip_gpu_cleanup_for_stop_tests(monkeypatch) -> None:
+    """Stop synchronization tests do not exercise GPU cache reclamation."""
+
+    monkeypatch.setattr("jasna.gui.processor._cleanup_torch", lambda _torch: None)
+
+
 class _FakePipeline:
     def __init__(self):
         self.cancel_requested = False

--- a/tests/test_media_init.py
+++ b/tests/test_media_init.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from av.video.reformatter import Colorspace as AvColorspace, ColorRange as AvColorRange
 
+from jasna.accelerator import AcceleratorVendor
 from jasna.media import (
     SUPPORTED_ENCODER_SETTINGS,
     SUPPORTED_ENCODER_SETTINGS_BY_CODEC,
@@ -18,6 +19,16 @@ from jasna.media import (
     resolve_video_start_pts,
     VideoMetadata,
 )
+
+
+@pytest.fixture(autouse=True)
+def _use_nvidia_encoder_contracts_by_default(monkeypatch) -> None:
+    """Keep legacy NVENC assertions independent of the test host GPU vendor."""
+
+    monkeypatch.setattr(
+        "jasna.media.vendor_for_device",
+        lambda: AcceleratorVendor.NVIDIA,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_session_factory.py
+++ b/tests/test_session_factory.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
+import sys
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -57,17 +60,45 @@ def _build_session(
     amd: bool = False,
 ):
     compile_result = MagicMock(use_basicvsrpp_tensorrt=True)
+    basic_module = importlib.import_module(
+        "jasna.restorer.basicvsrpp_mosaic_restorer"
+    )
+    pipeline_module = importlib.import_module("jasna.restorer.restoration_pipeline")
+    tvai_cls = MagicMock(name="TvaiSecondaryRestorer")
+    unet_cls = MagicMock(name="Unet4xSecondaryRestorer")
+    rtx_cls = MagicMock(name="RtxSuperresSecondaryRestorer")
+
+    def stub_module(name: str, export: str, value) -> ModuleType:
+        module = ModuleType(name)
+        setattr(module, export, value)
+        return module
+
+    secondary_modules = {
+        "jasna.restorer.tvai_secondary_restorer": stub_module(
+            "jasna.restorer.tvai_secondary_restorer",
+            "TvaiSecondaryRestorer",
+            tvai_cls,
+        ),
+        "jasna.restorer.unet4x_secondary_restorer": stub_module(
+            "jasna.restorer.unet4x_secondary_restorer",
+            "Unet4xSecondaryRestorer",
+            unet_cls,
+        ),
+        "jasna.restorer.rtx_superres_secondary_restorer": stub_module(
+            "jasna.restorer.rtx_superres_secondary_restorer",
+            "RtxSuperresSecondaryRestorer",
+            rtx_cls,
+        ),
+    }
     with (
+        patch.dict(sys.modules, secondary_modules),
         patch("jasna.accelerator.is_amd_device", return_value=amd),
         patch(
             "jasna.engine_compiler.ensure_engines_compiled",
             return_value=compile_result,
         ) as compiled,
-        patch("jasna.restorer.basicvsrpp_mosaic_restorer.BasicvsrppMosaicRestorer") as restorer_cls,
-        patch("jasna.restorer.restoration_pipeline.RestorationPipeline") as pipeline_cls,
-        patch("jasna.restorer.tvai_secondary_restorer.TvaiSecondaryRestorer") as tvai_cls,
-        patch("jasna.restorer.unet4x_secondary_restorer.Unet4xSecondaryRestorer") as unet_cls,
-        patch("jasna.restorer.rtx_superres_secondary_restorer.RtxSuperresSecondaryRestorer") as rtx_cls,
+        patch.object(basic_module, "BasicvsrppMosaicRestorer") as restorer_cls,
+        patch.object(pipeline_module, "RestorationPipeline") as pipeline_cls,
     ):
         session = build_restoration_session(
             config,

--- a/tests/test_video_encoder_unit.py
+++ b/tests/test_video_encoder_unit.py
@@ -61,6 +61,17 @@ def _make_encoder(tmp_path, encoder_settings=None, codec="hevc", **meta_override
     )
 
 
+@pytest.fixture(autouse=True)
+def _use_nvidia_encoder_contracts_by_default(monkeypatch) -> None:
+    """This legacy suite asserts NVENC unless a test explicitly selects AMD."""
+
+    monkeypatch.setattr(
+        video_encoder_module,
+        "vendor_for_device",
+        lambda _device=None: AcceleratorVendor.NVIDIA,
+    )
+
+
 # Measured hevc_nvenc configuration; the HEVC path must never drift from it.
 _HEVC_OPTIONS_SNAPSHOT = {
     "preset": "p5",


### PR DESCRIPTION
## Summary

- isolate media/GUI unit tests from host GPU-vendor and lazy-import state
- make encoder/session expectations explicit inside each test
- remove cumulative integration-chain acceptance material from this single-purpose PR

This is an independent, test-only root PR based directly on `main`.

## Validation

- `/home/latiao/vr_toolbox_jasna_linux/.venv/bin/python -m pytest -q tests/test_gui_job_ordering.py tests/test_gui_processor_stop.py tests/test_media_init.py tests/test_session_factory.py tests/test_video_encoder_unit.py`
- Result: `225 passed`
- Exactly one commit above upstream `main`; `git diff --check` passed

## Scope

No product routing, encoder behavior, decoder behavior, or rocDecode logic changes are included.

## Follow-up PRs that depend on this PR

- **AMD encoder correctness** — adds AMD-specific encoder contract/product tests without inheriting NVIDIA-only assumptions from the host test environment.
- **HEVC Smart Render encoder selection** — follows after the encoder contract/correctness layer and uses the isolated media tests as its vendor-independent acceptance base.
