### PR TITLE
fix(streaming): guard zero-elapsed FPS diagnostics

### DIFF
--- a/jasna/streaming_pipeline.py
+++ b/jasna/streaming_pipeline.py
@@ -48,9 +48,12 @@ class _StreamingFrameWriter:
         if frames_written == 1:
             log.debug("[stream-blend-encode] first frame encoded: %.2fs", time.monotonic() - self._t0)
         elif frames_written % 100 == 0:
+            elapsed = time.monotonic() - self._t0
+            if elapsed <= 0:
+                elapsed = time.get_clock_info("monotonic").resolution
             log.debug(
                 "[stream-blend-encode] %d frames encoded (%.1f fps)",
-                frames_written, frames_written / (time.monotonic() - self._t0),
+                frames_written, frames_written / elapsed,
             )
 
         current_seg = self._start_segment + frames_written // self._frames_per_seg

--- a/tests/test_pipeline_threads.py
+++ b/tests/test_pipeline_threads.py
@@ -772,8 +772,9 @@ class TestStreamingFrameWriter:
         mock_server = MagicMock()
         mock_server.frames_per_segment.return_value = 120
 
-        writer = _StreamingFrameWriter(mock_enc, mock_server, start_segment=0)
-        writer.after_write(100)
+        with patch("jasna.streaming_pipeline.time.monotonic", return_value=42.0):
+            writer = _StreamingFrameWriter(mock_enc, mock_server, start_segment=0)
+            writer.after_write(100)
 
         mock_server.update_production.assert_called_once()
 


### PR DESCRIPTION
## Summary

- guard streaming FPS diagnostics when the measured elapsed interval is zero or non-positive
- prevent logging-only division errors without changing frame processing

This is an independent root PR based directly on `main`.

## Validation

- Focused streaming selection: `16 passed, 21 deselected`
- Exactly one commit above upstream `main`; `git diff --check` passed

## Scope

This PR changes only diagnostic metric calculation. It does not alter timing, pacing, frame counts, codecs, or GPU routing.

## Follow-up PRs that depend on this PR

- No current implementation PR has a hard dependency on this diagnostic guard. It may be merged and reviewed independently.
