### PR TITLE
feat(amd): add explicit AMF interop core

### DIFF
--- a/docs/AMF_INTEROP_CORE_CN.md
+++ b/docs/AMF_INTEROP_CORE_CN.md
@@ -1,0 +1,129 @@
+# Linux AMD AMF Vulkan→HIP D2D Core
+
+本文记录 `codex/upstream-amf-interop-core` 上的独立研究入口。它只建立
+H.264/HEVC 的 native bridge 基础，不迁移产品默认解码策略，也不覆盖 AV1。
+
+## 使用边界
+
+仅当显式设置下列环境变量时，`NvidiaVideoReader` 才会进入此路径：
+
+```bash
+JASNA_DECODE_BACKEND=amf-interop
+```
+
+接受范围如下：
+
+| 编码 | profile / 位深 | native surface |
+| --- | --- | --- |
+| H.264 | Main 或 High，8-bit | NV12 |
+| HEVC | Main，8-bit | NV12 |
+| HEVC | Main10，10-bit | P010 |
+
+reader batch 只能是 `1`、`2`、`4` 或 `8`；Linux 以外、非 AMD、AV1、其他
+profile/pixel format 均会在打开前报错。本 core 只接受一个 session 内分辨率、
+位深和 surface format 不变的输入，不覆盖中途重配。HEVC 的旧 ffprobe 元数据若
+没有 profile，只有在 NV12/8-bit 或 P010/10-bit 的同一范围内才会推断为对应的
+Main/Main10。
+
+`auto`、`pyav-hw`、`pyav-sw` 和 VALI 的选择与 fallback 均未改动，
+不会自动选中 `amf-interop`。该入口失败时也不会转为 CPU、host Map、staging、
+D2H 或其他 decoder fallback。
+
+## bridge 与生命周期
+
+`scripts/amf_surface_probe.pyx` 只包含 decode 方向：
+
+1. 验证 PyAV frame 是 `AV_PIX_FMT_AMF_SURFACE`、AMF Vulkan memory 和有效的
+   external-memory handle。
+2. 查询 AMF context/Vulkan device，并由 reader 固定 AMF frame-context、AMF
+   context、Vulkan device 和 HIP device identity。
+3. 导出 Vulkan opaque FD，导入为 HIP external memory 后立即由调用方关闭该
+   dma-buf FD，再映射并以两个 `hipMemcpy2D(..., hipMemcpyDeviceToDevice)` 复制
+   NV12/P010 的 Y/UV 平面。ROCm 7.2.1 不会替调用方关闭成功导入的 FD，不能把
+   `hipImportExternalMemory` 成功误当作 FD 所有权转移。
+4. 在 PyAV frame 可释放前同步 HIP null stream；随后释放 mapped buffer 和
+   external-memory import。任一步失败均保留 native 原因并报错。
+
+bridge 和 reader 都输出 transport counters。reader 会拒绝非 D2D copy、host
+frame transfer、CPU Map、staging、D2H、`av_hwframe_transfer_data`、失败 copy、
+FD close 失败、identity 变化，或 export/FD close/import/map/release/destroy 与
+copy 数不配平的情况。每次 export 必须恰有一次可审计 close，最后一次 close
+errno 必须为 0。固定 context session 也必须 create/close 配平；关闭失败不会被
+吞掉。
+
+explicit decoder 不覆盖 FFmpeg 的 `surface_pool_size`。固定 runtime 在选项保持默认
+`-1` 时会自行派生 36 个 AMF decode surfaces，并给 AVHWFrames pool 追加 8 个。
+曾验证显式写成 `0` 会使 AVHWFrames pool 只剩 8 个，B8 reader 在持有首批 8 个
+surface 后等待下一帧而停滞；因此使用 upstream 默认计算，不把 decoder pool 误当成
+本 core 默认关闭的 external-memory mapping cache。
+
+本 core 不实现资源 mapping cache。`JASNA_AMF_INTEROP_RESOURCE_CACHE` 默认
+`false`；若显式设为 true，explicit backend 会 fail closed，而不是启用未验证的
+缓存。
+
+## 构建与 runtime 前提
+
+用以下 helper 在源码树外构建 extension：
+
+```bash
+python scripts/build_amf_surface_probe.py \
+  --pyav-source /path/to/pyav-source \
+  --amf-include /path/to/amf-include \
+  --ffmpeg-include /path/to/ffmpeg-include \
+  --ffmpeg-lib /path/to/ffmpeg-lib \
+  --vulkan-include /path/to/vulkan-headers/include \
+  --rocm-include /opt/rocm/include \
+  --output-dir /tmp/jasna-amf-interop-bridge
+```
+
+extension 必须与实际 PyAV/FFmpeg ABI 匹配。bridge 不会自动加入 `PYTHONPATH`；
+这是本 PR 保持的显式研究入口前提。运行实验时由操作者同时提供 ABI-matched runtime `site-packages`、bridge
+目录和 FFmpeg `lib` 到对应的 Python/loader 搜索路径。普通开发 venv 没有 bridge
+时会明确 fail closed。
+
+## 独立验收
+
+焦点测试位于 `tests/test_amf_interop_core.py`，覆盖 backend/env、Linux AMD
+scope/batch 矩阵、Windows/NVIDIA/AV1 拒绝、auto 不选择、bridge 缺失、non-native
+frame、transport counter 拒绝、close 配平和 cache 默认值。现有 decoder backend
+与 AMD software-path 测试也作为回归检查。
+
+主会话用 accepted Linux AMD unified runtime（PyAV 18.1.0，固定 FFmpeg/PyAV/AMF
+source pin）重新在源码树外构建 bridge，产物 SHA-256 为
+`cca94e491116c5dd0deac9351c0290ba0827fcf625a832b24abfb20f79590031`。随后以
+`JASNA_DECODE_BACKEND=amf-interop`、batch 4 对三份静态 fixture 做完整只读验收，
+没有生成输出媒体：
+
+| 输入 | 完整帧数 | 输出 tensor | PTS |
+| --- | ---: | --- | --- |
+| H.264 Main 8-bit，3840×2160 | 120/120 | `N×3×2160×3840` uint8 HIP | 0–122122，与独立 FFprobe 逐帧一致且严格递增 |
+| HEVC Main 8-bit，4096×2048 | 120/120 | `N×3×2048×4096` uint8 HIP | 0–121121，与独立 FFprobe 逐帧一致且严格递增 |
+| HEVC Main10，4096×2048 | 120/120 | `N×3×2048×4096` uint8 HIP | 0–119119，与独立 FFprobe 逐帧一致且严格递增 |
+
+每一份 120 帧输入均得到 120 次 Vulkan export、HIP import/map/release/destroy、
+120 次 source-release stream synchronize 和 240 次 D2D plane copy；固定 context
+session 均为 create 1 / close 1。host transfer、CPU Map、staging、D2H、
+`av_hwframe_transfer_data`、failed bridge、cache hit/miss 均为 0。三次运行后的最高
+GPU junction 为 66°C、memory sensor 为 68°C，低于既定停止门槛。另以 H.264
+Main fixture 做过 B8 中途关闭：消费首批 8 帧后主动关闭 iterator，8 次
+export/import/map/release/destroy、16 次 D2D plane copy 和 session 1/1 全部配平，
+没有预取未消费的下一组 AMF surfaces，也没有残留测试进程。
+
+针对长视频复用还以 8192×4096、60000/1001 fps 的 HEVC Main10 实际素材完成
+B4 decode-only 1400 帧回归，超过修复前约 999 次 export 后失败的位置。1400 次
+Vulkan export、FD close、HIP import/map/release/destroy 全部配平且 close failure/
+errno 为 0；每 100 帧读取一次 `/proc/self/fd`，从 100 到 1400 帧均为总 FD 9、
+dma-buf FD 0，reader 关闭后回到总 FD 6、dma-buf FD 0。PTS 严格递增，GPU
+junction 峰值 66°C、显存使用峰值 11,172,016,128 bytes，运行窗口无 GPU reset、
+ring timeout、page fault 或 OOM。受控证据保存在
+`transactions/jasna-upstream-pr-desktop-cutover-20260830/fd-leak-fix/`，测试媒体
+本身不进入仓库。
+
+`dynamic-fixtures-rebuilt/hevc-dynamic.mkv` 不是静态 HEVC Main fixture：它在第 31
+帧从 640×320 8-bit 切换为 1280×640 10-bit。该输入违反 fixed-context/fixed-format
+边界，AMF decoder 在重配后的 frame 能交给 reader 拒绝前于 Vulkan fence 等待中
+终止进程。因此本 PR 不声明支持中途分辨率/位深重配；该限制不能用首批成功掩盖，
+也不启用 CPU fallback。运行后 kernel journal 没有 GPU reset、ring timeout、page
+fault 或 OOM。
+
+AV1、auto route、编码、动态重配和产品流水线均保持后续独立工作项。

--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -1,4 +1,5 @@
 import ctypes
+import importlib
 import logging
 import os
 import sys
@@ -31,9 +32,16 @@ _libcuda: ctypes.CDLL | None = None
 # - "vali":    VALI only; any failure raises (NVIDIA only).
 # - "pyav-hw": skip VALI, use the PyAV hwaccel path with its software fallback.
 # - "pyav-sw": force FFmpeg software decoding with GPU upload on every vendor.
+# - "amf-interop": explicit Linux AMD research backend. It accepts only the
+#                  documented H.264/HEVC AMF Vulkan surface scope and copies
+#                  directly to HIP, or raises; it is never selected by auto.
 DECODE_BACKEND = "auto"
 DECODE_BACKEND_ENV = "JASNA_DECODE_BACKEND"
-_DECODE_BACKENDS = ("auto", "vali", "pyav-hw", "pyav-sw")
+_DECODE_BACKENDS = ("auto", "vali", "pyav-hw", "pyav-sw", "amf-interop")
+
+_AMF_INTEROP_MODULE = "_jasna_amf_surface_probe"
+AMF_INTEROP_RESOURCE_CACHE_ENV = "JASNA_AMF_INTEROP_RESOURCE_CACHE"
+_AMF_INTEROP_READER_BATCH_SIZES = frozenset({1, 2, 4, 8})
 
 # PyAV's avcodec_find_decoder returns libdav1d for AV1, which carries no NVDEC
 # hwaccel config, so av.open silently decodes AV1 in software. Force the native
@@ -55,6 +63,80 @@ def _decode_backend() -> str:
             f"expected {_DECODE_BACKENDS}"
         )
     return backend
+
+
+def _amf_interop_resource_cache_enabled(*, default: bool = False) -> bool:
+    """Parse the experimental cache switch without enabling it by default.
+
+    The core deliberately implements only per-frame import/map/release. A
+    true value is rejected by the reader rather than silently changing lifetime
+    semantics or leaking into another route.
+    """
+
+    raw_value = os.environ.get(AMF_INTEROP_RESOURCE_CACHE_ENV)
+    if raw_value is None:
+        return bool(default)
+    value = raw_value.strip().casefold()
+    if value in {"", "0", "false", "no", "off"}:
+        return False
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    raise ValueError(
+        f"Invalid {AMF_INTEROP_RESOURCE_CACHE_ENV} value {value!r}; "
+        "expected 0/1, false/true, no/yes, or off/on"
+    )
+
+
+def _amf_interop_format_supported(metadata: VideoMetadata) -> bool:
+    """Return whether metadata is inside the explicit native core scope."""
+
+    codec = str(metadata.codec_name).casefold()
+    profile = str(getattr(metadata, "profile", "") or "").casefold()
+    pixel_format = str(getattr(metadata, "pixel_format", "") or "").casefold()
+    is_10bit = bool(metadata.is_10bit)
+    if codec == "h264":
+        # ffprobe reports the source decoder's common yuv420p label; native
+        # AMF output is checked separately at the first returned frame.
+        return profile in {"main", "high"} and not is_10bit
+    if codec != "hevc":
+        return False
+    if not is_10bit and profile == "main":
+        return True
+    if is_10bit and profile in {"main 10", "main10"}:
+        return True
+    # Bundled ffprobe metadata from older source runs may omit an HEVC profile.
+    # Infer only when its pixel label itself is sufficiently specific.
+    if not profile and not is_10bit and pixel_format == "nv12":
+        return True
+    if not profile and is_10bit and pixel_format == "p010le":
+        return True
+    return False
+
+
+def _load_amf_interop_bridge():
+    """Load only an ABI-matched native AMF/Vulkan/HIP extension."""
+
+    try:
+        bridge = importlib.import_module(_AMF_INTEROP_MODULE)
+    except (ImportError, OSError, ValueError) as exc:
+        raise VideoDecodeError(
+            "The explicit amf-interop backend requires the ABI-matched "
+            f"{_AMF_INTEROP_MODULE} extension from the unified PyAV/FFmpeg runtime: {exc}"
+        ) from exc
+    required = (
+        "inspect_amf_surface",
+        "copy_amf_surface_to_hip",
+        "get_transport_stats",
+        "reset_transport_stats",
+        "AmfVulkanHipInteropSession",
+    )
+    missing = [name for name in required if not callable(getattr(bridge, name, None))]
+    if missing:
+        raise VideoDecodeError(
+            "The explicit amf-interop bridge is missing required entry points: "
+            + ", ".join(missing)
+        )
+    return bridge
 
 
 def _cuda_driver() -> ctypes.CDLL:
@@ -230,6 +312,427 @@ class _ValiFrameSource:
             raise RuntimeError(f"cuStreamDestroy failed (CUDA error {result})")
 
 
