### PR TITLE
fix(windows): shim MMEngine import for ROCm no-c10d builds

### DIFF
--- a/docs/WINDOWS_ROCM_MMENGINE_COMPAT_CN.md
+++ b/docs/WINDOWS_ROCM_MMENGINE_COMPAT_CN.md
@@ -1,0 +1,37 @@
+# Windows ROCm MMEngine 导入兼容层
+
+## 目的与边界
+
+Windows ROCm 的 Torch wheel 不提供 distributed c10d，
+`torch.distributed.is_available()` 因此为 false。MMEngine 0.10.x 即使只用于
+BasicVSR++ 单进程推理，也会在导入阶段访问 `ReduceOp` 和 FSDP 模块。
+
+Jasna 只在 `win32 + torch.version.hip + distributed unavailable` 的精确交集内补齐
+MMEngine 导入所需的两个表面：`ReduceOp` 占位符和不可实例化的 FSDP 模块。
+FSDP 构造仍会显式报错，且 `torch.distributed.is_available()` 保持 false。
+
+Linux ROCm、Windows/Linux CUDA，以及真正具备 distributed 的 Torch 环境完全不进入
+该兼容层。本修复只解除 MMEngine 的模块导入阻断，不启用分布式训练，不改变
+BasicVSR++ 模型、checkpoint、推理路线、共享编排或产品默认值。
+
+## 实现位置
+
+- `jasna/models/basicvsrpp/mmengine_compat.py`：精确平台能力判定与临时导入表面。
+- `jasna/models/basicvsrpp/__init__.py`：仅在加载 BasicVSR++ 模型前应用兼容层。
+
+## 验证
+
+聚焦测试覆盖：
+
+- Windows ROCm 且 distributed 不可用时可完成 MMEngine 导入；
+- FSDP 构造仍失败；
+- Linux ROCm、CUDA 和具备 distributed 的环境不注入兼容层；
+- 临时模块状态在测试后恢复。
+
+运行命令：
+
+```bash
+python -m pytest -q tests/test_mmengine_windows_rocm_compat.py
+```
+
+这项 Linux mock/结构验证不能替代 Windows ROCm 真机加载 BasicVSR++ 的验收。

--- a/jasna/models/basicvsrpp/__init__.py
+++ b/jasna/models/basicvsrpp/__init__.py
@@ -1,6 +1,14 @@
 # SPDX-FileCopyrightText: Lada Authors
 # SPDX-License-Identifier: AGPL-3.0
 
+from jasna.models.basicvsrpp.mmengine_compat import prepare_mmengine_for_windows_rocm
+
+
+# MMEngine imports distributed-only symbols before exposing the inference
+# helpers used below. Prepare that dependency boundary first on Windows ROCm.
+prepare_mmengine_for_windows_rocm()
+
+
 def register_all_modules():
     from jasna.models.basicvsrpp.mmagic import register_all_modules
     register_all_modules()

