### PR TITLE
fix(amd): restore Windows decode correctness routes

### DIFF
--- a/docs/WINDOWS_AMD_CORRECTNESS_CN.md
+++ b/docs/WINDOWS_AMD_CORRECTNESS_CN.md
@@ -1,0 +1,103 @@
+# Windows AMD 解码正确性后端
+
+## 目的与边界
+
+本候选只重建 Windows AMD 的既有正确性解码策略，不引入 Linux 原生
+AMF 路由、NVIDIA 改动、GUI 改动或新的产品默认值。它保留
+`JASNA_DECODE_BACKEND=auto` 的既有选择顺序，只在 Windows、AMD 和下表指定的
+输入交集上作出明确选择。
+
+| 条件 | `auto` 解码/上传路线 | PyAV 线程设置 |
+| --- | --- | --- |
+| Windows AMD H.264 8-bit | AMF host frame → 既有 ROCm 上传 | 既有 AMF 设置 |
+| Windows AMD HEVC 8-bit | AMF host frame → 既有 ROCm 上传 | 既有 AMF 设置 |
+| Windows AMD HEVC Main10/P010 | FFmpeg/PyAV 软件解码 → P010 规范化/上传 ROCm | `thread_count=1`，`thread_type="SLICE"` |
+| Windows AMD AV1 8-bit / Main10 | FFmpeg/PyAV 软件解码 → NV12/P010 规范化/上传 ROCm | `thread_type="AUTO"` |
+
+这里的“软件解码”只限解码阶段：`_frames_software()` 仍将已规范化的 NV12/P010
+帧批量上传至 Torch 的 ROCm 设备内存，并在 GPU 上执行共享的 YUV→RGB 转换；它不是
+返回 CPU tensor 的降级路线。
+
+H.264 10-bit、其他 codec/profile，以及非 Windows AMD 平台不匹配这项策略，继续走
+当前分支原有的路径。
+
+## 选择与失败语义
+
+- 仅 `auto` 自动应用 HEVC Main10/AV1 的 Windows AMD 软件解码策略。它会记录一条
+  明确 warning，说明原因及“上传到 ROCm”。
+- `JASNA_DECODE_BACKEND=pyav-hw` 保留为诊断入口，故意绕过这项自动策略，仍尝试既有
+  AMF 设置；这不等同于把问题格式提升为已验证的 Windows AMF 路线。
+- 显式 `pyav-sw` 仍会强制软件解码；其中 Windows AMD HEVC Main10 同样使用单线程
+  slice 限制，避免绕过已知的线程稳定性约束。
+- 受控软件路线无法打开或读取时，错误直接作为 `VideoDecodeError` 交给调用者，不会
+  悄悄继续为 CPU-only 输出。
+- H.264/HEVC 8-bit 的既有 AMF 打开失败会沿既有逻辑记录硬件失败 warning，并进入已有的
+  软件解码加 GPU 上传路径；本候选没有把这种失败吞掉或替换为未记录的 fallback。
+
+## 实现来源
+
+实现仅重建下列历史提交中与 Windows 解码相关的窄逻辑，而不是恢复旧文件或
+cherry-pick 整个提交：
+
+- `fc10db2`：Windows AMD HEVC Main10/P010 自动软件解码上传；
+- `f8d4a3d`：Windows AMD AV1 自动软件解码上传；
+- `892801a`：Windows AMD HEVC Main10 的单线程 slice 限制。
+
+当前实现入口在 `jasna/media/video_decoder.py` 的
+`_requires_windows_amd_software_decode()` 和
+`_requires_single_slice_pyav_threads()`。二者均先检查 `sys.platform == "win32"`
+及 AMD vendor，因此不会改变 Linux、NVIDIA 或其他平台的选择。
+
+## 当前验证范围与 Windows 验收
+
+本独立 PR 的 Linux 重放工作区只能运行 mock/structural 测试：它验证平台/vendor/codec
+选择、AMF 是否被跳过、线程设置和显式 `pyav-hw` 隔离。相同的保留逻辑此前已随 Windows
+集成提交 `de2143dace5b2b134859422e6ab6bc4071518a72` 在固定 PyAV 18.1.0、
+PyTorch ROCm 7.2.1 环境完成真机验收；这里将两类证据分开记录，避免把 Linux mock 结果
+误写成 Windows 实机执行。
+
+本次重建在 Linux 上执行：
+
+```bash
+/home/latiao/vr_toolbox_jasna_linux/.venv/bin/python -m pytest -q \
+  tests/test_video_decoder_backends.py tests/test_video_decoder_amd_path.py
+```
+
+结果为 `37 passed, 1 skipped`；`compileall`（变更的 decoder 与测试）和
+`git diff --check` 也通过。该结果只证明上述结构契约，不能替代下列 Windows 真机矩阵。
+
+Windows 真机验收结果（`auto`、B4、严格 FFmpeg 解码、源/PTS hash、GPU tensor 和资源
+关闭检查）如下：
+
+| 样本 | 结果与路线 |
+| --- | --- |
+| H.264 Main/High 8-bit NV12 | 120/120；AMF host；ROCm GPU tensor；PASS |
+| HEVC Main 8-bit NV12 | 120/120；AMF host；ROCm GPU tensor；PASS |
+| HEVC Main10 P010 | 120/120；软件解码后 ROCm 上传；严格 PTS；PASS |
+| AV1 Main10 P010 | 60/60；软件解码后 ROCm 上传；严格 PTS；PASS |
+
+全部用例均无 CPU-only 输出、无 fallback 列表、无残留进程/partial/tmp，运行窗口内未发现
+TDR、Display 4101/4107、AMF/ROCm、OOM、访问违规或 fail-fast。该结果证明的是上述集成
+提交；本 PR 后续若修改这些 helper 或线程策略，仍须重新做 Windows 回归。
+
+复验前先使用固定 runtime 预检：
+
+```powershell
+cd D:\AI\jasna_windows_amd_dev
+.\scripts\run_jasna_unified_windows.ps1 -PreflightOnly
+```
+
+随后以 `JASNA_DECODE_BACKEND=auto` 分别用短真实素材运行产品入口，并记录输入、输出、
+首个 decoder/frame format、日志、帧数、严格递增 PTS、时长、输出 bit depth 与关闭/取消
+结果。最少需要覆盖：
+
+| 样本 | 预期路线 | 必查项 |
+| --- | --- | --- |
+| H.264 Main/High 8-bit NV12 | AMF host | 帧数/PTS、GPU tensor、关闭 |
+| HEVC Main 8-bit NV12 | AMF host | 帧数/PTS、GPU tensor、关闭 |
+| HEVC Main10 P010 | 受控软件上传 | 单线程 slice、P010、帧数/PTS、关闭 |
+| AV1 Main 8-bit | 受控软件上传 | NV12、帧数/PTS、关闭 |
+| AV1 Main10 P010 | 受控软件上传 | P010、帧数/PTS、关闭 |
+
+每个输出还必须用独立 FFmpeg/FFprobe 做严格解码、时长和帧数检查；错误、短输出、PTS
+不连续、CPU tensor、AMF/FFmpeg native failure 或关闭异常均为阻断项。