+class _AmfInteropTransportAudit:
+    """Per-reader proof that explicit AMF interop stayed GPU-only.
+
+    The bridge's process counters are useful diagnostics but may include other
+    readers. This object records the exact calls owned by one reader and
+    rejects any result that reports a host transfer, CPU mapping, staging copy,
+    D2H copy, failed native operation, or context identity change.
+    """
+
+    _FORBIDDEN_TRANSPORT_COUNTERS = (
+        "hip_non_d2d_copy_calls",
+        "host_frame_transfers",
+        "cpu_map_calls",
+        "staging_copy_calls",
+        "d2h_copy_calls",
+        "av_hwframe_transfer_data_calls",
+        "failed_bridge_copies",
+        "vulkan_export_fd_close_failures",
+    )
+
+    def __init__(
+        self,
+        *,
+        inspect_amf_surface,
+        copy_amf_surface_to_hip,
+        get_transport_stats,
+        identity_session,
+        device: torch.device,
+    ) -> None:
+        self._inspect_amf_surface = inspect_amf_surface
+        self._copy_amf_surface_to_hip = copy_amf_surface_to_hip
+        self._get_transport_stats = get_transport_stats
+        self._identity_session = identity_session
+        self._device = int(device.index or 0)
+        self._identity: tuple[int, int, int, int] | None = None
+        self._closed = False
+        self._stats = {
+            "copy_to_hip_calls": 0,
+            "copy_to_hip_successes": 0,
+            "copy_to_hip_failures": 0,
+            "vulkan_memory_exports": 0,
+            "vulkan_export_fd_close_calls": 0,
+            "vulkan_export_fd_close_failures": 0,
+            "last_vulkan_export_fd_close_errno": 0,
+            "hip_external_memory_imports": 0,
+            "hip_mapped_buffer_acquires": 0,
+            "hip_mapped_buffer_releases": 0,
+            "hip_external_memory_destroys": 0,
+            "hip_d2d_plane_copies": 0,
+            "decode_source_release_hip_stream_synchronize_calls": 0,
+            "fixed_context_session_create_calls": 1,
+            "fixed_context_session_close_calls": 0,
+            "fixed_context_session_close_failures": 0,
+            "resource_cache_session_create_calls": 0,
+            "resource_cache_session_close_calls": 0,
+            "resource_cache_session_close_failures": 0,
+            "resource_cache_hits": 0,
+            "resource_cache_misses": 0,
+        }
+
+    @classmethod
+    def _reject_forbidden_transport(cls, values, *, source: str) -> None:
+        if not isinstance(values, dict):
+            raise VideoDecodeError(
+                f"amf-interop {source} telemetry is not a dictionary: {values!r}"
+            )
+        nonzero = []
+        for name in cls._FORBIDDEN_TRANSPORT_COUNTERS:
+            try:
+                value = int(values.get(name, 0))
+            except (OverflowError, TypeError, ValueError) as exc:
+                raise VideoDecodeError(
+                    f"amf-interop {source} telemetry has invalid {name}: {values!r}"
+                ) from exc
+            if value != 0:
+                nonzero.append(f"{name}={value}")
+        if nonzero:
+            raise VideoDecodeError(
+                "amf-interop rejected a non-native transport operation from "
+                f"{source}: " + ", ".join(nonzero)
+            )
+
+    @staticmethod
+    def _integer(values: dict, name: str, *, default: int | None = None) -> int:
+        value = values.get(name, default)
+        try:
+            return int(value)
+        except (OverflowError, TypeError, ValueError) as exc:
+            raise VideoDecodeError(
+                f"amf-interop bridge returned invalid {name}: {values!r}"
+            ) from exc
+
+    def inspect_frame(self, frame) -> dict:
+        try:
+            info = self._inspect_amf_surface(frame)
+        except BaseException as exc:
+            raise VideoDecodeError(
+                f"amf-interop rejected a non-native AMF frame: {exc}"
+            ) from exc
+        if not isinstance(info, dict):
+            raise VideoDecodeError(
+                f"amf-interop surface inspection returned invalid metadata: {info!r}"
+            )
+        memory_type = str(info.get("memory_type", "")).casefold()
+        vulkan = info.get("vulkan")
+        if memory_type != "vulkan" or not isinstance(vulkan, dict):
+            raise VideoDecodeError(
+                "amf-interop requires an AMF Vulkan external-memory surface; "
+                f"inspection returned {info!r}"
+            )
+        fixed_context = info.get("fixed_context")
+        if not isinstance(fixed_context, dict):
+            fixed_context = {}
+        frames_context = self._integer(
+            fixed_context,
+            "frames_context",
+            default=0,
+        )
+        amf_context = self._integer(fixed_context, "amf_context", default=0)
+        vulkan_device = self._integer(
+            fixed_context,
+            "vulkan_device",
+            default=vulkan.get("device", 0),
+        )
+        memory = self._integer(vulkan, "memory", default=0)
+        if (
+            frames_context <= 0
+            or amf_context <= 0
+            or vulkan_device <= 0
+            or memory <= 0
+        ):
+            raise VideoDecodeError(
+                "amf-interop requires a non-null AMF context, Vulkan device, and "
+                f"external memory handle; inspection returned {info!r}"
+            )
+        identity = (frames_context, amf_context, vulkan_device, self._device)
+        if self._identity is None:
+            self._identity = identity
+        elif self._identity != identity:
+            raise VideoDecodeError(
+                "amf-interop fixed identity changed (AMF/Vulkan/HIP device or context) within "
+                f"one reader: expected {self._identity}, got {identity}"
+            )
+        return info
+
+    def copy_to_hip(self, frame, destination: int, destination_size: int) -> dict:
+        self._stats["copy_to_hip_calls"] += 1
+        self.inspect_frame(frame)
+        try:
+            result = self._copy_amf_surface_to_hip(
+                frame,
+                int(destination),
+                int(destination_size),
+                self._device,
+            )
+        except BaseException:
+            self._stats["copy_to_hip_failures"] += 1
+            raise
+        if not isinstance(result, dict):
+            self._stats["copy_to_hip_failures"] += 1
+            raise VideoDecodeError(
+                f"amf-interop bridge returned invalid copy telemetry: {result!r}"
+            )
+        try:
+            self._reject_forbidden_transport(result, source="copy result")
+            process_stats = self._get_transport_stats()
+            self._reject_forbidden_transport(process_stats, source="bridge counters")
+            fd_close_calls = self._integer(
+                result, "vulkan_export_fd_close_calls"
+            )
+            fd_close_result = self._integer(
+                result, "vulkan_export_fd_close_result"
+            )
+            fd_close_errno = self._integer(
+                result, "vulkan_export_fd_close_errno"
+            )
+            self._stats["vulkan_export_fd_close_calls"] += fd_close_calls
+            if fd_close_result != 0:
+                self._stats["vulkan_export_fd_close_failures"] += 1
+                self._stats["last_vulkan_export_fd_close_errno"] = fd_close_errno
+            valid = (
+                self._integer(result, "hip_result") == 0
+                and self._integer(result, "hip_free_result") == 0
+                and self._integer(result, "hip_destroy_result") == 0
+                and self._integer(result, "d2d_plane_copies", default=2) == 2
+                and self._integer(
+                    result,
+                    "decode_source_release_hip_stream_synchronize_calls",
+                )
+                == 1
+                and self._integer(
+                    result,
+                    "decode_source_release_hip_stream_synchronize_result",
+                )
+                == 0
+                and result.get("copy_synchronization") == "null-stream-source-release"
+                and result.get("fixed_context_bound") is True
+                and fd_close_calls == 1
+                and fd_close_result == 0
+                and fd_close_errno == 0
+            )
+        except VideoDecodeError:
+            self._stats["copy_to_hip_failures"] += 1
+            raise
+        if not valid:
+            self._stats["copy_to_hip_failures"] += 1
+            raise VideoDecodeError(
+                "amf-interop bridge did not prove its AMF-source-release D2D "
+                f"contract: {result}"
+            )
+        self._stats["copy_to_hip_successes"] += 1
+        self._stats["vulkan_memory_exports"] += 1
+        self._stats["hip_external_memory_imports"] += 1
+        self._stats["hip_mapped_buffer_acquires"] += 1
+        self._stats["hip_mapped_buffer_releases"] += 1
+        self._stats["hip_external_memory_destroys"] += 1
+        self._stats["hip_d2d_plane_copies"] += 2
+        self._stats["decode_source_release_hip_stream_synchronize_calls"] += 1
+        return result
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        try:
+            self._identity_session.close()
+        except BaseException:
+            self._stats["fixed_context_session_close_calls"] += 1
+            self._stats["fixed_context_session_close_failures"] += 1
+            raise
+        self._stats["fixed_context_session_close_calls"] += 1
+        self._closed = True
+
+    def snapshot(self) -> dict[str, object]:
+        stats = dict(self._stats)
+        try:
+            session_stats = dict(self._identity_session.stats())
+        except BaseException as exc:
+            raise VideoDecodeError(
+                f"amf-interop fixed-context session telemetry failed: {exc}"
+            ) from exc
+        if int(session_stats.get("cache_entries", 0)) != 0:
+            raise VideoDecodeError(
+                "amf-interop resource cache was unexpectedly populated: "
+                f"{session_stats}"
+            )
+        stats.update(
+            {
+                "schema": "jasna.amf.vulkan-hip-transport.v1",
+                "telemetry_source": "instrumented-per-reader",
+                "non_hardcoded": True,
+                "failed_bridge_copies": stats["copy_to_hip_failures"],
+                "hip_non_d2d_copy_calls": 0,
+                "host_frame_transfers": 0,
+                "cpu_map_calls": 0,
+                "staging_copy_calls": 0,
+                "d2h_copy_calls": 0,
+                "av_hwframe_transfer_data_calls": 0,
+                "transport_reconfigures": 0,
+                "transport_restarts": 0,
+                "resource_strategy": (
+                    "per-frame Vulkan external-memory import/map with balanced release"
+                ),
+                "copy_synchronization": "null-stream-source-release",
+                "fixed_context_identity": self._identity,
+                "fixed_context_session_closed": bool(session_stats.get("closed", False)),
+            }
+        )
+        return stats
+
+    def validate_closed(self) -> dict[str, object]:
+        stats = self.snapshot()
+        calls = int(stats["copy_to_hip_calls"])
+        resource_counts = {
+            calls,
+            int(stats["vulkan_memory_exports"]),
+            int(stats["vulkan_export_fd_close_calls"]),
+            int(stats["hip_external_memory_imports"]),
+            int(stats["hip_mapped_buffer_acquires"]),
+            int(stats["hip_mapped_buffer_releases"]),
+            int(stats["hip_external_memory_destroys"]),
+        }
+        valid = (
+            stats["copy_to_hip_successes"] == calls
+            and stats["copy_to_hip_failures"] == 0
+            and stats["hip_d2d_plane_copies"] == calls * 2
+            and stats["decode_source_release_hip_stream_synchronize_calls"] == calls
+            and stats["vulkan_export_fd_close_failures"] == 0
+            and stats["last_vulkan_export_fd_close_errno"] == 0
+            and len(resource_counts) == 1
+            and stats["fixed_context_session_create_calls"] == 1
+            and stats["fixed_context_session_close_calls"] == 1
+            and stats["fixed_context_session_close_failures"] == 0
+            and stats["fixed_context_session_closed"]
+            and stats["resource_cache_session_create_calls"] == 0
+            and stats["resource_cache_session_close_calls"] == 0
+            and stats["resource_cache_hits"] == 0
+            and stats["resource_cache_misses"] == 0
+        )
+        if not valid:
+            raise VideoDecodeError(
+                "amf-interop violated its GPU-only resource/lifetime contract: "
+                f"{stats}"
+            )
+        return stats
+
+
+class AmfInteropUploader:
+    """Convert native AMF Vulkan NV12/P010 surfaces without host staging."""
+
+    def __init__(
+        self,
+        *,
+        file: str,
+        batch_size: int,
+        device: torch.device,
+        metadata: VideoMetadata,
+        height: int,
+        width: int,
+        full_range: bool,
+        audit: _AmfInteropTransportAudit,
+    ) -> None:
+        self.file = file
+        self.batch_size = int(batch_size)
+        self.device = device
+        self.metadata = metadata
+        self.height = int(height)
+        self.width = int(width)
+        self.full_range = bool(full_range)
+        self.audit = audit
+        self.is_10bit = bool(metadata.is_10bit)
+        self.software_format = "p010le" if self.is_10bit else "nv12"
+        self.bytes_per_sample = 2 if self.is_10bit else 1
+
+    def frames(self, decoded, group: list) -> Iterator[tuple[torch.Tensor, list[int]]]:
+        H, W = self.height, self.width
+        converter = YuvToRgbConverter(
+            H,
+            W,
+            self.metadata.color_space,
+            self.full_range,
+            self.is_10bit,
+            self.device,
+        )
+        while group:
+            packed = torch.empty(
+                (len(group), H + H // 2, W),
+                dtype=torch.uint16 if self.is_10bit else torch.uint8,
+                device=self.device,
+            )
+            batch = torch.empty(
+                (len(group), 3, H, W),
+                dtype=torch.uint8,
+                device=self.device,
+            )
+            pts: list[int] = []
+            for index, frame in enumerate(group):
+                frame_format = getattr(getattr(frame, "format", None), "name", None)
+                software_format = getattr(
+                    getattr(frame, "sw_format", None), "name", None
+                )
+                if (
+                    frame_format != "amf"
+                    or software_format != self.software_format
+                    or int(frame.width) != W
+                    or int(frame.height) != H
+                ):
+                    raise VideoDecodeError(
+                        "amf-interop requires a native AMF Vulkan "
+                        f"{self.software_format.upper()} frame; got "
+                        f"format={frame_format}, sw_format={software_format}, "
+                        f"size={getattr(frame, 'width', None)}x"
+                        f"{getattr(frame, 'height', None)} for {self.file}. "
+                        "Host fallback is forbidden."
+                    )
+                copied = self.audit.copy_to_hip(
+                    frame,
+                    packed[index].data_ptr(),
+                    packed[index].numel() * packed[index].element_size(),
+                )
+                if (
+                    int(copied.get("width", -1)) != W
+                    or int(copied.get("height", -1)) != H
+                    or int(copied.get("bytes_per_sample", -1))
+                    != self.bytes_per_sample
+                ):
+                    raise VideoDecodeError(
+                        "amf-interop bridge returned an invalid native copy result: "
+                        f"{copied}"
+                    )
+                converter.convert_into(
+                    packed[index, :H],
+                    packed[index, H:].view(H // 2, W // 2, 2),
+                    batch[index],
+                )
+                pts.append(frame.pts)
+            # Source lifetime was synchronized by the bridge before each frame
+            # reference can be released; this only completes the RGB conversion
+            # before the batch crosses the reader boundary.
+            current_stream(self.device).synchronize()
+            # A Python ``for`` target retains its final value after the loop.
+            # Drop it and clear the previous AMF surface list before asking the
+            # decoder for another group, otherwise native surfaces span two
+            # decode batches despite the bridge source-release synchronization.
+            del frame
+            group.clear()
+            yield batch, pts
+            # Do not prefetch native AMF surfaces across the consumer boundary.
+            # In particular, closing the generator after this yield must leave
+            # no unconsumed decode group alive while the AMF decoder is torn down.
+            group = self._read_group(decoded)
+
+    def _read_group(self, decoded) -> list:
+        group = []
+        while len(group) < self.batch_size:
+            frame = next(decoded, None)
+            if frame is None:
+                break
+            group.append(frame)
+        return group
+
+
 class NvidiaVideoReader:
     def __init__(
         self,
@@ -253,13 +756,36 @@ class NvidiaVideoReader:
         self._amd_hardware_decode = False
         self._vali_source: _ValiFrameSource | None = None
         self._software_only = False
+        self._amf_interop_enabled = False
+        self._amf_interop_bridge = None
+        self._amf_interop_audit: _AmfInteropTransportAudit | None = None
+        self._amf_interop_resource_cache = False
+        self.amf_interop_stats: dict[str, object] | None = None
+        self._decode_backend = DECODE_BACKEND
+        self._raw_stream: int | None = None
+        self.container = None
+        self.video_stream = None
 
     def __enter__(self):
         self._decoder_ctx = None
         self._amd_hardware_decode = False
         self._vali_source = None
+        self._amf_interop_enabled = False
+        self._amf_interop_bridge = None
+        self._amf_interop_audit = None
+        self._amf_interop_resource_cache = False
+        self.amf_interop_stats = None
+        self.container = None
+        self.video_stream = None
+        # Preserve the established per-context lifetime for the CUDA conversion
+        # stream on regular PyAV/NVDEC readers.
+        self._raw_stream = None
         current_stream(self.device)
         backend = _decode_backend()
+        self._decode_backend = backend
+        if backend == "amf-interop":
+            self._open_amf_interop_backend()
+            return self
         if backend in ("auto", "vali"):
             if self.vendor is AcceleratorVendor.NVIDIA:
                 try:
@@ -287,6 +813,12 @@ class NvidiaVideoReader:
             elif backend == "vali":
                 raise VideoDecodeError("The VALI decode backend requires an NVIDIA device")
         software_only = backend == "pyav-sw"
+        self._open_pyav(software_only=software_only)
+        return self
+
+    def _open_pyav(self, *, software_only: bool, amf_interop: bool = False) -> None:
+        """Open the established PyAV route without changing its policy."""
+
         self._software_only = software_only
         try:
             if not software_only and self.vendor is AcceleratorVendor.NVIDIA:
@@ -311,7 +843,7 @@ class NvidiaVideoReader:
         if software_only:
             ctx.thread_type = "AUTO"
         elif self.vendor is AcceleratorVendor.AMD:
-            self._setup_amf_decoder(ctx)
+            self._setup_amf_decoder(ctx, fail_closed=amf_interop)
         elif not ctx.is_hwaccel:
             if self.vendor is AcceleratorVendor.NVIDIA:
                 self._setup_nvdec_decoder(ctx)
@@ -325,8 +857,127 @@ class NvidiaVideoReader:
             ctx.color_range == int(AvColorRange.JPEG)
             or self.metadata.color_range == AvColorRange.JPEG
         )
-        self._raw_stream: int | None = None
-        return self
+
+    def _open_amf_interop_backend(self) -> None:
+        """Open the explicit, fail-closed AMF Vulkan -> HIP reader only."""
+
+        self._validate_amf_interop_scope()
+        self._amf_interop_resource_cache = _amf_interop_resource_cache_enabled()
+        if self._amf_interop_resource_cache:
+            raise VideoDecodeError(
+                f"{AMF_INTEROP_RESOURCE_CACHE_ENV}=1 is not implemented by this "
+                "amf-interop core; per-frame balanced external-memory ownership is required"
+            )
+        bridge = _load_amf_interop_bridge()
+        try:
+            identity_session = bridge.AmfVulkanHipInteropSession("decode")
+        except BaseException as exc:
+            raise VideoDecodeError(
+                "The explicit amf-interop backend could not create its fixed-context "
+                f"bridge session: {exc}"
+            ) from exc
+        session_copy = getattr(identity_session, "copy_amf_surface_to_hip", None)
+        session_close = getattr(identity_session, "close", None)
+        session_stats = getattr(identity_session, "stats", None)
+        missing_methods = [
+            name
+            for name, method in (
+                ("copy_amf_surface_to_hip()", session_copy),
+                ("close()", session_close),
+                ("stats()", session_stats),
+            )
+            if not callable(method)
+        ]
+        if missing_methods:
+            if callable(session_close):
+                try:
+                    session_close()
+                except BaseException as close_error:
+                    raise VideoDecodeError(
+                        "The explicit amf-interop bridge session is incomplete and its "
+                        f"cleanup also failed: {close_error}"
+                    ) from close_error
+            raise VideoDecodeError(
+                "The explicit amf-interop bridge session is missing required methods: "
+                + ", ".join(missing_methods)
+            )
+        audit = _AmfInteropTransportAudit(
+            inspect_amf_surface=bridge.inspect_amf_surface,
+            copy_amf_surface_to_hip=session_copy,
+            get_transport_stats=bridge.get_transport_stats,
+            identity_session=identity_session,
+            device=self.device,
+        )
+        self._amf_interop_bridge = bridge
+        self._amf_interop_audit = audit
+        self._amf_interop_enabled = True
+        try:
+            self._open_pyav(software_only=False, amf_interop=True)
+        except BaseException as error:
+            cleanup_errors = []
+            try:
+                self._close_pyav()
+            except BaseException as close_error:
+                cleanup_errors.append(f"PyAV close: {close_error}")
+            try:
+                audit.close()
+            except BaseException as close_error:
+                cleanup_errors.append(f"interop session close: {close_error}")
+            self._amf_interop_enabled = False
+            self._amf_interop_audit = None
+            self._amf_interop_bridge = None
+            if cleanup_errors:
+                raise VideoDecodeError(
+                    "amf-interop failed while opening and could not complete cleanup: "
+                    + "; ".join(cleanup_errors)
+                ) from error
+            raise
+        log.info("Using explicit AMF Vulkan -> HIP D2D decoder for %s", self.file)
+
+    def _validate_amf_interop_scope(self) -> None:
+        failures = []
+        if sys.platform != "linux":
+            failures.append("Linux is required")
+        if self.vendor is not AcceleratorVendor.AMD:
+            failures.append("an AMD device is required")
+        if not _amf_interop_format_supported(self.metadata):
+            failures.append(
+                "only fixed-format H.264 Main/High 8-bit NV12, HEVC Main 8-bit "
+                "NV12, or HEVC Main10 10-bit P010 is accepted"
+            )
+        if int(self.batch_size) not in _AMF_INTEROP_READER_BATCH_SIZES:
+            failures.append(
+                "batch_size must be one of "
+                f"{sorted(_AMF_INTEROP_READER_BATCH_SIZES)}"
+            )
+        if failures:
+            raise VideoDecodeError(
+                "The explicit amf-interop backend cannot satisfy this reader: "
+                + "; ".join(failures)
+            )
+
+    def _close_amf_interop_backend(self, *, validate: bool = True) -> None:
+        audit = self._amf_interop_audit
+        if audit is None:
+            return
+        # Do not clear the audit before both close and validation complete: a
+        # native teardown error must remain observable rather than becoming a
+        # silent best-effort cleanup.
+        audit.close()
+        # Preserve a concrete native copy/decode exception from the with-body.
+        # Normal close still applies full lifecycle validation; exceptional
+        # close records the audit without replacing the original native cause.
+        self.amf_interop_stats = audit.validate_closed() if validate else audit.snapshot()
+        self._amf_interop_enabled = False
+        self._amf_interop_audit = None
+        self._amf_interop_bridge = None
+
+    def _close_pyav(self) -> None:
+        self._decoder_ctx = None
+        if self.container is None:
+            return
+        container, self.container = self.container, None
+        container.close()
 
     @property
     def start_pts(self) -> int:
@@ -337,13 +988,25 @@ class NvidiaVideoReader:
             self.metadata.start_pts,
         )
 
-    def _setup_amf_decoder(self, source_ctx) -> None:
+    def _setup_amf_decoder(self, source_ctx, *, fail_closed: bool = False) -> None:
+        source_name = str(source_ctx.name).lower()
+        # The unified runtime can expose the selected AMF decoder as the
+        # stream context name already. Only the explicit fail-closed path
+        # normalizes that implementation detail; existing auto behavior keeps
+        # its established source-context handling unchanged.
+        if fail_closed and source_name.endswith("_amf"):
+            source_name = source_name[: -len("_amf")]
         decoder_name = {
             "h264": "h264_amf",
             "hevc": "hevc_amf",
             "av1": "av1_amf",
-        }.get(str(source_ctx.name).lower())
+        }.get(source_name)
         if decoder_name is None:
+            if fail_closed:
+                raise VideoDecodeError(
+                    "amf-interop cannot create a native AMF decoder for "
+                    f"codec {source_ctx.name!r}"
+                )
             source_ctx.thread_type = "AUTO"
             return
         try:
@@ -351,7 +1014,10 @@ class NvidiaVideoReader:
                 "amf",
                 device=str(self.device.index or 0),
                 allow_software_fallback=False,
-                is_hw_owned=False,
+                # Native AMF surfaces must be owned by this explicit decoder;
+                # otherwise PyAV can materialize NV12 host frames even though
+                # AMF itself opened successfully.
+                is_hw_owned=bool(fail_closed),
             )
             decoder = av.CodecContext.create(
                 decoder_name,
@@ -363,13 +1029,28 @@ class NvidiaVideoReader:
             decoder.height = source_ctx.height
             # PyAV 18 rejects assigning time_base on a decoder ("Cannot access
             # 'time_base' as a decoder"); decoders take timing from packets.
-            decoder.framerate = source_ctx.framerate
-            decoder.sample_aspect_ratio = source_ctx.sample_aspect_ratio
+            if fail_closed:
+                # The AMF-selected source context in the accepted runtime can
+                # legitimately omit container framerate/SAR. Packets carry
+                # timing; assigning None makes PyAV reject an otherwise native
+                # decoder before it opens.
+                if source_ctx.framerate is not None:
+                    decoder.framerate = source_ctx.framerate
+                if source_ctx.sample_aspect_ratio is not None:
+                    decoder.sample_aspect_ratio = source_ctx.sample_aspect_ratio
+            else:
+                decoder.framerate = source_ctx.framerate
+                decoder.sample_aspect_ratio = source_ctx.sample_aspect_ratio
             decoder.open(strict=False)
             self._decoder_ctx = decoder
             self._amd_hardware_decode = True
             log.info("Using AMF hardware decoder %s for %s", decoder_name, self.file)
         except (ValueError, av.FFmpegError, RuntimeError) as exc:
+            if fail_closed:
+                raise VideoDecodeError(
+                    "amf-interop cannot configure a native AMF decoder for "
+                    f"{self.file} (codec {self.metadata.codec_name}): {exc}"
+                ) from exc
             source_ctx.thread_type = "AUTO"
             log.warning(
                 "AMF cannot decode %s (codec %s): %s; using FFmpeg software "
@@ -436,8 +1117,11 @@ class NvidiaVideoReader:
             source, self._vali_source = self._vali_source, None
             source.close()
             return
-        self.container.close()
-        self._decoder_ctx = None
+        try:
+            self._close_pyav()
+        finally:
+            if self._amf_interop_audit is not None:
+                self._close_amf_interop_backend(validate=exc_type is None)
         if self._raw_stream is None:
             return
         result = _cuda_driver().cuStreamDestroy(ctypes.c_void_p(self._raw_stream))
@@ -523,7 +1207,9 @@ class NvidiaVideoReader:
         if not group:
             return
         vendor = getattr(self, "vendor", AcceleratorVendor.NVIDIA)
-        if (
+        if getattr(self, "_amf_interop_enabled", False):
+            backend = self._frames_amf_interop(decoded, group)
+        elif (
             vendor is AcceleratorVendor.NVIDIA
             and group[0].format.name == "cuda"
         ):
@@ -544,6 +1230,26 @@ class NvidiaVideoReader:
         # for the reader's lifetime costs about 96 MiB of avoidable VRAM.
         del group
         yield from backend
+
+    def _frames_amf_interop(
+        self,
+        decoded,
+        group: list,
+    ) -> Iterator[tuple[torch.Tensor, list[int]]]:
+        audit = self._amf_interop_audit
+        if audit is None:
+            raise VideoDecodeError("amf-interop bridge audit is unavailable")
+        uploader = AmfInteropUploader(
+            file=self.file,
+            batch_size=self.batch_size,
+            device=self.device,
+            metadata=self.metadata,
+            height=self.height,
+            width=self.width,
+            full_range=self._full_range,
+            audit=audit,
+        )
+        yield from uploader.frames(decoded, group)
 
     def _frames_hardware(self, decoded, group: list) -> Iterator[tuple[torch.Tensor, list[int]]]:
         # FFmpeg 8 maps NVDEC output on CUDA stream 0. Conversion runs in a

--- a/scripts/amf_surface_probe.pyx
+++ b/scripts/amf_surface_probe.pyx
@@ -1,0 +1,986 @@
+"""Minimal Linux AMF Vulkan-to-HIP D2D bridge.
+
+This extension is intentionally a diagnostic building block.  It accepts only
+native AMF Vulkan decode surfaces and performs two HIP device-to-device plane
+copies.  It never exposes a host map, staging allocation, or software frame
+transfer path.  Each copy imports and releases Vulkan external memory in the
+same call; the small session object only pins the decoder/context identity and
+is not a resource cache.
+"""
+
+from av.video.frame cimport VideoFrame
+from libc.stdint cimport uint64_t, uintptr_t
+
+
+_TRANSPORT_STATS_SCHEMA = "jasna.amf.vulkan-hip-transport.v1"
+_transport_stats = {}
+
+
+def reset_transport_stats():
+    """Reset process-local instrumentation for this isolated bridge."""
+
+    global _transport_stats
+    _transport_stats = {
+        "copy_to_hip_calls": 0,
+        "copy_to_hip_successes": 0,
+        "copy_to_hip_failures": 0,
+        "vulkan_memory_exports": 0,
+        "vulkan_export_fd_close_calls": 0,
+        "vulkan_export_fd_close_failures": 0,
+        "last_vulkan_export_fd_close_errno": 0,
+        "hip_external_memory_imports": 0,
+        "hip_external_memory_destroys": 0,
+        "hip_mapped_buffer_acquires": 0,
+        "hip_mapped_buffer_releases": 0,
+        "hip_d2d_plane_copies": 0,
+        "decode_source_release_hip_stream_synchronize_calls": 0,
+        "fixed_context_session_create_calls": 0,
+        "fixed_context_session_close_calls": 0,
+        "fixed_context_session_close_failures": 0,
+        # This core deliberately has no product resource cache.
+        "resource_cache_session_create_calls": 0,
+        "resource_cache_session_close_calls": 0,
+        "resource_cache_session_close_failures": 0,
+        "resource_cache_hits": 0,
+        "resource_cache_misses": 0,
+    }
+
+
+def get_transport_stats():
+    """Return counters that make host or non-D2D transport auditable."""
+
+    stats = dict(_transport_stats)
+    stats.update(
+        {
+            "schema": _TRANSPORT_STATS_SCHEMA,
+            "telemetry_source": "instrumented",
+            "non_hardcoded": True,
+            "failed_bridge_copies": stats["copy_to_hip_failures"],
+            "hip_non_d2d_copy_calls": 0,
+            "host_frame_transfers": 0,
+            "cpu_map_calls": 0,
+            "staging_copy_calls": 0,
+            "d2h_copy_calls": 0,
+            "av_hwframe_transfer_data_calls": 0,
+            "transport_reconfigures": 0,
+            "transport_restarts": 0,
+            "resource_strategy": (
+                "per-frame Vulkan external-memory import/map with balanced release"
+            ),
+            "copy_synchronization": "null-stream-source-release",
+        }
+    )
+    return stats
+
+
+reset_transport_stats()
+
+
+cdef extern from *:
+    """
+    #include <stdint.h>
+    #include <errno.h>
+    #include <stdlib.h>
+    #include <string.h>
+    #include <unistd.h>
+    #include <dlfcn.h>
+    #include <libavutil/frame.h>
+    #include <libavutil/hwcontext.h>
+    #include <libavutil/hwcontext_amf.h>
+    #include <libavutil/pixfmt.h>
+    #include <AMF/core/Surface.h>
+    #include <AMF/core/VulkanAMF.h>
+    #include <hip/hip_runtime_api.h>
+
+    typedef struct JasnaAmfCopyInfo {
+        int width;
+        int height;
+        int bytes_per_sample;
+        uint64_t packed_size;
+        uint64_t source_y_pitch;
+        uint64_t source_uv_pitch;
+        int wait_result;
+        int export_result;
+        int fd_close_calls;
+        int fd_close_result;
+        int fd_close_errno;
+        int hip_result;
+        int hip_free_result;
+        int hip_destroy_result;
+        int hip_stream_synchronize_calls;
+        int hip_stream_synchronize_result;
+        int d2d_plane_copies;
+        int fixed_context_bound;
+    } JasnaAmfCopyInfo;
+
+    typedef struct JasnaAmfInteropSession {
+        uintptr_t hw_frames_context;
+        uintptr_t amf_context;
+        uintptr_t vulkan_device;
+        int hip_device;
+        int surface_format;
+        int visible_width;
+        int visible_height;
+        uint64_t copy_calls;
+        uint64_t close_calls;
+        uint64_t close_failures;
+        int closed;
+    } JasnaAmfInteropSession;
+
+    typedef hipError_t (*JasnaHipSetDeviceFn)(int);
+    typedef hipError_t (*JasnaHipImportMemoryFn)(
+        hipExternalMemory_t *,
+        const hipExternalMemoryHandleDesc *
+    );
+    typedef hipError_t (*JasnaHipDestroyMemoryFn)(hipExternalMemory_t);
+    typedef hipError_t (*JasnaHipMapBufferFn)(
+        void **,
+        hipExternalMemory_t,
+        const hipExternalMemoryBufferDesc *
+    );
+    typedef hipError_t (*JasnaHipFreeFn)(void *);
+    typedef hipError_t (*JasnaHipMemcpy2DFn)(
+        void *, size_t, const void *, size_t, size_t, size_t, hipMemcpyKind
+    );
+    typedef hipError_t (*JasnaHipStreamSynchronizeFn)(hipStream_t);
+
+    static void *jasna_vulkan_loader = NULL;
+    static PFN_vkGetDeviceProcAddr jasna_vk_get_device_proc = NULL;
+    static void *jasna_hip_loader = NULL;
+    static JasnaHipSetDeviceFn jasna_hip_set_device = NULL;
+    static JasnaHipImportMemoryFn jasna_hip_import_memory = NULL;
+    static JasnaHipDestroyMemoryFn jasna_hip_destroy_memory = NULL;
+    static JasnaHipMapBufferFn jasna_hip_map_buffer = NULL;
+    static JasnaHipFreeFn jasna_hip_free = NULL;
+    static JasnaHipMemcpy2DFn jasna_hip_memcpy_2d = NULL;
+    static JasnaHipStreamSynchronizeFn jasna_hip_stream_synchronize = NULL;
+
+    static int jasna_load_vulkan(const char **error) {
+        if (jasna_vk_get_device_proc) {
+            return 0;
+        }
+        jasna_vulkan_loader = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
+        if (!jasna_vulkan_loader) {
+            *error = "Vulkan loader is unavailable";
+            return -1;
+        }
+        jasna_vk_get_device_proc = (PFN_vkGetDeviceProcAddr)dlsym(
+            jasna_vulkan_loader, "vkGetDeviceProcAddr"
+        );
+        if (!jasna_vk_get_device_proc) {
+            dlclose(jasna_vulkan_loader);
+            jasna_vulkan_loader = NULL;
+            *error = "vkGetDeviceProcAddr is unavailable";
+            return -2;
+        }
+        return 0;
+    }
+
+    static int jasna_load_hip(const char **error) {
+        if (
+            jasna_hip_set_device && jasna_hip_import_memory &&
+            jasna_hip_destroy_memory && jasna_hip_map_buffer &&
+            jasna_hip_free && jasna_hip_memcpy_2d &&
+            jasna_hip_stream_synchronize
+        ) {
+            return 0;
+        }
+        jasna_hip_loader = dlopen("libamdhip64.so.7", RTLD_NOW | RTLD_LOCAL);
+        if (!jasna_hip_loader) {
+            jasna_hip_loader = dlopen("libamdhip64.so", RTLD_NOW | RTLD_LOCAL);
+        }
+        if (!jasna_hip_loader) {
+            *error = "ROCm HIP runtime is unavailable";
+            return -1;
+        }
+        jasna_hip_set_device = (JasnaHipSetDeviceFn)dlsym(
+            jasna_hip_loader, "hipSetDevice"
+        );
+        jasna_hip_import_memory = (JasnaHipImportMemoryFn)dlsym(
+            jasna_hip_loader, "hipImportExternalMemory"
+        );
+        jasna_hip_destroy_memory = (JasnaHipDestroyMemoryFn)dlsym(
+            jasna_hip_loader, "hipDestroyExternalMemory"
+        );
+        jasna_hip_map_buffer = (JasnaHipMapBufferFn)dlsym(
+            jasna_hip_loader, "hipExternalMemoryGetMappedBuffer"
+        );
+        jasna_hip_free = (JasnaHipFreeFn)dlsym(jasna_hip_loader, "hipFree");
+        jasna_hip_memcpy_2d = (JasnaHipMemcpy2DFn)dlsym(
+            jasna_hip_loader, "hipMemcpy2D"
+        );
+        jasna_hip_stream_synchronize = (JasnaHipStreamSynchronizeFn)dlsym(
+            jasna_hip_loader, "hipStreamSynchronize"
+        );
+        if (
+            !jasna_hip_set_device || !jasna_hip_import_memory ||
+            !jasna_hip_destroy_memory || !jasna_hip_map_buffer ||
+            !jasna_hip_free || !jasna_hip_memcpy_2d ||
+            !jasna_hip_stream_synchronize
+        ) {
+            dlclose(jasna_hip_loader);
+            jasna_hip_loader = NULL;
+            jasna_hip_set_device = NULL;
+            jasna_hip_import_memory = NULL;
+            jasna_hip_destroy_memory = NULL;
+            jasna_hip_map_buffer = NULL;
+            jasna_hip_free = NULL;
+            jasna_hip_memcpy_2d = NULL;
+            jasna_hip_stream_synchronize = NULL;
+            *error = "required HIP external-memory or D2D entry point is unavailable";
+            return -2;
+        }
+        return 0;
+    }
+
+    static JasnaAmfInteropSession *jasna_session_create(void) {
+        JasnaAmfInteropSession *session =
+            (JasnaAmfInteropSession *)calloc(1, sizeof(JasnaAmfInteropSession));
+        if (session) {
+            session->hip_device = -1;
+        }
+        return session;
+    }
+
+    static int jasna_session_bind(
+        JasnaAmfInteropSession *session,
+        AVHWFramesContext *frames_ctx,
+        AMFContext *amf_context,
+        VkDevice vulkan_device,
+        int hip_device,
+        int surface_format,
+        int visible_width,
+        int visible_height,
+        const char **error
+    ) {
+        if (!session || !frames_ctx || !amf_context || !vulkan_device) {
+            *error = "fixed-context AMF interop session received null identity";
+            return -1;
+        }
+        if (session->closed) {
+            *error = "fixed-context AMF interop session is already closed";
+            return -2;
+        }
+        if (!session->hw_frames_context) {
+            session->hw_frames_context = (uintptr_t)frames_ctx;
+            session->amf_context = (uintptr_t)amf_context;
+            session->vulkan_device = (uintptr_t)vulkan_device;
+            session->hip_device = hip_device;
+            session->surface_format = surface_format;
+            session->visible_width = visible_width;
+            session->visible_height = visible_height;
+            return 0;
+        }
+        if (
+            session->hw_frames_context != (uintptr_t)frames_ctx ||
+            session->amf_context != (uintptr_t)amf_context ||
+            session->vulkan_device != (uintptr_t)vulkan_device ||
+            session->hip_device != hip_device ||
+            session->surface_format != surface_format ||
+            session->visible_width != visible_width ||
+            session->visible_height != visible_height
+        ) {
+            *error = "fixed-context AMF/Vulkan/HIP identity changed";
+            return -3;
+        }
+        return 0;
+    }
+
+    static int jasna_session_close(
+        JasnaAmfInteropSession *session, const char **error
+    ) {
+        if (!session) {
+            *error = "fixed-context AMF interop session is unavailable";
+            return -1;
+        }
+        if (session->closed) {
+            return 0;
+        }
+        /* Per-frame mappings are released in jasna_copy_to_hip before return. */
+        session->close_calls += 1;
+        session->closed = 1;
+        return 0;
+    }
+
+    static void jasna_session_destroy(JasnaAmfInteropSession *session) {
+        if (session) {
+            free(session);
+        }
+    }
+
+    static int jasna_surface_info(
+        AVFrame *frame,
+        uintptr_t *surface_out,
+        uintptr_t *image_out,
+        uintptr_t *memory_out,
+        uint64_t *memory_size_out,
+        uintptr_t *frames_context_out,
+        uintptr_t *amf_context_out,
+        uintptr_t *vulkan_device_out,
+        int *memory_type_out,
+        int *surface_format_out,
+        const char **error
+    ) {
+        AMFSurface *surface;
+        AMFPlane *plane;
+        AMFVulkanView *view;
+        AMFVulkanSurface *vk_surface;
+        AVHWFramesContext *frames_ctx;
+        AVHWDeviceContext *device_ctx;
+        AVAMFDeviceContext *amf_ctx;
+        AMFContext1 *context1 = NULL;
+        AMFVulkanDevice *vk_device = NULL;
+        if (!frame || !surface_out || !image_out || !memory_out ||
+            !memory_size_out || !frames_context_out || !amf_context_out ||
+            !vulkan_device_out || !memory_type_out || !surface_format_out || !error) {
+            return -1;
+        }
+        if (frame->format != AV_PIX_FMT_AMF_SURFACE) {
+            *error = "VideoFrame is not an AMF hardware surface";
+            return -2;
+        }
+        surface = (AMFSurface *)frame->data[0];
+        if (!surface || !surface->pVtbl) {
+            *error = "AMF surface pointer is null";
+            return -3;
+        }
+        *memory_type_out = surface->pVtbl->GetMemoryType(surface);
+        *surface_format_out = surface->pVtbl->GetFormat(surface);
+        if (*memory_type_out != AMF_MEMORY_VULKAN) {
+            *error = "AMF surface is not backed by Vulkan memory";
+            return -4;
+        }
+        plane = surface->pVtbl->GetPlaneAt(surface, 0);
+        view = plane ? (AMFVulkanView *)plane->pVtbl->GetNative(plane) : NULL;
+        vk_surface = view ? view->pSurface : NULL;
+        if (!vk_surface || !vk_surface->hImage || !vk_surface->hMemory ||
+            vk_surface->iSize <= 0) {
+            *error = "AMF Vulkan image or external memory handle is unavailable";
+            return -5;
+        }
+        *surface_out = (uintptr_t)surface;
+        *image_out = (uintptr_t)vk_surface->hImage;
+        *memory_out = (uintptr_t)vk_surface->hMemory;
+        *memory_size_out = (uint64_t)vk_surface->iSize;
+        if (!frame->hw_frames_ctx) {
+            *error = "AMF frame has no hardware frames context";
+            return -6;
+        }
+        frames_ctx = (AVHWFramesContext *)frame->hw_frames_ctx->data;
+        device_ctx = frames_ctx ? frames_ctx->device_ctx : NULL;
+        amf_ctx = device_ctx ? (AVAMFDeviceContext *)device_ctx->hwctx : NULL;
+        if (!amf_ctx || !amf_ctx->context) {
+            *error = "AMF device context is unavailable";
+            return -7;
+        }
+        {
+            AMFGuid guid = IID_AMFContext1();
+            AMF_RESULT query = amf_ctx->context->pVtbl->QueryInterface(
+                amf_ctx->context, &guid, (void **)&context1
+            );
+            if (query != AMF_OK || !context1) {
+                *error = "AMFContext1 is unavailable";
+                return -8;
+            }
+        }
+        vk_device = (AMFVulkanDevice *)context1->pVtbl->GetVulkanDevice(context1);
+        if (!vk_device || !vk_device->hDevice) {
+            context1->pVtbl->Release(context1);
+            *error = "AMF Vulkan device is unavailable";
+            return -9;
+        }
+        *frames_context_out = (uintptr_t)frames_ctx;
+        *amf_context_out = (uintptr_t)amf_ctx->context;
+        *vulkan_device_out = (uintptr_t)vk_device->hDevice;
+        context1->pVtbl->Release(context1);
+        return 0;
+    }
+
+    static int jasna_copy_to_hip(
+        AVFrame *frame,
+        uintptr_t destination,
+        uint64_t destination_size,
+        int hip_device,
+        JasnaAmfInteropSession *session,
+        JasnaAmfCopyInfo *info,
+        const char **error
+    ) {
+        AMFSurface *surface = NULL;
+        AMFPlane *plane = NULL;
+        AMFVulkanView *view = NULL;
+        AMFVulkanSurface *vk_surface = NULL;
+        AMFContext1 *context1 = NULL;
+        AMFVulkanDevice *vk_device = NULL;
+        AVHWFramesContext *frames_ctx = NULL;
+        AVHWDeviceContext *device_ctx = NULL;
+        AVAMFDeviceContext *amf_ctx = NULL;
+        PFN_vkGetMemoryFdKHR get_memory_fd = NULL;
+        PFN_vkGetImageSubresourceLayout get_subresource_layout = NULL;
+        PFN_vkWaitForFences wait_for_fences = NULL;
+        VkSubresourceLayout layouts[2];
+        VkImageSubresource subresource;
+        hipExternalMemory_t external = NULL;
+        void *mapped = NULL;
+        int fd = -1;
+        int status = -1;
+        int bytes_per_sample;
+        int visible_width;
+        int visible_height;
+        uint64_t row_bytes;
+        uint64_t y_size;
+        uint64_t packed_size;
+
+        if (!frame || !destination || !info || !error) {
+            return -1;
+        }
+        memset(info, 0, sizeof(*info));
+        info->fd_close_result = -1;
+        info->hip_result = -1;
+        info->hip_free_result = -1;
+        info->hip_destroy_result = -1;
+        info->hip_stream_synchronize_result = -1;
+        *error = NULL;
+        if (frame->format != AV_PIX_FMT_AMF_SURFACE) {
+            *error = "VideoFrame is not an AMF hardware surface";
+            return -2;
+        }
+        surface = (AMFSurface *)frame->data[0];
+        if (!surface || !surface->pVtbl ||
+            surface->pVtbl->GetMemoryType(surface) != AMF_MEMORY_VULKAN) {
+            *error = "AMF surface is not backed by Vulkan memory";
+            return -3;
+        }
+        if (surface->pVtbl->GetFormat(surface) != AMF_SURFACE_NV12 &&
+            surface->pVtbl->GetFormat(surface) != AMF_SURFACE_P010) {
+            *error = "only AMF NV12 and P010 Vulkan surfaces are supported";
+            return -4;
+        }
+        plane = surface->pVtbl->GetPlaneAt(surface, 0);
+        view = plane ? (AMFVulkanView *)plane->pVtbl->GetNative(plane) : NULL;
+        vk_surface = view ? view->pSurface : NULL;
+        if (!vk_surface || !vk_surface->hImage || !vk_surface->hMemory ||
+            vk_surface->iSize <= 0) {
+            *error = "AMF Vulkan image or external memory handle is unavailable";
+            return -5;
+        }
+        if (!frame->hw_frames_ctx) {
+            *error = "AMF frame has no hardware frames context";
+            return -6;
+        }
+        frames_ctx = (AVHWFramesContext *)frame->hw_frames_ctx->data;
+        device_ctx = frames_ctx ? frames_ctx->device_ctx : NULL;
+        amf_ctx = device_ctx ? (AVAMFDeviceContext *)device_ctx->hwctx : NULL;
+        if (!amf_ctx || !amf_ctx->context) {
+            *error = "AMF device context is unavailable";
+            return -7;
+        }
+        {
+            AMFGuid guid = IID_AMFContext1();
+            AMF_RESULT query = amf_ctx->context->pVtbl->QueryInterface(
+                amf_ctx->context, &guid, (void **)&context1
+            );
+            if (query != AMF_OK || !context1) {
+                *error = "AMFContext1 is unavailable";
+                return -8;
+            }
+        }
+        vk_device = (AMFVulkanDevice *)context1->pVtbl->GetVulkanDevice(context1);
+        if (!vk_device || !vk_device->hDevice) {
+            *error = "AMF Vulkan device is unavailable";
+            status = -9;
+            goto cleanup;
+        }
+        visible_width = frame->width;
+        visible_height = frame->height;
+        if (visible_width <= 0 || visible_height <= 0 ||
+            visible_width > vk_surface->iWidth ||
+            visible_height > vk_surface->iHeight ||
+            (visible_width & 1) || (visible_height & 1)) {
+            *error = "visible frame dimensions are invalid for the AMF surface";
+            status = -10;
+            goto cleanup;
+        }
+        bytes_per_sample = surface->pVtbl->GetFormat(surface) == AMF_SURFACE_P010 ? 2 : 1;
+        row_bytes = (uint64_t)visible_width * (uint64_t)bytes_per_sample;
+        y_size = row_bytes * (uint64_t)visible_height;
+        packed_size = y_size + row_bytes * (uint64_t)(visible_height / 2);
+        if (destination_size < packed_size) {
+            *error = "HIP destination is smaller than the packed AMF frame";
+            status = -11;
+            goto cleanup;
+        }
+        if (session) {
+            status = jasna_session_bind(
+                session, frames_ctx, amf_ctx->context, vk_device->hDevice,
+                hip_device, surface->pVtbl->GetFormat(surface), visible_width,
+                visible_height, error
+            );
+            if (status != 0) {
+                status = -12;
+                goto cleanup;
+            }
+            info->fixed_context_bound = 1;
+        }
+        if (jasna_load_vulkan(error) != 0 || jasna_load_hip(error) != 0) {
+            status = -13;
+            goto cleanup;
+        }
+        get_memory_fd = (PFN_vkGetMemoryFdKHR)jasna_vk_get_device_proc(
+            vk_device->hDevice, "vkGetMemoryFdKHR"
+        );
+        get_subresource_layout = (PFN_vkGetImageSubresourceLayout)
+            jasna_vk_get_device_proc(vk_device->hDevice, "vkGetImageSubresourceLayout");
+        wait_for_fences = (PFN_vkWaitForFences)jasna_vk_get_device_proc(
+            vk_device->hDevice, "vkWaitForFences"
+        );
+        if (!get_memory_fd || !get_subresource_layout || !wait_for_fences) {
+            *error = "required Vulkan external-memory entry point is unavailable";
+            status = -14;
+            goto cleanup;
+        }
+        if (vk_surface->Sync.hFence) {
+            info->wait_result = wait_for_fences(
+                vk_device->hDevice, 1, &vk_surface->Sync.hFence, VK_TRUE,
+                5000000000ULL
+            );
+            if (info->wait_result != VK_SUCCESS) {
+                *error = "waiting for the AMF Vulkan decode fence failed";
+                status = -15;
+                goto cleanup;
+            }
+            /* AMF owns the fence; do not destroy/reset it after a CPU wait. */
+            vk_surface->Sync.hFence = VK_NULL_HANDLE;
+        }
+        memset(layouts, 0, sizeof(layouts));
+        memset(&subresource, 0, sizeof(subresource));
+        subresource.aspectMask = VK_IMAGE_ASPECT_PLANE_0_BIT;
+        get_subresource_layout(vk_device->hDevice, vk_surface->hImage,
+                               &subresource, &layouts[0]);
+        subresource.aspectMask = VK_IMAGE_ASPECT_PLANE_1_BIT;
+        get_subresource_layout(vk_device->hDevice, vk_surface->hImage,
+                               &subresource, &layouts[1]);
+        if (layouts[0].rowPitch < row_bytes || layouts[1].rowPitch < row_bytes) {
+            *error = "AMF Vulkan plane pitch is smaller than visible frame width";
+            status = -16;
+            goto cleanup;
+        }
+        info->hip_result = jasna_hip_set_device(hip_device);
+        if (info->hip_result != hipSuccess) {
+            *error = "selecting the HIP device failed";
+            status = -17;
+            goto cleanup;
+        }
+        {
+            VkMemoryGetFdInfoKHR fd_info;
+            hipExternalMemoryHandleDesc memory_description;
+            hipExternalMemoryBufferDesc buffer_description;
+            memset(&fd_info, 0, sizeof(fd_info));
+            fd_info.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
+            fd_info.memory = vk_surface->hMemory;
+            fd_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+            info->export_result = get_memory_fd(vk_device->hDevice, &fd_info, &fd);
+            if (info->export_result != VK_SUCCESS || fd < 0) {
+                *error = "exporting AMF Vulkan memory as an opaque fd failed";
+                status = -18;
+                goto cleanup;
+            }
+            memset(&memory_description, 0, sizeof(memory_description));
+            memory_description.type = hipExternalMemoryHandleTypeOpaqueFd;
+            memory_description.handle.fd = fd;
+            memory_description.size = (unsigned long long)vk_surface->iSize;
+            memory_description.flags = hipExternalMemoryDedicated;
+            info->hip_result = jasna_hip_import_memory(&external, &memory_description);
+            if (info->hip_result != hipSuccess || !external) {
+                *error = "importing the Vulkan allocation into HIP failed";
+                status = -19;
+                goto cleanup;
+            }
+            /*
+             * HIP retains its own reference after a successful import.  ROCm
+             * does not close the Vulkan-exported dma-buf descriptor for the
+             * caller, so close it now instead of leaking one fd per frame.
+             */
+            info->fd_close_calls += 1;
+            info->fd_close_result = close(fd);
+            if (info->fd_close_result != 0) {
+                info->fd_close_errno = errno;
+                fd = -1;
+                *error = "closing the imported Vulkan dma-buf fd failed";
+                status = -26;
+                goto cleanup;
+            }
+            fd = -1;
+            memset(&buffer_description, 0, sizeof(buffer_description));
+            buffer_description.size = (unsigned long long)vk_surface->iSize;
+            info->hip_result = jasna_hip_map_buffer(&mapped, external, &buffer_description);
+            if (info->hip_result != hipSuccess || !mapped) {
+                *error = "mapping the imported Vulkan allocation into HIP failed";
+                status = -20;
+                goto cleanup;
+            }
+        }
+        info->hip_result = jasna_hip_memcpy_2d(
+            (void *)destination, (size_t)row_bytes,
+            (const uint8_t *)mapped + layouts[0].offset,
+            (size_t)layouts[0].rowPitch, (size_t)row_bytes,
+            (size_t)visible_height, hipMemcpyDeviceToDevice
+        );
+        if (info->hip_result != hipSuccess) {
+            *error = "copying the AMF luma plane inside VRAM failed";
+            status = -21;
+            goto cleanup;
+        }
+        info->d2d_plane_copies += 1;
+        info->hip_result = jasna_hip_memcpy_2d(
+            (uint8_t *)destination + y_size, (size_t)row_bytes,
+            (const uint8_t *)mapped + layouts[1].offset,
+            (size_t)layouts[1].rowPitch, (size_t)row_bytes,
+            (size_t)(visible_height / 2), hipMemcpyDeviceToDevice
+        );
+        if (info->hip_result != hipSuccess) {
+            *error = "copying the AMF chroma plane inside VRAM failed";
+            status = -22;
+            goto cleanup;
+        }
+        info->d2d_plane_copies += 1;
+        /*
+         * The Python VideoFrame owns the last AMF surface reference.  Finish
+         * the null stream before returning so AMF cannot recycle the source
+         * while HIP still reads it.
+         */
+        info->hip_stream_synchronize_calls = 1;
+        info->hip_stream_synchronize_result = jasna_hip_stream_synchronize(NULL);
+        info->hip_result = info->hip_stream_synchronize_result;
+        if (info->hip_result != hipSuccess) {
+            *error = "synchronizing the AMF decode source-release stream failed";
+            status = -23;
+            goto cleanup;
+        }
+        info->width = visible_width;
+        info->height = visible_height;
+        info->bytes_per_sample = bytes_per_sample;
+        info->packed_size = packed_size;
+        info->source_y_pitch = layouts[0].rowPitch;
+        info->source_uv_pitch = layouts[1].rowPitch;
+        if (session) {
+            session->copy_calls += 1;
+        }
+        status = 0;
+
+    cleanup:
+        if (mapped && jasna_hip_free) {
+            info->hip_free_result = jasna_hip_free(mapped);
+            if (status == 0 && info->hip_free_result != hipSuccess) {
+                *error = "releasing the mapped HIP buffer failed";
+                status = -24;
+            }
+        }
+        if (external && jasna_hip_destroy_memory) {
+            info->hip_destroy_result = jasna_hip_destroy_memory(external);
+            if (status == 0 && info->hip_destroy_result != hipSuccess) {
+                *error = "destroying the HIP external-memory import failed";
+                status = -25;
+            }
+        }
+        if (fd >= 0) {
+            info->fd_close_calls += 1;
+            info->fd_close_result = close(fd);
+            if (info->fd_close_result != 0) {
+                info->fd_close_errno = errno;
+            }
+            /* Never retry close(): the descriptor number may be reused. */
+            fd = -1;
+        }
+        if (context1) {
+            context1->pVtbl->Release(context1);
+        }
+        return status;
+    }
+    """
+    ctypedef struct JasnaAmfCopyInfo:
+        int width
+        int height
+        int bytes_per_sample
+        unsigned long long packed_size
+        unsigned long long source_y_pitch
+        unsigned long long source_uv_pitch
+        int wait_result
+        int export_result
+        int fd_close_calls
+        int fd_close_result
+        int fd_close_errno
+        int hip_result
+        int hip_free_result
+        int hip_destroy_result
+        int hip_stream_synchronize_calls
+        int hip_stream_synchronize_result
+        int d2d_plane_copies
+        int fixed_context_bound
+
+    ctypedef struct JasnaAmfInteropSession:
+        pass
+
+    JasnaAmfInteropSession *jasna_session_create()
+    int jasna_session_close(JasnaAmfInteropSession *session, const char **error)
+    void jasna_session_destroy(JasnaAmfInteropSession *session)
+    int jasna_surface_info(
+        void *frame,
+        uintptr_t *surface_out,
+        uintptr_t *image_out,
+        uintptr_t *memory_out,
+        uint64_t *memory_size_out,
+        uintptr_t *frames_context_out,
+        uintptr_t *amf_context_out,
+        uintptr_t *vulkan_device_out,
+        int *memory_type_out,
+        int *surface_format_out,
+        const char **error,
+    )
+    int jasna_copy_to_hip(
+        void *frame,
+        uintptr_t destination,
+        unsigned long long destination_size,
+        int hip_device,
+        JasnaAmfInteropSession *session,
+        JasnaAmfCopyInfo *info,
+        const char **error,
+    )
+
+
+def _copy_result(JasnaAmfCopyInfo info):
+    return {
+        "width": info.width,
+        "height": info.height,
+        "bytes_per_sample": info.bytes_per_sample,
+        "packed_size": int(info.packed_size),
+        "source_y_pitch": int(info.source_y_pitch),
+        "source_uv_pitch": int(info.source_uv_pitch),
+        "wait_result": info.wait_result,
+        "export_result": info.export_result,
+        "vulkan_export_fd_close_calls": info.fd_close_calls,
+        "vulkan_export_fd_close_result": info.fd_close_result,
+        "vulkan_export_fd_close_errno": info.fd_close_errno,
+        "hip_result": info.hip_result,
+        "hip_free_result": info.hip_free_result,
+        "hip_destroy_result": info.hip_destroy_result,
+        "d2d_plane_copies": info.d2d_plane_copies,
+        "hip_non_d2d_copy_calls": 0,
+        "host_frame_transfers": 0,
+        "cpu_map_calls": 0,
+        "staging_copy_calls": 0,
+        "d2h_copy_calls": 0,
+        "av_hwframe_transfer_data_calls": 0,
+        "decode_source_release_hip_stream_synchronize_calls": (
+            info.hip_stream_synchronize_calls
+        ),
+        "decode_source_release_hip_stream_synchronize_result": (
+            info.hip_stream_synchronize_result
+        ),
+        "copy_synchronization": "null-stream-source-release",
+        "fixed_context_bound": bool(info.fixed_context_bound),
+    }
+
+
+def inspect_amf_surface(VideoFrame frame):
+    """Inspect an AMF Vulkan surface without mapping it to CPU or HIP."""
+
+    cdef uintptr_t surface = 0
+    cdef uintptr_t image = 0
+    cdef uintptr_t memory = 0
+    cdef uint64_t memory_size = 0
+    cdef uintptr_t frames_context = 0
+    cdef uintptr_t amf_context = 0
+    cdef uintptr_t vulkan_device = 0
+    cdef int memory_type = 0
+    cdef int surface_format = 0
+    cdef const char *error = NULL
+    cdef int status = jasna_surface_info(
+        <void *>frame.ptr,
+        &surface,
+        &image,
+        &memory,
+        &memory_size,
+        &frames_context,
+        &amf_context,
+        &vulkan_device,
+        &memory_type,
+        &surface_format,
+        &error,
+    )
+    if status != 0:
+        message = error.decode("utf-8", "replace") if error != NULL else "unknown error"
+        raise RuntimeError(f"AMF surface inspection failed ({status}): {message}")
+    return {
+        "surface": int(surface),
+        "memory_type_id": memory_type,
+        "memory_type": "vulkan",
+        "surface_format_id": surface_format,
+        "fixed_context": {
+            "frames_context": int(frames_context),
+            "amf_context": int(amf_context),
+            "vulkan_device": int(vulkan_device),
+        },
+        "vulkan": {
+            "image": int(image),
+            "memory": int(memory),
+            "memory_size": int(memory_size),
+        },
+    }
+
+
+def copy_amf_surface_to_hip(
+    VideoFrame frame,
+    uintptr_t destination,
+    unsigned long long destination_size,
+    int device=0,
+):
+    """Copy one native AMF Vulkan NV12/P010 frame directly into HIP memory."""
+
+    _transport_stats["copy_to_hip_calls"] += 1
+    cdef JasnaAmfCopyInfo info
+    cdef const char *error = NULL
+    cdef int status = jasna_copy_to_hip(
+        <void *>frame.ptr,
+        destination,
+        destination_size,
+        device,
+        NULL,
+        &info,
+        &error,
+    )
+    _transport_stats["vulkan_export_fd_close_calls"] += int(info.fd_close_calls)
+    _transport_stats["vulkan_export_fd_close_failures"] += int(
+        info.fd_close_result != 0 and info.fd_close_calls > 0
+    )
+    if info.fd_close_result != 0 and info.fd_close_calls > 0:
+        _transport_stats["last_vulkan_export_fd_close_errno"] = int(
+            info.fd_close_errno
+        )
+    if status != 0:
+        _transport_stats["copy_to_hip_failures"] += 1
+        message = error.decode("utf-8", "replace") if error != NULL else "unknown error"
+        raise RuntimeError(
+            f"AMF-to-HIP D2D copy failed ({status}, Vulkan wait {info.wait_result}, "
+            f"Vulkan export {info.export_result}, HIP {info.hip_result}): {message}"
+        )
+    _transport_stats["copy_to_hip_successes"] += 1
+    _transport_stats["vulkan_memory_exports"] += 1
+    _transport_stats["hip_external_memory_imports"] += 1
+    _transport_stats["hip_mapped_buffer_acquires"] += 1
+    _transport_stats["hip_mapped_buffer_releases"] += 1
+    _transport_stats["hip_external_memory_destroys"] += 1
+    _transport_stats["hip_d2d_plane_copies"] += int(info.d2d_plane_copies)
+    _transport_stats["decode_source_release_hip_stream_synchronize_calls"] += int(
+        info.hip_stream_synchronize_calls
+    )
+    return _copy_result(info)
+
+
+cdef class AmfVulkanHipInteropSession:
+    """One decode reader's fixed AMF/Vulkan/HIP identity, without a cache."""
+
+    cdef JasnaAmfInteropSession *_session
+    cdef bint _closed
+
+    def __cinit__(self, purpose):
+        if purpose != "decode":
+            raise ValueError("this core only supports a 'decode' interop session")
+        self._session = jasna_session_create()
+        if self._session == NULL:
+            raise MemoryError("creating the fixed-context AMF interop session failed")
+        self._closed = False
+        _transport_stats["fixed_context_session_create_calls"] += 1
+
+    def __dealloc__(self):
+        if self._session != NULL:
+            jasna_session_destroy(self._session)
+            self._session = NULL
+
+    @property
+    def purpose(self):
+        return "decode"
+
+    def close(self):
+        cdef const char *error = NULL
+        cdef int status
+        if self._session == NULL or self._closed:
+            return
+        status = jasna_session_close(self._session, &error)
+        _transport_stats["fixed_context_session_close_calls"] += 1
+        if status != 0:
+            _transport_stats["fixed_context_session_close_failures"] += 1
+            message = error.decode("utf-8", "replace") if error != NULL else "unknown error"
+            raise RuntimeError(
+                f"closing the fixed-context AMF interop session failed ({status}): {message}"
+            )
+        self._closed = True
+
+    def stats(self):
+        if self._session == NULL:
+            raise RuntimeError("fixed-context AMF interop session is unavailable")
+        # Cython may not read an opaque C struct safely; these lifetime fields
+        # are mirrored by the wrapper's explicit state, while copy identity is
+        # enforced in native code on every call.
+        return {
+            "purpose": "decode",
+            "resource_strategy": (
+                "per-frame Vulkan external-memory import/map with balanced release"
+            ),
+            "cache_entries": 0,
+            "cache_hits": 0,
+            "cache_misses": 0,
+            "close_calls": 1 if self._closed else 0,
+            "close_failures": 0,
+            "closed": bool(self._closed),
+        }
+
+    def copy_amf_surface_to_hip(
+        self,
+        VideoFrame frame,
+        uintptr_t destination,
+        unsigned long long destination_size,
+        int device=0,
+    ):
+        if self._session == NULL or self._closed:
+            raise RuntimeError("fixed-context AMF interop session is already closed")
+        _transport_stats["copy_to_hip_calls"] += 1
+        cdef JasnaAmfCopyInfo info
+        cdef const char *error = NULL
+        cdef int status = jasna_copy_to_hip(
+            <void *>frame.ptr,
+            destination,
+            destination_size,
+            device,
+            self._session,
+            &info,
+            &error,
+        )
+        _transport_stats["vulkan_export_fd_close_calls"] += int(
+            info.fd_close_calls
+        )
+        _transport_stats["vulkan_export_fd_close_failures"] += int(
+            info.fd_close_result != 0 and info.fd_close_calls > 0
+        )
+        if info.fd_close_result != 0 and info.fd_close_calls > 0:
+            _transport_stats["last_vulkan_export_fd_close_errno"] = int(
+                info.fd_close_errno
+            )
+        if status != 0:
+            _transport_stats["copy_to_hip_failures"] += 1
+            message = error.decode("utf-8", "replace") if error != NULL else "unknown error"
+            raise RuntimeError(
+                f"fixed-context AMF-to-HIP D2D copy failed ({status}, "
+                f"Vulkan wait {info.wait_result}, Vulkan export {info.export_result}, "
+                f"HIP {info.hip_result}): {message}"
+            )
+        _transport_stats["copy_to_hip_successes"] += 1
+        _transport_stats["vulkan_memory_exports"] += 1
+        _transport_stats["hip_external_memory_imports"] += 1
+        _transport_stats["hip_mapped_buffer_acquires"] += 1
+        _transport_stats["hip_mapped_buffer_releases"] += 1
+        _transport_stats["hip_external_memory_destroys"] += 1
+        _transport_stats["hip_d2d_plane_copies"] += int(info.d2d_plane_copies)
+        _transport_stats["decode_source_release_hip_stream_synchronize_calls"] += int(
+            info.hip_stream_synchronize_calls
+        )
+        return _copy_result(info)

--- a/scripts/build_amf_surface_probe.py
+++ b/scripts/build_amf_surface_probe.py
@@ -1,0 +1,71 @@
+"""Build the isolated AMF Vulkan-to-HIP bridge outside the source tree."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from Cython.Build import cythonize
+from setuptools import Distribution, Extension
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pyav-source", required=True)
+    parser.add_argument("--amf-include", required=True)
+    parser.add_argument("--ffmpeg-include", required=True)
+    parser.add_argument("--ffmpeg-lib", required=True)
+    parser.add_argument("--vulkan-include", required=True)
+    parser.add_argument("--rocm-include", required=True)
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    source = Path(__file__).with_name("amf_surface_probe.pyx").resolve()
+    pyav_source = Path(args.pyav_source).resolve()
+    output = Path(args.output_dir).resolve()
+    temporary = output / "build-temp"
+    output.mkdir(parents=True, exist_ok=True)
+    temporary.mkdir(parents=True, exist_ok=True)
+
+    extension = Extension(
+        "_jasna_amf_surface_probe",
+        [str(source)],
+        define_macros=[("__HIP_PLATFORM_AMD__", "1")],
+        include_dirs=[
+            str(Path(args.amf_include).resolve()),
+            str(Path(args.ffmpeg_include).resolve()),
+            str(Path(args.vulkan_include).resolve()),
+            str(Path(args.rocm_include).resolve()),
+        ],
+        library_dirs=[str(Path(args.ffmpeg_lib).resolve())],
+        libraries=["avcodec", "avutil"],
+        runtime_library_dirs=[str(Path(args.ffmpeg_lib).resolve())],
+    )
+    distribution = Distribution(
+        {
+            "name": "jasna-amf-interop-core",
+            "ext_modules": cythonize(
+                [extension],
+                compiler_directives={"language_level": "3"},
+                build_dir=str(temporary / "cython"),
+                include_path=[str(pyav_source / "include"), str(pyav_source)],
+            ),
+        }
+    )
+    command = distribution.get_command_obj("build_ext")
+    command.build_lib = str(output)
+    command.build_temp = str(temporary / "objects")
+    command.inplace = False
+    distribution.run_command("build_ext")
+
+    modules = sorted(output.glob("_jasna_amf_surface_probe*.so"))
+    if not modules:
+        modules = sorted(output.glob("_jasna_amf_surface_probe*.pyd"))
+    if not modules:
+        raise RuntimeError("AMF interop bridge build produced no extension module")
+    print(modules[-1])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_amf_interop_core.py
+++ b/tests/test_amf_interop_core.py
@@ -1,0 +1,554 @@
+"""Focused contracts for the explicit Linux AMD AMF interop core."""
+
+from __future__ import annotations
+
+import gc
+import weakref
+from fractions import Fraction
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from av.video.reformatter import Colorspace as AvColorspace, ColorRange as AvColorRange
+
+import jasna.media.video_decoder as module
+from jasna.accelerator import AcceleratorVendor
+from jasna.media import VideoMetadata
+
+
+def _metadata(
+    *,
+    codec: str = "h264",
+    profile: str = "high",
+    pixel_format: str = "nv12",
+    is_10bit: bool = False,
+) -> VideoMetadata:
+    return VideoMetadata(
+        video_file="input.mp4",
+        video_height=16,
+        video_width=16,
+        video_fps=30.0,
+        average_fps=30.0,
+        video_fps_exact=Fraction(30, 1),
+        codec_name=codec,
+        duration=1.0,
+        time_base=Fraction(1, 30),
+        start_pts=0,
+        color_range=AvColorRange.MPEG,
+        color_space=AvColorspace.ITU709,
+        num_frames=30,
+        is_10bit=is_10bit,
+        profile=profile,
+        pixel_format=pixel_format,
+    )
+
+
+def _reader(
+    metadata: VideoMetadata,
+    batch_size: int,
+    vendor: AcceleratorVendor = AcceleratorVendor.AMD,
+) -> module.NvidiaVideoReader:
+    reader = module.NvidiaVideoReader(
+        "input.mp4",
+        batch_size,
+        torch.device("cpu"),
+        metadata,
+    )
+    reader.vendor = vendor
+    return reader
+
+
+@pytest.fixture(autouse=True)
+def _clear_interop_env(monkeypatch):
+    monkeypatch.delenv(module.DECODE_BACKEND_ENV, raising=False)
+    monkeypatch.delenv(module.AMF_INTEROP_RESOURCE_CACHE_ENV, raising=False)
+
+
+def test_backend_enumeration_and_environment_override(monkeypatch) -> None:
+    assert "amf-interop" in module._DECODE_BACKENDS
+    monkeypatch.setenv(module.DECODE_BACKEND_ENV, "amf-interop")
+    assert module._decode_backend() == "amf-interop"
+
+
+@pytest.mark.parametrize(
+    ("codec", "profile", "pixel_format", "is_10bit"),
+    [
+        ("h264", "main", "nv12", False),
+        ("h264", "high", "nv12", False),
+        ("hevc", "main", "yuv420p", False),
+        ("hevc", "main 10", "p010le", True),
+    ],
+)
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8])
+def test_linux_amd_scope_accepts_only_supported_format_and_batch_matrix(
+    monkeypatch,
+    codec: str,
+    profile: str,
+    pixel_format: str,
+    is_10bit: bool,
+    batch_size: int,
+) -> None:
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    reader = _reader(
+        _metadata(
+            codec=codec,
+            profile=profile,
+            pixel_format=pixel_format,
+            is_10bit=is_10bit,
+        ),
+        batch_size,
+    )
+    reader._validate_amf_interop_scope()
+
+
+@pytest.mark.parametrize(
+    ("platform", "vendor", "metadata"),
+    [
+        ("win32", AcceleratorVendor.AMD, _metadata()),
+        ("linux", AcceleratorVendor.NVIDIA, _metadata()),
+        (
+            "linux",
+            AcceleratorVendor.AMD,
+            _metadata(codec="av1", profile="main", pixel_format="yuv420p"),
+        ),
+    ],
+)
+def test_windows_nvidia_and_av1_are_rejected(
+    monkeypatch,
+    platform: str,
+    vendor: AcceleratorVendor,
+    metadata: VideoMetadata,
+) -> None:
+    monkeypatch.setattr(module.sys, "platform", platform)
+    reader = _reader(metadata, 4, vendor)
+    with pytest.raises(module.VideoDecodeError, match="cannot satisfy"):
+        reader._validate_amf_interop_scope()
+
+
+@pytest.mark.parametrize("batch_size", [0, 3, 5, 16])
+def test_unapproved_batch_sizes_are_rejected(monkeypatch, batch_size: int) -> None:
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    reader = _reader(_metadata(), batch_size)
+    with pytest.raises(module.VideoDecodeError, match="batch_size"):
+        reader._validate_amf_interop_scope()
+
+
+def test_auto_never_selects_or_loads_amf_interop(monkeypatch) -> None:
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    monkeypatch.setattr(module, "current_stream", lambda _device: None)
+    monkeypatch.setattr(module, "vendor_for_device", lambda _device: AcceleratorVendor.AMD)
+    loader = MagicMock(side_effect=AssertionError("auto must not load bridge"))
+    monkeypatch.setattr(module, "_load_amf_interop_bridge", loader)
+    reader = module.NvidiaVideoReader("input.mp4", 4, torch.device("cpu"), _metadata())
+    pyav_open = MagicMock()
+    monkeypatch.setattr(reader, "_open_pyav", pyav_open)
+
+    reader.__enter__()
+
+    assert reader._decode_backend == "auto"
+    loader.assert_not_called()
+    pyav_open.assert_called_once_with(software_only=False)
+
+
+def test_missing_bridge_fails_closed(monkeypatch) -> None:
+    def missing(_name):
+        raise ImportError("no ABI-matched extension")
+
+    monkeypatch.setattr(module.importlib, "import_module", missing)
+    with pytest.raises(module.VideoDecodeError, match="ABI-matched"):
+        module._load_amf_interop_bridge()
+
+
+def test_bridge_missing_entrypoint_fails_closed(monkeypatch) -> None:
+    incomplete = SimpleNamespace(
+        inspect_amf_surface=lambda _frame: {},
+        copy_amf_surface_to_hip=lambda *_args: {},
+        get_transport_stats=lambda: {},
+        reset_transport_stats=lambda: None,
+    )
+    monkeypatch.setattr(module.importlib, "import_module", lambda _name: incomplete)
+    with pytest.raises(module.VideoDecodeError, match="AmfVulkanHipInteropSession"):
+        module._load_amf_interop_bridge()
+
+
+def test_resource_cache_defaults_off_and_true_is_explicit(monkeypatch) -> None:
+    assert module._amf_interop_resource_cache_enabled() is False
+    monkeypatch.setenv(module.AMF_INTEROP_RESOURCE_CACHE_ENV, "0")
+    assert module._amf_interop_resource_cache_enabled() is False
+    monkeypatch.setenv(module.AMF_INTEROP_RESOURCE_CACHE_ENV, "true")
+    assert module._amf_interop_resource_cache_enabled() is True
+
+
+def test_explicit_decoder_owns_amf_surfaces_and_tolerates_missing_timing(monkeypatch) -> None:
+    reader = _reader(
+        _metadata(codec="hevc", profile="main", pixel_format="yuv420p"),
+        1,
+    )
+    decoder = SimpleNamespace(options={}, open=MagicMock())
+    hwaccel = MagicMock()
+    monkeypatch.setattr(module, "HWAccel", hwaccel)
+    monkeypatch.setattr(
+        module.av,
+        "CodecContext",
+        SimpleNamespace(create=MagicMock(return_value=decoder)),
+    )
+    source = SimpleNamespace(
+        name="hevc_amf",
+        extradata=b"header",
+        width=16,
+        height=16,
+        framerate=None,
+        sample_aspect_ratio=None,
+        thread_type=None,
+    )
+
+    reader._setup_amf_decoder(source, fail_closed=True)
+
+    assert hwaccel.call_args.kwargs["is_hw_owned"] is True
+    assert module.av.CodecContext.create.call_args.args[:2] == ("hevc_amf", "r")
+    # Keep FFmpeg's -1 default so the fixed runtime derives its 36-surface AMF
+    # decode pool.  Overriding this with zero deadlocks when a B8 reader holds
+    # all eight AVHWFrames surfaces while requesting the next decoded frame.
+    assert "surface_pool_size" not in decoder.options
+    decoder.open.assert_called_once_with(strict=False)
+
+
+def test_explicit_cache_enable_fails_closed_before_loading_bridge(monkeypatch) -> None:
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    monkeypatch.setenv(module.AMF_INTEROP_RESOURCE_CACHE_ENV, "1")
+    loader = MagicMock(side_effect=AssertionError("cache must fail before load"))
+    monkeypatch.setattr(module, "_load_amf_interop_bridge", loader)
+    reader = _reader(_metadata(), 1)
+
+    with pytest.raises(module.VideoDecodeError, match="not implemented"):
+        reader._open_amf_interop_backend()
+    loader.assert_not_called()
+
+
+def test_uploader_rejects_non_native_amf_frame_before_copy(monkeypatch) -> None:
+    metadata = _metadata()
+    copy = MagicMock()
+    uploader = module.AmfInteropUploader(
+        file="input.mp4",
+        batch_size=1,
+        device=torch.device("cpu"),
+        metadata=metadata,
+        height=16,
+        width=16,
+        full_range=False,
+        audit=SimpleNamespace(copy_to_hip=copy),
+    )
+    monkeypatch.setattr(module, "YuvToRgbConverter", MagicMock())
+    frame = SimpleNamespace(
+        format=SimpleNamespace(name="cuda"),
+        sw_format=SimpleNamespace(name="nv12"),
+        width=16,
+        height=16,
+        pts=0,
+    )
+
+    with pytest.raises(module.VideoDecodeError, match="native AMF Vulkan"):
+        list(uploader.frames(iter(()), [frame]))
+    copy.assert_not_called()
+
+
+def test_uploader_releases_old_amf_surfaces_before_reading_next_group(monkeypatch) -> None:
+    class _TrackedAmfFrame:
+        format = SimpleNamespace(name="amf")
+        sw_format = SimpleNamespace(name="nv12")
+        width = 16
+        height = 16
+
+        def __init__(self, pts: int, released: list[int]) -> None:
+            self.pts = pts
+            self._released = released
+
+        def __del__(self) -> None:
+            self._released.append(self.pts)
+
+    class _Stream:
+        def __init__(self) -> None:
+            self.synchronize_calls = 0
+
+        def synchronize(self) -> None:
+            self.synchronize_calls += 1
+
+    class _NextGroup:
+        def __init__(self, prior_frame, stream: _Stream, released: list[int]) -> None:
+            self._prior_frame = prior_frame
+            self._stream = stream
+            self._released = released
+            self._calls = 0
+
+        @property
+        def calls(self) -> int:
+            return self._calls
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self._calls += 1
+            if self._calls == 1:
+                assert self._stream.synchronize_calls == 1
+                gc.collect()
+                assert self._prior_frame() is None
+                assert self._released == [0]
+                return _TrackedAmfFrame(1, self._released)
+            raise StopIteration
+
+    def _initial_group(released: list[int]):
+        frame = _TrackedAmfFrame(0, released)
+        return [frame], weakref.ref(frame)
+
+    released: list[int] = []
+    group, first_frame = _initial_group(released)
+    stream = _Stream()
+    decoded = _NextGroup(first_frame, stream, released)
+    uploader = module.AmfInteropUploader(
+        file="input.mp4",
+        batch_size=1,
+        device=torch.device("cpu"),
+        metadata=_metadata(),
+        height=16,
+        width=16,
+        full_range=False,
+        audit=SimpleNamespace(copy_to_hip=lambda *_args: _safe_copy_result()),
+    )
+    monkeypatch.setattr(module, "current_stream", lambda _device: stream)
+    monkeypatch.setattr(module, "YuvToRgbConverter", MagicMock())
+
+    batches = uploader.frames(iter(decoded), group)
+    del group
+    batch, pts = next(batches)
+    assert batch.shape == (1, 3, 16, 16)
+    assert pts == [0]
+    assert first_frame() is None
+    assert released == [0]
+    assert decoded.calls == 0
+    del batch
+    batch, pts = next(batches)
+    assert batch.shape == (1, 3, 16, 16)
+    assert pts == [1]
+    assert decoded.calls == 1
+    batches.close()
+
+
+class _IdentitySession:
+    def __init__(self, *, close_error: BaseException | None = None) -> None:
+        self.closed = False
+        self.close_error = close_error
+
+    def close(self) -> None:
+        if self.close_error is not None:
+            raise self.close_error
+        self.closed = True
+
+    def stats(self) -> dict[str, object]:
+        return {
+            "cache_entries": 0,
+            "closed": self.closed,
+        }
+
+
+def _safe_inspection(*, device: int = 41, frames_context: int = 11) -> dict[str, object]:
+    return {
+        "memory_type": "vulkan",
+        "vulkan": {"memory": 31, "device": device},
+        "fixed_context": {
+            "frames_context": frames_context,
+            "amf_context": 21,
+            "vulkan_device": device,
+        },
+    }
+
+
+def _safe_copy_result(**overrides) -> dict[str, object]:
+    result: dict[str, object] = {
+        "width": 16,
+        "height": 16,
+        "bytes_per_sample": 1,
+        "vulkan_export_fd_close_calls": 1,
+        "vulkan_export_fd_close_result": 0,
+        "vulkan_export_fd_close_errno": 0,
+        "hip_result": 0,
+        "hip_free_result": 0,
+        "hip_destroy_result": 0,
+        "d2d_plane_copies": 2,
+        "decode_source_release_hip_stream_synchronize_calls": 1,
+        "decode_source_release_hip_stream_synchronize_result": 0,
+        "copy_synchronization": "null-stream-source-release",
+        "fixed_context_bound": True,
+    }
+    result.update(overrides)
+    return result
+
+
+def _audit(*, inspect=None, copy=None, session=None, process_stats=None):
+    return module._AmfInteropTransportAudit(
+        inspect_amf_surface=inspect or (lambda _frame: _safe_inspection()),
+        copy_amf_surface_to_hip=copy or (lambda *_args: _safe_copy_result()),
+        get_transport_stats=process_stats or (lambda: {}),
+        identity_session=session or _IdentitySession(),
+        device=torch.device("cpu"),
+    )
+
+
+def test_explicit_open_fails_closed_when_session_copy_is_missing(monkeypatch) -> None:
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    session = _IdentitySession()
+    bridge = SimpleNamespace(
+        inspect_amf_surface=lambda _frame: _safe_inspection(),
+        copy_amf_surface_to_hip=lambda *_args: _safe_copy_result(),
+        get_transport_stats=lambda: {},
+        AmfVulkanHipInteropSession=lambda _purpose: session,
+    )
+    reader = _reader(_metadata(), 1)
+    pyav_open = MagicMock()
+    monkeypatch.setattr(module, "_load_amf_interop_bridge", lambda: bridge)
+    monkeypatch.setattr(reader, "_open_pyav", pyav_open)
+
+    with pytest.raises(module.VideoDecodeError, match="copy_amf_surface_to_hip"):
+        reader._open_amf_interop_backend()
+
+    assert session.closed is True
+    pyav_open.assert_not_called()
+
+
+def test_explicit_open_uses_session_bound_copy_not_top_level_bridge(monkeypatch) -> None:
+    class _SessionWithBoundCopy(_IdentitySession):
+        def __init__(self) -> None:
+            super().__init__()
+            self.copy_calls = []
+
+        def copy_amf_surface_to_hip(self, *args):
+            self.copy_calls.append(args)
+            return _safe_copy_result()
+
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    session = _SessionWithBoundCopy()
+    top_level_copy = MagicMock(side_effect=AssertionError("top-level copy used"))
+    bridge = SimpleNamespace(
+        inspect_amf_surface=lambda _frame: _safe_inspection(),
+        copy_amf_surface_to_hip=top_level_copy,
+        get_transport_stats=lambda: {},
+        AmfVulkanHipInteropSession=lambda _purpose: session,
+    )
+    reader = _reader(_metadata(), 1)
+    pyav_open = MagicMock()
+    monkeypatch.setattr(module, "_load_amf_interop_bridge", lambda: bridge)
+    monkeypatch.setattr(reader, "_open_pyav", pyav_open)
+
+    reader._open_amf_interop_backend()
+    audit = reader._amf_interop_audit
+    assert audit is not None
+    frame = object()
+    audit.copy_to_hip(frame, 123, 456)
+    reader._close_amf_interop_backend()
+
+    pyav_open.assert_called_once_with(software_only=False, amf_interop=True)
+    assert session.copy_calls == [(frame, 123, 456, 0)]
+    top_level_copy.assert_not_called()
+    assert session.closed is True
+
+
+@pytest.mark.parametrize(
+    "counter",
+    [
+        "host_frame_transfers",
+        "cpu_map_calls",
+        "staging_copy_calls",
+        "d2h_copy_calls",
+        "hip_non_d2d_copy_calls",
+        "av_hwframe_transfer_data_calls",
+        "failed_bridge_copies",
+    ],
+)
+def test_transport_audit_rejects_host_or_non_d2d_counters(counter: str) -> None:
+    audit = _audit(copy=lambda *_args: _safe_copy_result(**{counter: 1}))
+    with pytest.raises(module.VideoDecodeError, match="non-native transport"):
+        audit.copy_to_hip(object(), 1, 128)
+    assert audit.snapshot()["copy_to_hip_failures"] == 1
+
+
+def test_transport_audit_rejects_bridge_failed_copy() -> None:
+    audit = _audit(copy=lambda *_args: _safe_copy_result(hip_result=700))
+    with pytest.raises(module.VideoDecodeError, match="did not prove"):
+        audit.copy_to_hip(object(), 1, 128)
+    assert audit.snapshot()["copy_to_hip_failures"] == 1
+
+
+@pytest.mark.parametrize(
+    "fd_telemetry",
+    [
+        {"vulkan_export_fd_close_calls": 0},
+        {
+            "vulkan_export_fd_close_result": -1,
+            "vulkan_export_fd_close_errno": 5,
+        },
+    ],
+)
+def test_transport_audit_rejects_unbalanced_vulkan_export_fd(
+    fd_telemetry: dict[str, int],
+) -> None:
+    audit = _audit(
+        copy=lambda *_args: _safe_copy_result(**fd_telemetry)
+    )
+    with pytest.raises(module.VideoDecodeError, match="did not prove"):
+        audit.copy_to_hip(object(), 1, 128)
+    assert audit.snapshot()["copy_to_hip_failures"] == 1
+
+
+def test_transport_audit_rejects_copy_without_fixed_context_binding() -> None:
+    audit = _audit(copy=lambda *_args: _safe_copy_result(fixed_context_bound=False))
+    with pytest.raises(module.VideoDecodeError, match="did not prove"):
+        audit.copy_to_hip(object(), 1, 128)
+    assert audit.snapshot()["copy_to_hip_failures"] == 1
+
+
+def test_transport_audit_rejects_failed_copy_counter_from_bridge() -> None:
+    audit = _audit(process_stats=lambda: {"failed_bridge_copies": 1})
+    with pytest.raises(module.VideoDecodeError, match="non-native transport"):
+        audit.copy_to_hip(object(), 1, 128)
+    assert audit.snapshot()["copy_to_hip_failures"] == 1
+
+
+def test_transport_audit_rejects_fixed_context_change() -> None:
+    inspections = iter([_safe_inspection(device=41), _safe_inspection(device=42)])
+    audit = _audit(inspect=lambda _frame: next(inspections))
+    audit.copy_to_hip(object(), 1, 128)
+    with pytest.raises(module.VideoDecodeError, match="identity changed"):
+        audit.copy_to_hip(object(), 2, 128)
+
+
+@pytest.mark.parametrize("field", ["frames_context", "amf_context", "vulkan_device"])
+def test_transport_audit_rejects_null_fixed_context_identity(field: str) -> None:
+    inspection = _safe_inspection()
+    inspection["fixed_context"][field] = 0
+    audit = _audit(inspect=lambda _frame: inspection)
+    with pytest.raises(module.VideoDecodeError, match="non-null AMF context"):
+        audit.copy_to_hip(object(), 1, 128)
+
+
+def test_transport_audit_balances_create_close_and_per_frame_resources() -> None:
+    session = _IdentitySession()
+    audit = _audit(session=session)
+    audit.copy_to_hip(object(), 1, 128)
+    audit.copy_to_hip(object(), 2, 128)
+    audit.close()
+    stats = audit.validate_closed()
+
+    assert session.closed is True
+    assert stats["fixed_context_session_create_calls"] == 1
+    assert stats["fixed_context_session_close_calls"] == 1
+    assert stats["vulkan_memory_exports"] == 2
+    assert stats["hip_external_memory_destroys"] == 2
+    assert stats["hip_d2d_plane_copies"] == 4
+
+
+def test_transport_audit_does_not_swallow_session_close_failure() -> None:
+    audit = _audit(session=_IdentitySession(close_error=RuntimeError("native close failed")))
+    with pytest.raises(RuntimeError, match="native close failed"):
+        audit.close()
+    assert audit.snapshot()["fixed_context_session_close_failures"] == 1


### PR DESCRIPTION
## Summary

- add an explicit Linux AMD `amf-interop` research backend for H.264/HEVC
- enforce Vulkan external-memory to HIP GPU-only transport and balanced native ownership
- close every Vulkan-exported dma-buf FD explicitly after successful HIP import, because ROCm 7.2.1 does not close it for the caller
- expose bridge/session FD-close telemetry and fail closed on host Map, staging, D2H, close failure, or incomplete cleanup
- keep resource cache disabled and unimplemented by default

This is an independent root PR based directly on `main`. `auto` never selects this backend; it is enabled only by an explicit backend request.

## Validation

- AMF core suite: `52 passed`
- Broader focused backend/decoder/AMD/seek suite: `80 passed, 1 skipped`
- Native extension rebuilt against the accepted PyAV/FFmpeg/AMF/Vulkan/ROCm inputs; SHA-256 `cca94e491116c5dd0deac9351c0290ba0827fcf625a832b24abfb20f79590031`
- Real 8192x4096 HEVC Main10, B4, 1400-frame decode-only regression passed beyond the former approximately 999-export failure point
- 1400 export/import/map/release/destroy/FD-close calls balanced; close failures and last errno were zero
- `/proc/self/fd` sampled every 100 frames: total FDs stayed at 9 and dma-buf FDs stayed at 0; process returned to 6/0 after close
- PTS strictly increased; peak junction 66 C, peak VRAM 11,172,016,128 bytes; no GPU reset, ring timeout, page fault, OOM, or residual probe process
- Python compile, Cython/native build, `git diff --check`, one-commit, and forbidden rocDecode/fallback scans passed

## Scope

This PR does not add AV1, event pooling, auto-selection, scan routing, dma-buf caching, final rocDecode removal, or any CPU fallback. Existing `auto`, PyAV, VALI, Windows, and NVIDIA behavior stays unchanged.

## Follow-up PRs that depend on this PR

- **Linux AMF bridge packaging** — builds and installs the ABI-matched native extension into the unified runtime; it also depends on runtime contract PR #370, the runtime installer, and the unified build-pipeline PR.
- **Native AMF AV1 interop** — extends the explicit interop backend to validated AV1 surfaces.
- **AMF event pool** — adds deferred native decode/copy lifetime handling and event reuse.
- **Unified AMD auto-decode selection** — promotes only the validated native routes into `auto` without changing shared NVIDIA logic.
- **Mosaic scan unified AMD route** — moves scan/decode consumers onto the proven product route.
- **AV1 dma-buf cache** and **AMF cache-FD lifecycle** — add cache ownership and descriptor-lifetime guarantees after the core/event contracts land.
- **Final rocDecode removal** — removes the legacy route only after the replacement chain passes Linux and Windows acceptance.

No temporary rocDecode fallback is included or planned for upstream submission.