--- a/jasna/models/basicvsrpp/mmengine_compat.py
+++ b/jasna/models/basicvsrpp/mmengine_compat.py
@@ -1,0 +1,86 @@
+"""Narrow MMEngine import compatibility for the Windows ROCm torch wheel.
+
+The Windows ROCm build intentionally omits distributed c10d, while MMEngine
+0.10.x imports a small distributed-only surface even for single-process
+inference. Keep this shim at the BasicVSR++ dependency boundary so Linux ROCm,
+CUDA, and distributed-capable torch installations are untouched.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+
+_FSDP_MODULE = "mmengine.model.wrappers.fully_sharded_distributed"
+
+
+def _is_windows_rocm_without_distributed(
+    torch_module: Any,
+    platform: str,
+) -> bool:
+    if platform != "win32":
+        return False
+    torch_version = getattr(torch_module, "version", None)
+    if not getattr(torch_version, "hip", None):
+        return False
+    torch_dist = getattr(torch_module, "distributed", None)
+    is_available = getattr(torch_dist, "is_available", None)
+    if not callable(is_available):
+        return False
+    try:
+        return not bool(is_available())
+    except Exception:
+        return False
+
+
+def prepare_mmengine_for_windows_rocm(
+    torch_module: Any | None = None,
+    *,
+    platform: str | None = None,
+) -> tuple[str, ...]:
+    """Make MMEngine importable for single-process Windows ROCm inference.
+
+    Returns the compatibility surfaces installed by this call. The optional
+    inputs keep the platform gate directly unit-testable without replacing the
+    active torch installation.
+    """
+
+    if torch_module is None:
+        import torch as torch_module
+
+    active_platform = sys.platform if platform is None else platform
+    if not _is_windows_rocm_without_distributed(torch_module, active_platform):
+        return ()
+
+    installed: list[str] = []
+    torch_dist = torch_module.distributed
+    if not hasattr(torch_dist, "ReduceOp"):
+
+        class _ReduceOp:
+            SUM = "sum"
+            PRODUCT = "product"
+            MIN = "min"
+            MAX = "max"
+            BAND = "band"
+            BOR = "bor"
+            BXOR = "bxor"
+
+        torch_dist.ReduceOp = _ReduceOp
+        installed.append("torch.distributed.ReduceOp")
+
+    if _FSDP_MODULE not in sys.modules:
+        module = types.ModuleType(_FSDP_MODULE)
+
+        class MMFullyShardedDataParallel:
+            def __init__(self, *_args: object, **_kwargs: object) -> None:
+                raise RuntimeError(
+                    "MMEngine FSDP is unavailable in this Windows ROCm torch build"
+                )
+
+        module.MMFullyShardedDataParallel = MMFullyShardedDataParallel
+        sys.modules[_FSDP_MODULE] = module
+        installed.append("mmengine FSDP stub")
+
+    return tuple(installed)

--- a/tests/test_mmengine_windows_rocm_compat.py
+++ b/tests/test_mmengine_windows_rocm_compat.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from jasna.models.basicvsrpp.mmengine_compat import (
+    _FSDP_MODULE,
+    prepare_mmengine_for_windows_rocm,
+)
+
+
+def _fake_torch(
+    *,
+    hip: str | None = "7.2.1",
+    distributed_available: bool = False,
+    with_reduce_op: bool = False,
+) -> SimpleNamespace:
+    distributed = SimpleNamespace(
+        is_available=lambda: distributed_available,
+    )
+    if with_reduce_op:
+        distributed.ReduceOp = SimpleNamespace(SUM="existing")
+    return SimpleNamespace(
+        distributed=distributed,
+        version=SimpleNamespace(hip=hip),
+    )
+
+
+@pytest.mark.parametrize(
+    ("platform", "torch_module"),
+    [
+        ("linux", _fake_torch()),
+        ("win32", _fake_torch(hip=None)),
+        ("win32", _fake_torch(distributed_available=True)),
+    ],
+)
+def test_compatibility_does_not_modify_other_torch_environments(
+    monkeypatch,
+    platform: str,
+    torch_module: SimpleNamespace,
+) -> None:
+    monkeypatch.delitem(sys.modules, _FSDP_MODULE, raising=False)
+
+    installed = prepare_mmengine_for_windows_rocm(
+        torch_module,
+        platform=platform,
+    )
+
+    assert installed == ()
+    assert not hasattr(torch_module.distributed, "ReduceOp")
+    assert _FSDP_MODULE not in sys.modules
+
+
+def test_missing_windows_rocm_distributed_surfaces_are_stubbed(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, _FSDP_MODULE, raising=False)
+    torch_module = _fake_torch()
+
+    installed = prepare_mmengine_for_windows_rocm(
+        torch_module,
+        platform="win32",
+    )
+
+    assert installed == (
+        "torch.distributed.ReduceOp",
+        "mmengine FSDP stub",
+    )
+    assert not torch_module.distributed.is_available()
+    assert torch_module.distributed.ReduceOp.SUM == "sum"
+    assert torch_module.distributed.ReduceOp.BXOR == "bxor"
+    with pytest.raises(RuntimeError, match="Windows ROCm"):
+        sys.modules[_FSDP_MODULE].MMFullyShardedDataParallel()
+
+
+def test_compatibility_setup_is_idempotent(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, _FSDP_MODULE, raising=False)
+    torch_module = _fake_torch()
+    prepare_mmengine_for_windows_rocm(torch_module, platform="win32")
+
+    installed = prepare_mmengine_for_windows_rocm(
+        torch_module,
+        platform="win32",
+    )
+
+    assert installed == ()
+    assert not torch_module.distributed.is_available()
+
+
+def test_existing_reduce_op_is_not_replaced(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, _FSDP_MODULE, raising=False)
+    torch_module = _fake_torch(with_reduce_op=True)
+    original = torch_module.distributed.ReduceOp
+
+    installed = prepare_mmengine_for_windows_rocm(
+        torch_module,
+        platform="win32",
+    )
+
+    assert installed == ("mmengine FSDP stub",)
+    assert torch_module.distributed.ReduceOp is original
+
+
+def test_real_windows_rocm_mmengine_import_keeps_distributed_unavailable() -> None:
+    if sys.platform != "win32":
+        pytest.skip("Windows ROCm import contract")
+    import torch
+
+    if not torch.version.hip or torch.distributed.is_available():
+        pytest.skip("requires a Windows ROCm torch build without distributed c10d")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    code = """
+import torch
+import jasna.models.basicvsrpp
+from mmengine.runner import load_checkpoint
+assert callable(load_checkpoint)
+assert not torch.distributed.is_available()
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr or completed.stdout


### PR DESCRIPTION
## Summary

- add a narrowly gated MMEngine compatibility shim for Windows ROCm builds without c10d/distributed support
- route BasicVSR++ initialization through the shim only on `win32 + HIP + distributed unavailable`
- leave Linux ROCm, CUDA, and normal PyTorch installations unchanged

This is an independent root PR based directly on `main`.

## Validation

- Focused compatibility suite: `6 passed, 1 skipped`
- Exactly one commit above upstream `main`; `git diff --check` passed

## Scope

This PR addresses import compatibility only. It does not optimize BasicVSR++, change model output, add MIGraphX restoration, or claim Windows real-video acceptance.

## Follow-up PRs that depend on this PR

- **Windows ROCm BasicVSR++ real-machine acceptance** — validates import, model load, FP16 inference, output quality, and cancellation on an actual Windows ROCm installation before any broader product-default claim.

No Linux implementation PR depends on this Windows-only shim.