--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -27,7 +27,8 @@ _libcuda: ctypes.CDLL | None = None
 # Decode backend selection (`JASNA_DECODE_BACKEND` overrides the default):
 # - "auto":    NVIDIA tries VALI first and falls back to PyAV hwaccel, then PyAV
 #              software, when VALI cannot open or decode the first frame. AMD
-#              keeps its AMF -> software escalation.
+#              keeps its AMF -> software escalation. Windows AMD explicitly
+#              uses software decode plus ROCm upload for HEVC Main10 and AV1.
 # - "vali":    VALI only; any failure raises (NVIDIA only).
 # - "pyav-hw": skip VALI, use the PyAV hwaccel path with its software fallback.
 # - "pyav-sw": force FFmpeg software decoding with GPU upload on every vendor.
@@ -45,6 +46,42 @@ _NVDEC_MIN_CODED_SIZE = {"av1": (128, 128)}
 
 class VideoDecodeError(RuntimeError):
     pass
+
+
+def _requires_windows_amd_software_decode(
+    metadata: VideoMetadata,
+    vendor: AcceleratorVendor,
+) -> bool:
+    """Return whether Windows AMD auto mode must bypass PyAV AMF.
+
+    AMF host frames are the established route for H.264 and 8-bit HEVC.  On
+    Windows, PyAV cannot reliably transfer HEVC Main10/P010 AMF frames, and
+    AV1 AMF is unreliable across frame transfer and shutdown.  The selected
+    software path still normalizes and uploads YUV frames to ROCm; it is not a
+    CPU-only output fallback.  Explicit ``pyav-hw`` remains a diagnostic AMF
+    entry point and intentionally bypasses this auto-only policy.
+    """
+
+    if sys.platform != "win32" or vendor is not AcceleratorVendor.AMD:
+        return False
+    codec_name = str(metadata.codec_name).casefold()
+    return codec_name == "av1" or (
+        codec_name == "hevc" and bool(metadata.is_10bit)
+    )
+
+
+def _requires_single_slice_pyav_threads(
+    metadata: VideoMetadata,
+    vendor: AcceleratorVendor,
+) -> bool:
+    """Limit the known Windows AMD HEVC Main10 software decoder to one slice."""
+
+    return (
+        sys.platform == "win32"
+        and vendor is AcceleratorVendor.AMD
+        and str(metadata.codec_name).casefold() == "hevc"
+        and bool(metadata.is_10bit)
+    )
 
 
 def _decode_backend() -> str:
@@ -286,7 +323,30 @@ class NvidiaVideoReader:
                     return self
             elif backend == "vali":
                 raise VideoDecodeError("The VALI decode backend requires an NVIDIA device")
-        software_only = backend == "pyav-sw"
+        windows_amd_software_decode = (
+            backend == "auto"
+            and _requires_windows_amd_software_decode(
+                self.metadata,
+                self.vendor,
+            )
+        )
+        software_only = backend == "pyav-sw" or windows_amd_software_decode
+        if windows_amd_software_decode:
+            codec_name = str(self.metadata.codec_name).casefold()
+            if codec_name == "av1":
+                log.warning(
+                    "Windows AMD AV1 PyAV AMF decoding is unreliable across frame "
+                    "transfer and shutdown; using FFmpeg software decoding and "
+                    "uploading frames to ROCm for %s",
+                    self.file,
+                )
+            else:
+                log.warning(
+                    "Windows AMD HEVC Main10/P010 cannot transfer PyAV AMF hardware "
+                    "frames; using FFmpeg software decoding and uploading frames to "
+                    "ROCm for %s",
+                    self.file,
+                )
         self._software_only = software_only
         try:
             if not software_only and self.vendor is AcceleratorVendor.NVIDIA:
@@ -309,7 +369,11 @@ class NvidiaVideoReader:
 
         ctx = self.video_stream.codec_context
         if software_only:
-            ctx.thread_type = "AUTO"
+            if _requires_single_slice_pyav_threads(self.metadata, self.vendor):
+                ctx.thread_count = 1
+                ctx.thread_type = "SLICE"
+            else:
+                ctx.thread_type = "AUTO"
         elif self.vendor is AcceleratorVendor.AMD:
             self._setup_amf_decoder(ctx)
         elif not ctx.is_hwaccel:

--- a/tests/test_video_decoder_backends.py
+++ b/tests/test_video_decoder_backends.py
@@ -22,7 +22,7 @@ def _clear_decode_backend_env(monkeypatch) -> None:
     monkeypatch.delenv(module.DECODE_BACKEND_ENV, raising=False)
 
 
-def _metadata() -> VideoMetadata:
+def _metadata(codec_name: str = "h264", is_10bit: bool = False) -> VideoMetadata:
     return VideoMetadata(
         video_file="input.mp4",
         video_height=16,
@@ -30,31 +30,41 @@ def _metadata() -> VideoMetadata:
         video_fps=30.0,
         average_fps=30.0,
         video_fps_exact=Fraction(30, 1),
-        codec_name="h264",
+        codec_name=codec_name,
         duration=1.0,
         time_base=Fraction(1, 30),
         start_pts=0,
         color_range=AvColorRange.MPEG,
         color_space=AvColorspace.ITU709,
         num_frames=30,
-        is_10bit=False,
+        is_10bit=is_10bit,
     )
 
 
-def _reader(monkeypatch, vendor: AcceleratorVendor) -> module.NvidiaVideoReader:
+def _reader(
+    monkeypatch,
+    vendor: AcceleratorVendor,
+    metadata: VideoMetadata | None = None,
+) -> module.NvidiaVideoReader:
     monkeypatch.setattr(module, "vendor_for_device", lambda _device: vendor)
     monkeypatch.setattr(module, "current_stream", lambda _device: None)
-    return module.NvidiaVideoReader("input.mp4", 4, torch.device("cuda:0"), _metadata())
+    return module.NvidiaVideoReader(
+        "input.mp4",
+        4,
+        torch.device("cuda:0"),
+        metadata or _metadata(),
+    )
 
 
-def _fake_container(is_hwaccel: bool) -> MagicMock:
+def _fake_container(is_hwaccel: bool, codec_name: str = "h264") -> MagicMock:
     ctx = SimpleNamespace(
         is_hwaccel=is_hwaccel,
         width=16,
         height=16,
         color_range=0,
+        thread_count=0,
         thread_type=None,
-        name="h264",
+        name=codec_name,
     )
     container = MagicMock()
     container.streams.video = [SimpleNamespace(codec_context=ctx)]
@@ -121,6 +131,120 @@ def test_auto_backend_skips_vali_on_amd(monkeypatch) -> None:
     amf_setup.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    ("codec_name", "is_10bit", "log_marker", "thread_count", "thread_type"),
+    [
+        ("hevc", True, "HEVC Main10/P010", 1, "SLICE"),
+        ("av1", False, "AV1 PyAV AMF", 0, "AUTO"),
+        ("av1", True, "AV1 PyAV AMF", 0, "AUTO"),
+    ],
+)
+def test_auto_windows_amd_problem_formats_use_controlled_software_decode(
+    monkeypatch,
+    caplog,
+    codec_name: str,
+    is_10bit: bool,
+    log_marker: str,
+    thread_count: int,
+    thread_type: str,
+) -> None:
+    monkeypatch.setattr(module, "DECODE_BACKEND", "auto")
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    container = _fake_container(False, codec_name)
+    monkeypatch.setattr(module.av, "open", MagicMock(return_value=container))
+    reader = _reader(
+        monkeypatch,
+        AcceleratorVendor.AMD,
+        _metadata(codec_name, is_10bit),
+    )
+    amf_setup = MagicMock()
+    monkeypatch.setattr(reader, "_setup_amf_decoder", amf_setup)
+
+    with caplog.at_level("WARNING"):
+        reader.__enter__()
+
+    amf_setup.assert_not_called()
+    assert reader._software_only is True
+    assert module.av.open.call_args.kwargs == {}
+    context = container.streams.video[0].codec_context
+    assert context.thread_count == thread_count
+    assert context.thread_type == thread_type
+    assert log_marker in caplog.text
+    assert "ROCm" in caplog.text
+
+
+@pytest.mark.parametrize("codec_name", ("h264", "hevc"))
+def test_auto_windows_amd_8bit_formats_keep_amf_host_route(
+    monkeypatch,
+    codec_name: str,
+) -> None:
+    monkeypatch.setattr(module, "DECODE_BACKEND", "auto")
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    container = _fake_container(False, codec_name)
+    monkeypatch.setattr(module.av, "open", MagicMock(return_value=container))
+    reader = _reader(
+        monkeypatch,
+        AcceleratorVendor.AMD,
+        _metadata(codec_name, is_10bit=False),
+    )
+    amf_setup = MagicMock()
+    monkeypatch.setattr(reader, "_setup_amf_decoder", amf_setup)
+
+    reader.__enter__()
+
+    amf_setup.assert_called_once_with(container.streams.video[0].codec_context)
+    assert reader._software_only is False
+
+
+@pytest.mark.parametrize(
+    ("platform", "vendor", "codec_name", "is_10bit"),
+    [
+        ("linux", AcceleratorVendor.AMD, "hevc", True),
+        ("darwin", AcceleratorVendor.AMD, "av1", True),
+        ("win32", AcceleratorVendor.NVIDIA, "hevc", True),
+    ],
+)
+def test_windows_amd_software_policy_does_not_match_other_routes(
+    monkeypatch,
+    platform: str,
+    vendor: AcceleratorVendor,
+    codec_name: str,
+    is_10bit: bool,
+) -> None:
+    monkeypatch.setattr(module.sys, "platform", platform)
+    assert not module._requires_windows_amd_software_decode(
+        _metadata(codec_name, is_10bit),
+        vendor,
+    )
+
+
+@pytest.mark.parametrize(
+    ("codec_name", "is_10bit"),
+    (("hevc", True), ("av1", False), ("av1", True)),
+)
+def test_explicit_pyav_hw_bypasses_windows_amd_software_policy(
+    monkeypatch,
+    codec_name: str,
+    is_10bit: bool,
+) -> None:
+    monkeypatch.setattr(module, "DECODE_BACKEND", "pyav-hw")
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    container = _fake_container(False, codec_name)
+    monkeypatch.setattr(module.av, "open", MagicMock(return_value=container))
+    reader = _reader(
+        monkeypatch,
+        AcceleratorVendor.AMD,
+        _metadata(codec_name, is_10bit),
+    )
+    amf_setup = MagicMock()
+    monkeypatch.setattr(reader, "_setup_amf_decoder", amf_setup)
+
+    reader.__enter__()
+
+    amf_setup.assert_called_once_with(container.streams.video[0].codec_context)
+    assert reader._software_only is False
+
+
 def test_pyav_sw_backend_skips_hwaccel_and_amf(monkeypatch) -> None:
     monkeypatch.setattr(module, "DECODE_BACKEND", "pyav-sw")
     vali_factory = MagicMock()
@@ -139,6 +263,42 @@ def test_pyav_sw_backend_skips_hwaccel_and_amf(monkeypatch) -> None:
         nvdec_setup.assert_not_called()
         assert module.av.open.call_args.kwargs == {}
         assert container.streams.video[0].codec_context.thread_type == "AUTO"
+
+
+@pytest.mark.parametrize(
+    ("platform", "vendor", "codec_name", "is_10bit", "thread_count", "thread_type"),
+    [
+        ("win32", AcceleratorVendor.AMD, "hevc", True, 1, "SLICE"),
+        ("win32", AcceleratorVendor.AMD, "hevc", False, 0, "AUTO"),
+        ("win32", AcceleratorVendor.AMD, "av1", True, 0, "AUTO"),
+        ("win32", AcceleratorVendor.NVIDIA, "hevc", True, 0, "AUTO"),
+        ("linux", AcceleratorVendor.AMD, "hevc", True, 0, "AUTO"),
+    ],
+)
+def test_pyav_sw_limits_only_windows_amd_hevc_main10_threads(
+    monkeypatch,
+    platform: str,
+    vendor: AcceleratorVendor,
+    codec_name: str,
+    is_10bit: bool,
+    thread_count: int,
+    thread_type: str,
+) -> None:
+    monkeypatch.setattr(module, "DECODE_BACKEND", "pyav-sw")
+    monkeypatch.setattr(module.sys, "platform", platform)
+    container = _fake_container(False, codec_name)
+    monkeypatch.setattr(module.av, "open", MagicMock(return_value=container))
+    reader = _reader(
+        monkeypatch,
+        vendor,
+        _metadata(codec_name, is_10bit),
+    )
+
+    reader.__enter__()
+
+    context = container.streams.video[0].codec_context
+    assert context.thread_count == thread_count
+    assert context.thread_type == thread_type
 
 
 def test_unknown_backend_raises(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- preserve Windows AMD AMF for H.264 and 8-bit HEVC
- route Windows AMD HEVC Main10/P010 and AV1 through software decode followed by the existing ROCm GPU upload in `auto`
- retain explicit `pyav-hw` as a diagnostic AMF request
- constrain Windows AMD HEVC Main10 software decode to single-slice threading

This is an independent root PR based directly on `main`.

## Validation

- Main acceptance: `/home/latiao/vr_toolbox_jasna_linux/.venv/bin/python -m pytest -q tests/test_video_decoder_backends.py tests/test_video_decoder_amd_path.py` → `37 passed, 1 skipped`
- Exactly one commit above upstream `main`; compile and `git diff --check` passed
- The same retained logic passed prior Windows ROCm real-media acceptance: H.264 120/120 and HEVC 8-bit 120/120 via AMF host; HEVC Main10 120/120 and AV1 Main10 60/60 via software decode plus ROCm upload; strict PTS/hash/FFmpeg checks, GPU tensors, balanced closure, and no TDR/OOM/native failure

## Scope

This PR does not add Linux AMF interop, alter NVIDIA behavior, restore rocDecode, or silently produce CPU-only tensors. Explicit decoder failures remain visible.

## Follow-up PRs that depend on this PR

- **Final rocDecode removal** — removes the legacy decoder only after this Windows correctness policy and the separate Linux AMF replacement chain are both present and accepted.
- **Windows AMD decode regression matrix** — keeps the H.264/HEVC8/HEVC10/AV1 real-media route, PTS, format, GPU-tensor, and shutdown checks attached to the final integrated product set.

This PR is independent of the Smart Render timestamp/seam root.
