### PR TITLE
fix(media): preserve Smart Render timestamps and seams

### DIFF
--- a/docs/SMART_RENDER_TIMESTAMP_SEAM_CN.md
+++ b/docs/SMART_RENDER_TIMESTAMP_SEAM_CN.md
@@ -1,0 +1,37 @@
+# Smart Render 时间戳与 HEVC seam 收口
+
+更新时间：2026-08-29
+
+本阶段在现有 PyAV 媒体链上收口局部处理后的直接装配、精确 PTS 和 HEVC 拼接安全性，
+不改变检测、Tracker、修复、阈值或产品 B4 默认值。
+
+## 实现边界
+
+- 最终 mux 直接读取 fragment concat manifest，并从原片复制兼容的音频、字幕、章节、
+  metadata、attachment 与视频 disposition，不再先生成一份中间 assembled video。
+- secondary reader 按 `FrameMeta.pts` 读取原帧。若 decoder 偶发偏移，先丢弃有限数量的
+  旧帧，再以相同产品 decode backend 最多重开两次；仍不一致就明确失败，不转入隐藏的
+  `pyav-sw`/CPU fallback。
+- keyframe probe 记录最后 packet tail 与源关键帧 decode delay；仅对没有自身 B-frame
+  重排的 render fragment 补回 DTS delay，避免复制段和重编码段的 PTS/DTS 语义分裂。
+- 本候选不改变既有的 encoder bit-depth 或 VUI/fps 选择；只收口 fragment 的时间戳、
+  装配与 HEVC seam 验证。
+- HEVC 拼接前逐 RAP 比较 VPS/SPS/PPS。共享 parameter-set ID 内容变化时 fail-closed；
+  装配后只在 render seam 两侧各取一个有界 copy GOP，比较帧 hash、duration、size 和
+  归一化 PTS。
+- framemd5 比较允许 seek 边界最多一帧差异和一个恒定的亚帧 PTS origin 偏移，但不允许
+  内部 hash 改变或时间轴漂移。
+
+## 验收
+
+- `tests/test_splice.py`：packet tail/decode delay、fragment timestamp、HEVC parameter-set
+  顺序、非零 stream start、copy window 归一化。
+- `tests/test_splice_media.py`：H.264 decode-delay 实片、HEVC hvcC/Annex-B parameter-set、
+  collision fail-closed、copy seam hash。
+- `tests/test_pipeline_segments.py`：HEVC gate 与 seam 两侧有界 GOP。
+- `tests/test_pipeline_threads.py`：精确 PTS、相同 backend 重开、取消和无 CPU fallback。
+- Linux 聚焦回归：149 passed、1 skipped。
+
+手动选择的 Smart Render 范围遇到 seam 不兼容时保持显式失败。当前 GUI 没有可靠保存
+“范围由粗扫自动生成”的来源标记，因此本阶段不把失败静默改成 full render；后续只有在
+来源标记成为持久合同后才可对真正 automatic ranges 增加显式回退。

--- a/jasna/media/splice.py
+++ b/jasna/media/splice.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import bisect
+import hashlib
 import logging
 import os
 import subprocess
@@ -45,6 +46,16 @@ class SmartRenderCompatibilityError(ValueError):
 
 
 @dataclass(frozen=True)
+class HevcParameterSet:
+    """Canonical identity for one HEVC VPS, SPS, or PPS NAL unit."""
+
+    nal_type: int
+    parameter_set_id: int
+    referenced_id: int | None
+    sha256: str
+
+
+@dataclass(frozen=True)
 class KeyframeIndex:
     pts: tuple[int, ...]
     time_base: Fraction
@@ -52,6 +63,7 @@ class KeyframeIndex:
     end_pts: int
     max_b_frames: int = 0
     uses_b_references: bool = False
+    decode_delay_pts: int = 0
 
     def seconds_for_pts(self, pts: int) -> float:
         return float((int(pts) - self.start_pts) * self.time_base)
@@ -86,7 +98,7 @@ def _canonical_codec(name: str) -> str:
         return "hevc"
     if value in {"avc", "h.264"}:
         return "h264"
-    if value == "av01":
+    if value in {"av01", "libdav1d"}:
         return "av1"
     return value
 
@@ -246,9 +258,23 @@ def resolve_smart_encoder_settings(
     return resolved
 
 
+def _nominal_frame_duration_pts(metadata: VideoMetadata, time_base: Fraction) -> int:
+    """Return one frame duration in stream timestamp units when packets omit it."""
+
+    try:
+        return max(
+            1,
+            round(1 / (float(metadata.video_fps) * float(time_base))),
+        )
+    except (TypeError, ValueError, ZeroDivisionError, OverflowError):
+        return 1
+
+
 def probe_keyframes(path: str | Path, metadata: VideoMetadata) -> KeyframeIndex:
     keyframes: list[int] = []
     packet_pts: list[int] = []
+    packet_end_pts: int | None = None
+    decode_delay_pts = 0
     with av.open(str(path)) as container:
         stream = container.streams.video[0]
         codec = _canonical_codec(metadata.codec_name)
@@ -262,10 +288,18 @@ def probe_keyframes(path: str | Path, metadata: VideoMetadata) -> KeyframeIndex:
             length_size = (extradata[21] & 0x03) + 1
         time_base = Fraction(stream.time_base)
         start_pts = resolve_video_start_pts(stream.start_time, metadata.start_pts)
+        nominal_frame_duration = _nominal_frame_duration_pts(metadata, time_base)
         for packet in container.demux(stream):
             if packet.pts is not None:
-                packet_pts.append(int(packet.pts))
-            if (
+                pts = int(packet.pts)
+                packet_pts.append(pts)
+                packet_duration = int(packet.duration or 0)
+                packet_end = pts + (
+                    packet_duration if packet_duration > 0 else nominal_frame_duration
+                )
+                if packet_end_pts is None or packet_end > packet_end_pts:
+                    packet_end_pts = packet_end
+            is_safe_keyframe = (
                 packet.pts is not None
                 and packet.is_keyframe
                 and _is_safe_random_access_packet(
@@ -274,8 +308,14 @@ def probe_keyframes(path: str | Path, metadata: VideoMetadata) -> KeyframeIndex:
                     length_size,
                     length_prefixed=length_prefixed,
                 )
-            ):
+            )
+            if is_safe_keyframe:
                 keyframes.append(int(packet.pts))
+                if packet.dts is not None:
+                    decode_delay_pts = max(
+                        decode_delay_pts,
+                        int(packet.pts) - int(packet.dts),
+                    )
         stream_duration = stream.duration
 
     if not keyframes:
@@ -285,8 +325,10 @@ def probe_keyframes(path: str | Path, metadata: VideoMetadata) -> KeyframeIndex:
         end_pts = start_pts + int(stream_duration)
     else:
         end_pts = start_pts + round(float(metadata.duration) / time_base)
+    if packet_end_pts is not None:
+        end_pts = max(end_pts, packet_end_pts)
     if end_pts <= keyframes[-1]:
-        end_pts = keyframes[-1] + max(1, round(1 / (metadata.video_fps * time_base)))
+        end_pts = keyframes[-1] + nominal_frame_duration
     max_b_frames, uses_b_references = _analyze_packet_reordering(packet_pts)
     return KeyframeIndex(
         tuple(keyframes),
@@ -295,16 +337,16 @@ def probe_keyframes(path: str | Path, metadata: VideoMetadata) -> KeyframeIndex:
         int(end_pts),
         max_b_frames=max_b_frames,
         uses_b_references=uses_b_references,
+        decode_delay_pts=decode_delay_pts,
     )
 
 
-def _nal_unit_types(
+def _split_nal_units(
     data: bytes,
     *,
-    codec: str,
     length_size: int,
     length_prefixed: bool,
-) -> tuple[int, ...]:
+) -> tuple[bytes, ...]:
     units: list[bytes] = []
     if not length_prefixed:
         starts: list[tuple[int, int]] = []
@@ -331,9 +373,278 @@ def _nal_unit_types(
                 break
             units.append(data[offset:offset + size])
             offset += size
+    return tuple(units)
+
+
+def _nal_unit_types(
+    data: bytes,
+    *,
+    codec: str,
+    length_size: int,
+    length_prefixed: bool,
+) -> tuple[int, ...]:
+    units = _split_nal_units(
+        data,
+        length_size=length_size,
+        length_prefixed=length_prefixed,
+    )
     if codec == "h264":
         return tuple(unit[0] & 0x1F for unit in units if unit)
     return tuple((unit[0] >> 1) & 0x3F for unit in units if unit)
+
+
+class _BitReader:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._offset = 0
+
+    def read_bits(self, count: int) -> int:
+        if count < 0 or self._offset + count > len(self._data) * 8:
+            raise ValueError("truncated HEVC parameter set")
+        value = 0
+        for _ in range(count):
+            byte = self._data[self._offset // 8]
+            value = (value << 1) | ((byte >> (7 - self._offset % 8)) & 1)
+            self._offset += 1
+        return value
+
+    def read_ue(self) -> int:
+        leading_zeroes = 0
+        while self.read_bits(1) == 0:
+            leading_zeroes += 1
+            if leading_zeroes > 31:
+                raise ValueError("invalid HEVC Exp-Golomb value")
+        if not leading_zeroes:
+            return 0
+        return (1 << leading_zeroes) - 1 + self.read_bits(leading_zeroes)
+
+
+def _hevc_rbsp(nal: bytes) -> bytes:
+    payload = nal[2:]
+    rbsp = bytearray()
+    zeroes = 0
+    for value in payload:
+        if zeroes >= 2 and value == 0x03:
+            zeroes = 0
+            continue
+        rbsp.append(value)
+        zeroes = zeroes + 1 if value == 0 else 0
+    return bytes(rbsp)
+
+
+def _skip_hevc_profile_tier_level(reader: _BitReader, max_sub_layers: int) -> None:
+    # general_profile_tier_level (88 bits) + general_level_idc (8 bits)
+    reader.read_bits(96)
+    sub_layer_profile_present = [reader.read_bits(1) for _ in range(max_sub_layers)]
+    sub_layer_level_present = [reader.read_bits(1) for _ in range(max_sub_layers)]
+    if max_sub_layers:
+        reader.read_bits(2 * (8 - max_sub_layers))
+    for profile_present, level_present in zip(
+        sub_layer_profile_present,
+        sub_layer_level_present,
+    ):
+        if profile_present:
+            reader.read_bits(88)
+        if level_present:
+            reader.read_bits(8)
+
+
+def _parse_hevc_parameter_set(nal: bytes) -> HevcParameterSet | None:
+    if len(nal) < 3:
+        return None
+    nal_type = (nal[0] >> 1) & 0x3F
+    if nal_type not in {32, 33, 34}:
+        return None
+    reader = _BitReader(_hevc_rbsp(nal))
+    if nal_type == 32:
+        parameter_set_id = reader.read_bits(4)
+        referenced_id = None
+    elif nal_type == 33:
+        referenced_id = reader.read_bits(4)
+        max_sub_layers = reader.read_bits(3)
+        reader.read_bits(1)
+        _skip_hevc_profile_tier_level(reader, max_sub_layers)
+        parameter_set_id = reader.read_ue()
+    else:
+        parameter_set_id = reader.read_ue()
+        referenced_id = reader.read_ue()
+    canonical_nal = nal.rstrip(b"\x00")[:2] + _hevc_rbsp(nal.rstrip(b"\x00"))
+    return HevcParameterSet(
+        nal_type=nal_type,
+        parameter_set_id=parameter_set_id,
+        referenced_id=referenced_id,
+        sha256=hashlib.sha256(canonical_nal).hexdigest(),
+    )
+
+
+def _hevc_configuration_nals(extradata: bytes) -> tuple[bytes, ...]:
+    if len(extradata) <= 22 or extradata[0] != 1:
+        return _split_nal_units(
+            extradata,
+            length_size=4,
+            length_prefixed=False,
+        )
+    units: list[bytes] = []
+    offset = 23
+    for _ in range(extradata[22]):
+        if offset + 3 > len(extradata):
+            raise ValueError("truncated hvcC parameter-set array")
+        offset += 1
+        count = int.from_bytes(extradata[offset:offset + 2], "big")
+        offset += 2
+        for _ in range(count):
+            if offset + 2 > len(extradata):
+                raise ValueError("truncated hvcC NAL length")
+            size = int.from_bytes(extradata[offset:offset + 2], "big")
+            offset += 2
+            if size <= 0 or offset + size > len(extradata):
+                raise ValueError("truncated hvcC NAL payload")
+            units.append(extradata[offset:offset + size])
+            offset += size
+    return tuple(units)
+
+
+def _parameter_sets_from_nals(units: tuple[bytes, ...]) -> tuple[HevcParameterSet, ...]:
+    parameter_sets: list[HevcParameterSet] = []
+    seen: set[HevcParameterSet] = set()
+    for nal in units:
+        try:
+            parameter_set = _parse_hevc_parameter_set(nal)
+        except ValueError:
+            continue
+        if parameter_set is not None and parameter_set not in seen:
+            seen.add(parameter_set)
+            parameter_sets.append(parameter_set)
+    return tuple(parameter_sets)
+
+
+def _probe_hevc_parameter_set_sequences(
+    path: str | Path,
+) -> tuple[tuple[HevcParameterSet, ...], ...]:
+    """Preserve the VPS/SPS/PPS sequence at every random-access packet."""
+
+    sequences: list[tuple[HevcParameterSet, ...]] = []
+    with av.open(str(path)) as container:
+        stream = container.streams.video[0]
+        extradata = bytes(stream.codec_context.extradata or b"")
+        configuration = _parameter_sets_from_nals(_hevc_configuration_nals(extradata))
+        length_prefixed = len(extradata) > 21 and extradata[0] == 1
+        length_size = (extradata[21] & 0x03) + 1 if length_prefixed else 4
+        pending: list[HevcParameterSet] = []
+        for packet in container.demux(stream):
+            if packet.size <= 0:
+                continue
+            packet_parameter_sets = _parameter_sets_from_nals(
+                _split_nal_units(
+                    bytes(packet),
+                    length_size=length_size,
+                    length_prefixed=length_prefixed,
+                )
+            )
+            if not packet.is_keyframe:
+                pending.extend(packet_parameter_sets)
+                continue
+            combined = tuple(dict.fromkeys([*pending, *packet_parameter_sets]))
+            pending.clear()
+            sequences.append(combined or configuration)
+    if not sequences and configuration:
+        sequences.append(configuration)
+    return tuple(sequences)
+
+
+def probe_hevc_parameter_sets(path: str | Path) -> tuple[HevcParameterSet, ...]:
+    """Read unique hvcC/CodecPrivate and in-band VPS/SPS/PPS identities."""
+
+    return tuple(
+        dict.fromkeys(
+            parameter_set
+            for sequence in _probe_hevc_parameter_set_sequences(path)
+            for parameter_set in sequence
+        )
+    )
+
+
+def _hevc_parameter_set_map(
+    parameter_sets: tuple[HevcParameterSet, ...],
+) -> dict[tuple[int, int], set[str]]:
+    signature: dict[tuple[int, int], set[str]] = {}
+    for parameter_set in parameter_sets:
+        key = (parameter_set.nal_type, parameter_set.parameter_set_id)
+        signature.setdefault(key, set()).add(parameter_set.sha256)
+    return signature
+
+
+def validate_hevc_fragment_parameter_sets(
+    fragments: list[tuple[Path, str]],
+) -> None:
+    """Reject shared HEVC IDs that change across or inside a rendered seam."""
+
+    fragment_roles: set[str] = set()
+    sequences: list[tuple[tuple[HevcParameterSet, ...], ...]] = []
+    for path, role in fragments:
+        if role not in {"copy", "render"}:
+            raise ValueError(f"unknown smart-render fragment role: {role}")
+        fragment_roles.add(role)
+        try:
+            fragment_sequences = _probe_hevc_parameter_set_sequences(path)
+        except (OSError, ValueError, av.FFmpegError) as exc:
+            raise SmartRenderCompatibilityError(
+                f"Could not inspect HEVC parameter sets in {path.name}: {exc}",
+                reason="hevc_parameter_sets_unavailable",
+            ) from exc
+        sequences.append(fragment_sequences)
+    if fragment_roles != {"copy", "render"}:
+        return
+    for fragment_index, fragment_sequences in enumerate(sequences):
+        for sequence in fragment_sequences:
+            nal_types = {parameter_set.nal_type for parameter_set in sequence}
+            if {32, 33, 34}.issubset(nal_types):
+                continue
+            raise SmartRenderCompatibilityError(
+                "Could not identify complete HEVC VPS/SPS/PPS headers in "
+                f"fragment {fragment_index}",
+                reason="hevc_parameter_sets_unavailable",
+            )
+        if not fragment_sequences:
+            raise SmartRenderCompatibilityError(
+                f"Could not identify HEVC random-access headers in fragment {fragment_index}",
+                reason="hevc_parameter_sets_unavailable",
+            )
+
+    for fragment_index, ((_path, role), render_sequences) in enumerate(
+        zip(fragments, sequences)
+    ):
+        if role != "render":
+            continue
+        references: list[tuple[HevcParameterSet, ...]] = []
+        if fragment_index > 0 and fragments[fragment_index - 1][1] == "copy":
+            references.append(sequences[fragment_index - 1][-1])
+        if (
+            fragment_index + 1 < len(fragments)
+            and fragments[fragment_index + 1][1] == "copy"
+        ):
+            references.append(sequences[fragment_index + 1][0])
+        for render_sequence_index, render_sequence in enumerate(render_sequences):
+            render_map = _hevc_parameter_set_map(render_sequence)
+            for reference in references:
+                reference_map = _hevc_parameter_set_map(reference)
+                collisions = sorted(
+                    key
+                    for key in reference_map.keys() & render_map.keys()
+                    if reference_map[key] != render_map[key]
+                )
+                if not collisions:
+                    continue
+                details = ", ".join(
+                    f"NAL {nal_type} ID {parameter_set_id}"
+                    for nal_type, parameter_set_id in collisions
+                )
+                raise SmartRenderCompatibilityError(
+                    "HEVC copied and rendered spans redefine shared parameter-set "
+                    f"IDs in fragment {fragment_index} RAP {render_sequence_index} "
+                    f"({details})",
+                    reason="hevc_parameter_sets_incompatible",
+                )
 
 
 def _is_safe_random_access_packet(
@@ -483,14 +794,52 @@ def _codec_name(path: Path) -> str:
         return container.streams.video[0].codec_context.codec.canonical_name
 
 
-def normalize_fragment(source: Path, destination: Path, *, codec: str) -> None:
+def _fragment_pts_are_reordered(path: Path) -> bool:
+    packet_pts: list[int] = []
+    with av.open(str(path)) as container:
+        stream = container.streams.video[0]
+        for packet in container.demux(stream):
+            if packet.pts is not None:
+                packet_pts.append(int(packet.pts))
+    max_b_frames, _ = _analyze_packet_reordering(packet_pts)
+    return max_b_frames > 0
+
+
+def _normalization_parameters(codec: str) -> tuple[str, str, list[str]]:
     bitstream_filter = {
         "h264": "h264_mp4toannexb,dump_extra=freq=keyframe",
         "hevc": "hevc_mp4toannexb,dump_extra=freq=keyframe",
         "av1": "av1_metadata=td=insert,dump_extra=freq=keyframe",
     }[codec]
     muxer = "mpegts" if codec in {"h264", "hevc"} else "matroska"
-    container_args = ["-muxdelay", "0"] if muxer == "mpegts" else ["-avoid_negative_ts", "make_zero"]
+    container_args = (
+        ["-muxdelay", "0"]
+        if muxer == "mpegts"
+        else ["-avoid_negative_ts", "make_zero"]
+    )
+    return bitstream_filter, muxer, container_args
+
+
+def normalize_fragment(
+    source: Path,
+    destination: Path,
+    *,
+    codec: str,
+    decode_delay: Fraction = Fraction(0, 1),
+) -> None:
+    bitstream_filter, muxer, container_args = _normalization_parameters(codec)
+    timestamp_args: list[str] = []
+    if decode_delay > 0 and not _fragment_pts_are_reordered(source):
+        with av.open(str(source)) as container:
+            time_base = Fraction(container.streams.video[0].time_base)
+        delay_ticks = round(Fraction(decode_delay) / time_base)
+        bitstream_filter += f",setts=pts=PTS:dts=PTS-{delay_ticks}"
+        timestamp_args = [
+            "-output_ts_offset", _seconds(float(decode_delay)),
+            "-avoid_negative_ts", "disabled",
+        ]
+        if muxer == "matroska":
+            container_args = []
     _run_ffmpeg(
         [
             "-i", str(source),
@@ -499,6 +848,7 @@ def normalize_fragment(source: Path, destination: Path, *, codec: str) -> None:
             "-c:v", "copy",
             "-bsf:v", bitstream_filter,
             *container_args,
+            *timestamp_args,
             "-f", muxer,
             str(destination),
         ],
@@ -510,6 +860,17 @@ def _quote_concat_path(path: Path) -> str:
     return str(path.resolve()).replace("'", "'\\''")
 
 
+def _write_concat_manifest(
+    fragments: list[tuple[Path, float]],
+    manifest: Path,
+) -> None:
+    lines = ["ffconcat version 1.0"]
+    for path, duration in fragments:
+        lines.append(f"file '{_quote_concat_path(path)}'")
+        lines.append(f"duration {_seconds(duration)}")
+    manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def concatenate_fragments(
     fragments: list[tuple[Path, float]],
     *,
@@ -517,11 +878,7 @@ def concatenate_fragments(
     destination: Path,
     codec: str,
 ) -> None:
-    lines = ["ffconcat version 1.0"]
-    for path, duration in fragments:
-        lines.append(f"file '{_quote_concat_path(path)}'")
-        lines.append(f"duration {_seconds(duration)}")
-    manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    _write_concat_manifest(fragments, manifest)
     muxer = "mpegts" if codec in {"h264", "hevc"} else "matroska"
     muxer_args = ["-muxdelay", "0"] if muxer == "mpegts" else []
     _run_ffmpeg(
@@ -540,6 +897,18 @@ def concatenate_fragments(
     )
 
 
+def _ffmpeg_disposition(disposition) -> str:
+    """Serialize PyAV disposition flags for FFmpeg's stream option."""
+
+    value = int(disposition)
+    flags = [
+        name
+        for name, member in av.stream.Disposition.__members__.items()
+        if value & int(member)
+    ]
+    return "+".join(flags) if flags else "0"
+
+
 def mux_final_output(
     video: Path,
     source: Path,
@@ -548,6 +917,207 @@ def mux_final_output(
     codec: str,
 ) -> None:
     temporary = destination.with_name(f".{destination.stem}.smart-render{destination.suffix}")
+    args = _final_mux_args(
+        ["-i", str(video), "-i", str(source)],
+        source,
+        destination,
+        codec=codec,
+        source_input_index=1,
+    )
+    args.append(str(temporary))
+    try:
+        _run_ffmpeg(args, purpose=f"mux smart-render output {destination.name}")
+        os.replace(temporary, destination)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            log.warning("Could not remove temporary output %s", temporary)
+
+
+def mux_fragments_final_output(
+    fragments: list[tuple[Path, float]],
+    source: Path,
+    destination: Path,
+    *,
+    manifest: Path,
+    codec: str,
+    copy_validation_ranges: tuple[tuple[float, float], ...] = (),
+) -> None:
+    """Concatenate video fragments while preserving compatible source streams."""
+    _write_concat_manifest(fragments, manifest)
+    temporary = destination.with_name(f".{destination.stem}.smart-render{destination.suffix}")
+    args = _final_mux_args(
+        [
+            "-f", "concat",
+            "-safe", "0",
+            "-i", str(manifest),
+            "-i", str(source),
+        ],
+        source,
+        destination,
+        codec=codec,
+        source_input_index=1,
+    )
+    args.append(str(temporary))
+    try:
+        _run_ffmpeg(args, purpose=f"assemble smart-render output {destination.name}")
+        if _canonical_codec(codec) == "hevc" and copy_validation_ranges:
+            validate_hevc_copy_seams(
+                temporary,
+                source,
+                copy_validation_ranges,
+            )
+        os.replace(temporary, destination)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            log.warning("Could not remove temporary output %s", temporary)
+
+
+def _decoded_frame_hashes(
+    path: Path,
+    *,
+    start: float,
+    duration: float,
+) -> tuple[tuple[Fraction, Fraction, int, str], ...]:
+    with av.open(str(path)) as container:
+        stream = container.streams.video[0]
+        stream_start = (
+            Fraction(int(stream.start_time)) * Fraction(stream.time_base)
+            if stream.start_time is not None and stream.time_base is not None
+            else Fraction(0, 1)
+        )
+    absolute_start = float(stream_start) + start
+    command = [
+        resolve_executable("ffmpeg"),
+        "-hide_banner",
+        "-loglevel", "error",
+        "-copyts",
+        "-ss", _seconds(absolute_start),
+        "-i", str(path),
+        "-to", _seconds(absolute_start + duration),
+        "-map", "0:v:0",
+        "-an",
+        "-fps_mode", "passthrough",
+        "-f", "framemd5",
+        "-",
+    ]
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+        **subprocess_no_window_kwargs(),
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "unknown ffmpeg error").strip()
+        raise SmartRenderCompatibilityError(
+            f"Could not decode an HEVC copy seam: {detail}",
+            reason="hevc_copy_seam_decode_failed",
+        )
+    time_base = Fraction(1, 1)
+    frames: list[tuple[Fraction, Fraction, int, str]] = []
+    for line in completed.stdout.splitlines():
+        if line.startswith("#tb 0:"):
+            time_base = Fraction(line.split(":", 1)[1].strip())
+            continue
+        if not line or line.startswith("#"):
+            continue
+        fields = [field.strip() for field in line.split(",")]
+        if len(fields) < 6:
+            continue
+        frames.append(
+            (
+                int(fields[2]) * time_base - stream_start,
+                int(fields[3]) * time_base,
+                int(fields[4]),
+                fields[5],
+            )
+        )
+    if not frames:
+        raise SmartRenderCompatibilityError(
+            "HEVC copy seam produced no decoded frames",
+            reason="hevc_copy_seam_decode_failed",
+        )
+    return tuple(frames)
+
+
+def _hevc_copy_windows_match(
+    source_frames: tuple[tuple[Fraction, Fraction, int, str], ...],
+    output_frames: tuple[tuple[Fraction, Fraction, int, str], ...],
+) -> bool:
+    """Match copied content while tolerating one seek-boundary frame and PTS origin."""
+
+    if (
+        not source_frames
+        or not output_frames
+        or abs(len(source_frames) - len(output_frames)) > 1
+    ):
+        return False
+    minimum_match = min(len(source_frames), len(output_frames)) - 1
+    for source_offset, output_offset in ((0, 0), (1, 0), (0, 1)):
+        maximum_match = min(
+            len(source_frames) - source_offset,
+            len(output_frames) - output_offset,
+        )
+        for count in dict.fromkeys((maximum_match, max(1, minimum_match))):
+            unmatched = len(source_frames) + len(output_frames) - (2 * count)
+            if count > maximum_match or unmatched > 2:
+                continue
+            source_window = source_frames[source_offset : source_offset + count]
+            output_window = output_frames[output_offset : output_offset + count]
+            if [frame[1:] for frame in source_window] != [
+                frame[1:] for frame in output_window
+            ]:
+                continue
+            pts_offsets = [
+                output_frame[0] - source_frame[0]
+                for source_frame, output_frame in zip(source_window, output_window)
+            ]
+            max_frame_duration = max(
+                max(frame[1] for frame in source_window),
+                max(frame[1] for frame in output_window),
+            )
+            jitter_tolerance = max(Fraction(1, 1000), max_frame_duration / 20)
+            if (
+                abs(pts_offsets[0]) <= max_frame_duration
+                and max(pts_offsets) - min(pts_offsets) <= jitter_tolerance
+            ):
+                return True
+    return False
+
+
+def validate_hevc_copy_seams(
+    output: Path,
+    source: Path,
+    ranges: tuple[tuple[float, float], ...],
+) -> None:
+    """Compare bounded, timestamp-aligned decoded windows on untouched seams."""
+
+    for start, duration in ranges:
+        if duration <= 0:
+            continue
+        source_frames = _decoded_frame_hashes(source, start=start, duration=duration)
+        output_frames = _decoded_frame_hashes(output, start=start, duration=duration)
+        if not _hevc_copy_windows_match(source_frames, output_frames):
+            raise SmartRenderCompatibilityError(
+                "HEVC decoded pixels or timestamps differ in an untouched copy "
+                f"span at {start:.6f}s",
+                reason="hevc_copy_seam_mismatch",
+            )
+
+
+def _final_mux_args(
+    video_input_args: list[str],
+    source: Path,
+    destination: Path,
+    *,
+    codec: str,
+    source_input_index: int,
+) -> list[str]:
+    """Build final Smart Render mux arguments without losing side streams."""
     output_format = {
         ".mkv": "matroska",
         ".mov": "mov",
@@ -556,13 +1126,11 @@ def mux_final_output(
     with av.open(BytesIO(), "w", format=output_format) as probe:
         supported_codecs = probe.supported_codecs
 
-    args = [
-        "-i", str(video),
-        "-i", str(source),
-        "-map", "0:v:0",
-    ]
+    args = [*video_input_args, "-map", "0:v:0"]
     with av.open(str(source)) as container:
-        primary_video_index = container.streams.video[0].index
+        primary_video = container.streams.video[0]
+        primary_video_index = primary_video.index
+        primary_video_disposition = _ffmpeg_disposition(primary_video.disposition)
         copied_streams = []
         transcoded_subtitles = {}
         source_formats = set(container.format.name.split(","))
@@ -624,18 +1192,19 @@ def mux_final_output(
             )
 
         for stream in copied_streams:
-            args += ["-map", f"1:{stream.index}"]
+            args += ["-map", f"{source_input_index}:{stream.index}"]
 
         args += [
-            "-map_metadata", "1",
-            "-map_metadata:s:v:0", "1:s:v:0",
-            "-map_chapters", "1",
+            "-map_metadata", str(source_input_index),
+            "-map_metadata:s:v:0", f"{source_input_index}:s:v:0",
+            "-map_chapters", str(source_input_index),
             "-c", "copy",
+            "-disposition:v:0", primary_video_disposition,
         ]
         for output_index, stream in enumerate(copied_streams, start=1):
             args += [
                 f"-map_metadata:s:{output_index}",
-                f"1:s:{stream.index}",
+                f"{source_input_index}:s:{stream.index}",
             ]
         audio_streams = [
             stream for stream in copied_streams if stream.type == "audio"
@@ -656,12 +1225,4 @@ def mux_final_output(
     if destination.suffix.lower() in {".mp4", ".mov"}:
         tag = {"h264": "avc3", "hevc": "hev1", "av1": "av01"}[codec]
         args += ["-tag:v:0", tag, "-movflags", "+faststart"]
-    args.append(str(temporary))
-    try:
-        _run_ffmpeg(args, purpose=f"mux smart-render output {destination.name}")
-        os.replace(temporary, destination)
-    finally:
-        try:
-            temporary.unlink(missing_ok=True)
-        except OSError:
-            log.warning("Could not remove temporary output %s", temporary)
+    return args

--- a/jasna/media/video_decoder.py
+++ b/jasna/media/video_decoder.py
@@ -239,6 +239,7 @@ class NvidiaVideoReader:
         metadata: VideoMetadata,
         *,
         frame_stride: int = 1,
+        decode_backend: str | None = None,
     ):
         frame_stride = int(frame_stride)
         if frame_stride <= 0:
@@ -248,6 +249,8 @@ class NvidiaVideoReader:
         self.batch_size = batch_size
         self.metadata = metadata
         self.frame_stride = frame_stride
+        self.decode_backend = decode_backend
+        self._decode_backend: str | None = None
         self.vendor = vendor_for_device(device)
         self._decoder_ctx = None
         self._amd_hardware_decode = False
@@ -259,7 +262,12 @@ class NvidiaVideoReader:
         self._amd_hardware_decode = False
         self._vali_source = None
         current_stream(self.device)
-        backend = _decode_backend()
+        backend = self.decode_backend if self.decode_backend is not None else _decode_backend()
+        if backend not in _DECODE_BACKENDS:
+            raise ValueError(
+                f"Unknown decode backend {backend!r}, expected {_DECODE_BACKENDS}"
+            )
+        self._decode_backend = backend
         if backend in ("auto", "vali"):
             if self.vendor is AcceleratorVendor.NVIDIA:
                 try:

--- a/jasna/pipeline.py
+++ b/jasna/pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import bisect
 import gc
 import logging
 import os
@@ -23,12 +24,12 @@ from jasna.media.frame_rate import resolve_frame_rate_retarget
 from jasna.media.splice import (
     SplicePlan,
     build_splice_plan,
-    concatenate_fragments,
     create_copy_fragment,
-    mux_final_output,
+    mux_fragments_final_output,
     normalize_fragment,
     probe_keyframes,
     resolve_smart_encoder_settings,
+    validate_hevc_fragment_parameter_sets,
     validate_smart_render,
 )
 from jasna.mosaic.detection_registry import build_detection_model
@@ -679,26 +680,73 @@ class Pipeline:
                         )
                     else:
                         create_copy_fragment(self.input_video, span, index, raw, codec=codec)
-                    normalize_fragment(raw, normalized, codec=codec)
+                    if span.is_render:
+                        normalize_fragment(
+                            raw,
+                            normalized,
+                            codec=codec,
+                            decode_delay=index.decode_delay_pts * index.time_base,
+                        )
+                    else:
+                        normalize_fragment(raw, normalized, codec=codec)
                     fragments.append((normalized, duration))
 
                 if self._cancel_event.is_set():
                     return
-                assembled = temp_dir / f"assembled{fragment_suffix}"
-                concatenate_fragments(
+                if codec == "hevc":
+                    validate_hevc_fragment_parameter_sets(
+                        [
+                            (fragment, span.kind)
+                            for (fragment, _duration), span in zip(
+                                fragments,
+                                plan.spans,
+                            )
+                        ]
+                    )
+                mux_fragments_final_output(
                     fragments,
-                    manifest=temp_dir / "fragments.ffconcat",
-                    destination=assembled,
-                    codec=codec,
-                )
-                mux_final_output(
-                    assembled,
                     self.input_video,
                     self.output_video,
+                    manifest=temp_dir / "fragments.ffconcat",
                     codec=codec,
+                    copy_validation_ranges=(
+                        self._hevc_copy_validation_ranges(plan)
+                        if codec == "hevc"
+                        else ()
+                    ),
                 )
         finally:
             progress.close(ensure_completed_bar=True)
+
+    @staticmethod
+    def _hevc_copy_validation_ranges(
+        plan: SplicePlan,
+    ) -> tuple[tuple[float, float], ...]:
+        """Return one bounded GOP on every untouched side of a render seam."""
+
+        keyframes = plan.index.pts
+        ranges: set[tuple[int, int]] = set()
+        for span_index, span in enumerate(plan.spans):
+            if span.is_render:
+                continue
+            if span_index > 0 and plan.spans[span_index - 1].is_render:
+                next_keyframe = next(
+                    (pts for pts in keyframes if pts > span.start_pts),
+                    span.end_pts,
+                )
+                ranges.add((span.start_pts, min(span.end_pts, next_keyframe)))
+            if span_index + 1 < len(plan.spans) and plan.spans[span_index + 1].is_render:
+                previous_index = bisect.bisect_left(keyframes, span.end_pts) - 1
+                start_pts = keyframes[max(0, previous_index)]
+                ranges.add((max(span.start_pts, start_pts), span.end_pts))
+        return tuple(
+            (
+                plan.index.seconds_for_pts(start_pts),
+                float((end_pts - start_pts) * plan.index.time_base),
+            )
+            for start_pts, end_pts in sorted(ranges)
+            if end_pts > start_pts
+        )
 
     def run(self) -> None:
         metadata = get_video_meta_data(str(self.input_video))

--- a/jasna/pipeline_threads.py
+++ b/jasna/pipeline_threads.py
@@ -23,6 +23,197 @@ from jasna.tracking.scene_detector import SceneCutDetector
 
 log = logging.getLogger(__name__)
 
+PTS_RESYNC_HARDWARE_RETRIES = 2
+PTS_RESYNC_FORWARD_SCAN_LIMIT = 64
+
+
+class _PtsRecoveryCancelled(RuntimeError):
+    pass
+
+
+class _PtsAlignedFrameReader:
+    """Read exact source PTS and reopen the selected product route on divergence."""
+
+    def __init__(
+        self,
+        *,
+        input_video: str,
+        batch_size: int,
+        device: torch.device,
+        metadata,
+        frame_stride: int,
+        seek_ts: float | None,
+        cancel_event: threading.Event | None,
+    ) -> None:
+        self.input_video = input_video
+        self.batch_size = int(batch_size)
+        self.device = device
+        self.metadata = metadata
+        self.frame_stride = int(frame_stride)
+        self.seek_ts = seek_ts
+        self.cancel_event = cancel_event
+        self._reader: NvidiaVideoReader | None = None
+        self._frames = None
+        self._retry_backend: str | None = None
+        self._stream_start_pts = int(getattr(metadata, "start_pts", 0) or 0)
+
+    @staticmethod
+    def _flat_frames(reader: NvidiaVideoReader, seek_ts: float | None):
+        for batch, pts in reader.frames(seek_ts=seek_ts):
+            for index, frame_pts in enumerate(pts):
+                yield batch[index], int(frame_pts)
+
+    def __enter__(self):
+        self._open(self.seek_ts, decode_backend=None)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()
+
+    def close(self) -> None:
+        reader, self._reader = self._reader, None
+        frames, self._frames = self._frames, None
+        if frames is not None and hasattr(frames, "close"):
+            frames.close()
+        if reader is not None:
+            reader.__exit__(None, None, None)
+
+    def _open(self, seek_ts: float | None, *, decode_backend: str | None) -> None:
+        self.close()
+        reader = NvidiaVideoReader(
+            self.input_video,
+            batch_size=self.batch_size,
+            device=self.device,
+            metadata=self.metadata,
+            frame_stride=self.frame_stride,
+            decode_backend=decode_backend,
+        )
+        try:
+            entered = reader.__enter__()
+        except BaseException:
+            # The upstream reader only creates ``container`` after av.open()
+            # succeeds, while its __exit__ unconditionally closes it.  Preserve
+            # the original decoder error when opening failed before ownership
+            # was established, but still release a partially opened reader.
+            if (
+                getattr(reader, "container", None) is not None
+                or getattr(reader, "_vali_source", None) is not None
+            ):
+                reader.__exit__(None, None, None)
+            raise
+        self._reader = reader
+        self._frames = self._flat_frames(entered, seek_ts)
+        self._stream_start_pts = int(entered.start_pts)
+        self._retry_backend = str(entered._decode_backend)
+
+    def _next(self) -> tuple[torch.Tensor | None, int | None]:
+        if self.cancel_event is not None and self.cancel_event.is_set():
+            raise _PtsRecoveryCancelled("PTS recovery cancelled")
+        if self._frames is None:
+            return None, None
+        try:
+            return next(self._frames)
+        except StopIteration:
+            return None, None
+
+    def _scan_for_pts(
+        self,
+        expected_pts: int,
+        *,
+        first_frame: torch.Tensor | None = None,
+        first_pts: int | None = None,
+    ) -> tuple[torch.Tensor | None, int | None, int]:
+        frame, actual_pts = first_frame, first_pts
+        discarded = 0
+        for _ in range(PTS_RESYNC_FORWARD_SCAN_LIMIT + 1):
+            if actual_pts is None:
+                frame, actual_pts = self._next()
+            if actual_pts is None or actual_pts >= expected_pts:
+                return frame, actual_pts, discarded
+            discarded += 1
+            frame, actual_pts = self._next()
+        return frame, actual_pts, discarded
+
+    def _target_seek_seconds(self, expected_pts: int) -> float:
+        return max(
+            0.0,
+            float(
+                (int(expected_pts) - self._stream_start_pts)
+                * self.metadata.time_base
+            ),
+        )
+
+    def read_exact(self, expected_pts: int) -> torch.Tensor:
+        frame, actual_pts = self._next()
+        if actual_pts == expected_pts and frame is not None:
+            return frame
+
+        first_actual = actual_pts
+        if actual_pts is not None and actual_pts < expected_pts:
+            frame, actual_pts, discarded = self._scan_for_pts(
+                expected_pts,
+                first_frame=frame,
+                first_pts=actual_pts,
+            )
+            if actual_pts == expected_pts and frame is not None:
+                log.warning(
+                    "[blend-encode] PTS resynchronized by discarding %d stale "
+                    "secondary-reader frame(s): expected=%d first_actual=%d",
+                    discarded,
+                    expected_pts,
+                    first_actual,
+                )
+                return frame
+
+        seek_ts = self._target_seek_seconds(expected_pts)
+        observations: list[str] = []
+        retry_backend = self._retry_backend
+        attempts = [
+            (retry_backend, f"{retry_backend or 'decoder'} retry {attempt}")
+            for attempt in range(1, PTS_RESYNC_HARDWARE_RETRIES + 1)
+        ]
+        for backend, description in attempts:
+            if self.cancel_event is not None and self.cancel_event.is_set():
+                raise _PtsRecoveryCancelled("PTS recovery cancelled")
+            try:
+                self._open(seek_ts, decode_backend=backend)
+                frame, recovered_pts, discarded = self._scan_for_pts(expected_pts)
+            except _PtsRecoveryCancelled:
+                raise
+            except Exception as error:
+                observations.append(f"{description}: {type(error).__name__}: {error}")
+                log.warning(
+                    "[blend-encode] PTS recovery %s failed while reopening at "
+                    "PTS %d: %s",
+                    description,
+                    expected_pts,
+                    error,
+                )
+                continue
+
+            if recovered_pts == expected_pts and frame is not None:
+                log.warning(
+                    "[blend-encode] PTS mismatch recovered by %s at PTS %d "
+                    "(first_actual=%s, discarded=%d)",
+                    description,
+                    expected_pts,
+                    first_actual,
+                    discarded,
+                )
+                return frame
+            observations.append(
+                f"{description}: observed "
+                f"{recovered_pts if recovered_pts is not None else 'EOF'}"
+            )
+
+        self.close()
+        details = "; ".join(observations)
+        raise RuntimeError(
+            "[blend-encode] could not recover secondary-reader PTS mismatch: "
+            f"expected PTS {expected_pts}, initial actual PTS "
+            f"{first_actual if first_actual is not None else 'EOF'}; {details}"
+        )
+
 
 class FrameWriter(Protocol):
     def write(self, frame: torch.Tensor, pts: int, *, apply_lut: bool = True) -> None: ...
@@ -361,19 +552,15 @@ def blend_encode_loop(
     try:
         torch.cuda.set_device(device)
 
-        def _flat_frames(rdr: NvidiaVideoReader):
-            for batch, pts in rdr.frames(seek_ts=seek_ts):
-                for i in range(len(pts)):
-                    yield batch[i]
-
-        with NvidiaVideoReader(
-            input_video,
+        with _PtsAlignedFrameReader(
+            input_video=input_video,
             batch_size=batch_size,
             device=device,
             metadata=metadata,
             frame_stride=frame_stride,
+            seek_ts=seek_ts,
+            cancel_event=cancel_event,
         ) as reader2:
-            frame_gen = _flat_frames(reader2)
             secondary_done = False
             frames_encoded = 0
 
@@ -402,7 +589,7 @@ def blend_encode_loop(
                     break
                 meta: FrameMeta = meta_item
                 with timer.measure("decode"):
-                    original_frame = next(frame_gen)
+                    original_frame = reader2.read_exact(meta.pts)
 
                 with timer.measure("result-wait"):
                     while meta.apply_effect and not blend_buffer.is_frame_ready(meta.frame_idx):

--- a/tests/test_pipeline_segments.py
+++ b/tests/test_pipeline_segments.py
@@ -44,6 +44,7 @@ def test_smart_run_processes_only_render_spans_and_assembles_full_output(tmp_pat
         180,
         max_b_frames=3,
         uses_b_references=False,
+        decode_delay_pts=2,
     )
     plan = SplicePlan(
         index=index,
@@ -66,9 +67,8 @@ def test_smart_run_processes_only_render_spans_and_assembles_full_output(tmp_pat
         patch("jasna.pipeline.build_splice_plan") as build_splice_plan,
         patch("jasna.pipeline.NvidiaVideoEncoder") as encoder,
         patch("jasna.pipeline.create_copy_fragment") as copy_fragment,
-        patch("jasna.pipeline.normalize_fragment"),
-        patch("jasna.pipeline.concatenate_fragments") as concatenate,
-        patch("jasna.pipeline.mux_final_output") as mux,
+        patch("jasna.pipeline.normalize_fragment") as normalize_fragment,
+        patch("jasna.pipeline.mux_fragments_final_output") as mux,
     ):
         pipeline._run_smart(metadata)
 
@@ -92,8 +92,77 @@ def test_smart_run_processes_only_render_spans_and_assembles_full_output(tmp_pat
     assert pass_args["seek_ts"] == 2.0
     assert pass_args["end_pts"] == 120
     assert pass_args["effect_ranges"] == ((75, 90),)
-    concatenate.assert_called_once()
+    assert [call.kwargs for call in normalize_fragment.call_args_list] == [
+        {"codec": "h264"},
+        {"codec": "h264", "decode_delay": Fraction(1, 15)},
+        {"codec": "h264"},
+    ]
     mux.assert_called_once()
+    assert mux.call_args.args[0][0][0].parent == mux.call_args.kwargs["manifest"].parent
+
+
+def test_hevc_smart_run_checks_parameter_sets_and_bounded_copy_gops(tmp_path) -> None:
+    pipeline = object.__new__(Pipeline)
+    pipeline.input_video = tmp_path / "input.mkv"
+    pipeline.output_video = tmp_path / "output.mkv"
+    pipeline.codec = "hevc"
+    pipeline.encoder_settings = {"cq": 22}
+    pipeline.device = torch.device("cuda:0")
+    pipeline.disable_progress = True
+    pipeline.progress_callback = None
+    pipeline.lut_path = None
+    pipeline.sharpen_strength = 0.0
+    pipeline.retarget_high_fps = False
+    pipeline.segments = (SegmentRange(2.5, 3.0),)
+    pipeline.working_dir = tmp_path
+    pipeline._cancel_event = threading.Event()
+    pipeline._run_pass = MagicMock()
+    metadata = MagicMock(
+        video_fps=30.0,
+        video_fps_exact=Fraction(30, 1),
+        duration=6.0,
+        profile="Main 10",
+    )
+    plan = SplicePlan(
+        index=KeyframeIndex(
+            (0, 30, 60, 90, 120, 150),
+            Fraction(1, 30),
+            0,
+            180,
+        ),
+        spans=(
+            SpliceSpan("copy", 0, 60),
+            SpliceSpan("render", 60, 120, ((75, 90),)),
+            SpliceSpan("copy", 120, 180),
+        ),
+        segments=pipeline.segments,
+    )
+    pipeline.splice_plan = plan
+    with (
+        patch("jasna.pipeline.validate_smart_render", return_value="hevc"),
+        patch("jasna.pipeline.resolve_smart_encoder_settings", return_value={}),
+        patch("jasna.pipeline.NvidiaVideoEncoder") as encoder,
+        patch("jasna.pipeline.create_copy_fragment"),
+        patch("jasna.pipeline.normalize_fragment"),
+        patch("jasna.pipeline.validate_hevc_fragment_parameter_sets") as validate_sets,
+        patch("jasna.pipeline.mux_fragments_final_output") as mux,
+    ):
+        pipeline._run_smart(metadata)
+
+    assert encoder.call_args.kwargs["metadata"] is metadata
+    assert encoder.call_args.kwargs["output_fps"] == metadata.video_fps_exact
+    fragment_paths = [fragment for fragment, _duration in mux.call_args.args[0]]
+    validate_sets.assert_called_once_with(
+        [
+            (fragment_paths[0], "copy"),
+            (fragment_paths[1], "render"),
+            (fragment_paths[2], "copy"),
+        ]
+    )
+    assert mux.call_args.kwargs["copy_validation_ranges"] == (
+        (1.0, 1.0),
+        (4.0, 1.0),
+    )
 
 
 def test_smart_run_uses_working_dir_for_temp_files(tmp_path) -> None:
@@ -131,13 +200,13 @@ def test_smart_run_uses_working_dir_for_temp_files(tmp_path) -> None:
         patch("jasna.pipeline.NvidiaVideoEncoder"),
         patch("jasna.pipeline.create_copy_fragment"),
         patch("jasna.pipeline.normalize_fragment"),
-        patch("jasna.pipeline.concatenate_fragments"),
-        patch("jasna.pipeline.mux_final_output") as mux,
+        patch("jasna.pipeline.mux_fragments_final_output") as mux,
     ):
         pipeline._run_smart(metadata)
 
-    assembled = mux.call_args.args[0]
-    assert assembled.parent.parent == pipeline.working_dir
+    fragments = mux.call_args.args[0]
+    assert all(fragment.parent.parent == pipeline.working_dir for fragment, _ in fragments)
+    assert mux.call_args.kwargs["manifest"].parent.parent == pipeline.working_dir
     assert pipeline.working_dir.is_dir()
     assert pipeline.output_video.parent.is_dir()
 

--- a/tests/test_pipeline_threads.py
+++ b/tests/test_pipeline_threads.py
@@ -20,6 +20,8 @@ from jasna.media import VideoMetadata
 from jasna.pipeline_items import ClipRestoreItem, FrameMeta, PrimaryRestoreResult, SecondaryRestoreResult, _SENTINEL
 from jasna.pipeline_threads import (
     FrameWriter,
+    _PtsAlignedFrameReader,
+    _PtsRecoveryCancelled,
     decode_detect_loop,
     primary_restore_loop,
     secondary_restore_loop,
@@ -60,12 +62,57 @@ def _mock_reader(batches, seek_ts_check=None):
     return r
 
 
+class _ScriptedPtsReader:
+    def __init__(
+        self,
+        batches,
+        *,
+        start_pts: int = 0,
+        decode_backend: str = "auto",
+        on_first_batch=None,
+    ) -> None:
+        self.batches = list(batches)
+        self.start_pts = start_pts
+        self._decode_backend = decode_backend
+        self.on_first_batch = on_first_batch
+        self.seek_calls: list[float | None] = []
+        self.enter_calls = 0
+        self.exit_calls = 0
+
+    def __enter__(self):
+        self.enter_calls += 1
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.exit_calls += 1
+
+    def frames(self, seek_ts=None):
+        self.seek_calls.append(seek_ts)
+        for index, batch in enumerate(self.batches):
+            if index == 0 and self.on_first_batch is not None:
+                self.on_first_batch()
+            yield batch
+
+
+def _pts_batch(*pts: int) -> tuple[torch.Tensor, list[int]]:
+    return torch.tensor([[value] for value in pts]), list(pts)
+
+
+def _mock_exact_reader(frames: torch.Tensor, pts: list[int]):
+    reader = MagicMock()
+    reader.__enter__ = MagicMock(return_value=reader)
+    reader.__exit__ = MagicMock(return_value=False)
+    by_pts = {int(frame_pts): frames[index] for index, frame_pts in enumerate(pts)}
+    reader.read_exact.side_effect = lambda frame_pts: by_pts[int(frame_pts)]
+    return reader
+
+
 class _RecordingWriter:
     def __init__(self):
         self.written: list[tuple[torch.Tensor, int]] = []
         self.after_write_calls: list[int] = []
 
-    def write(self, frame: torch.Tensor, pts: int) -> None:
+    def write(self, frame: torch.Tensor, pts: int, *, apply_lut: bool = True) -> None:
         self.written.append((frame, pts))
 
     def after_write(self, frames_written: int) -> None:
@@ -84,6 +131,120 @@ class TestEstimateStartFrame:
     def test_zero(self):
         meta = _fake_metadata(fps=24.0)
         assert _estimate_start_frame(meta, 0.0) == 0
+
+
+# ---------------------------------------------------------------------------
+# _PtsAlignedFrameReader — exact secondary-reader PTS recovery
+# ---------------------------------------------------------------------------
+
+class TestPtsAlignedFrameReader:
+    def _reader(self, *, cancel_event=None, seek_ts=None):
+        return _PtsAlignedFrameReader(
+            input_video="fake.mkv",
+            batch_size=4,
+            device=torch.device("cpu"),
+            metadata=_fake_metadata(),
+            frame_stride=1,
+            seek_ts=seek_ts,
+            cancel_event=cancel_event,
+        )
+
+    def test_exact_pts_fast_path_uses_initial_reader(self):
+        source = _ScriptedPtsReader([_pts_batch(40)])
+        with patch("jasna.pipeline_threads.NvidiaVideoReader", return_value=source) as factory:
+            with self._reader() as reader:
+                frame = reader.read_exact(40)
+        assert torch.equal(frame, torch.tensor([40]))
+        factory.assert_called_once()
+        assert factory.call_args.kwargs["decode_backend"] is None
+        assert source.seek_calls == [None]
+
+    def test_open_failure_preserves_original_error_before_reader_ownership(self):
+        class _FailingReader:
+            def __init__(self) -> None:
+                self.exit_called = False
+
+            def __enter__(self):
+                raise RuntimeError("decoder open failed")
+
+            def __exit__(self, exc_type, exc_value, traceback) -> None:
+                self.exit_called = True
+                raise AssertionError("unopened reader must not be closed")
+
+        source = _FailingReader()
+        with patch("jasna.pipeline_threads.NvidiaVideoReader", return_value=source):
+            with pytest.raises(RuntimeError, match="decoder open failed"):
+                self._reader().__enter__()
+        assert source.exit_called is False
+
+    def test_discards_stale_frames_before_exact_pts(self):
+        source = _ScriptedPtsReader([_pts_batch(38, 39, 40)])
+        with patch("jasna.pipeline_threads.NvidiaVideoReader", return_value=source):
+            with self._reader() as reader:
+                frame = reader.read_exact(40)
+        assert torch.equal(frame, torch.tensor([40]))
+
+    def test_forward_mismatch_reopens_same_product_route(self):
+        first = _ScriptedPtsReader([_pts_batch(41)])
+        recovered = _ScriptedPtsReader([_pts_batch(40)])
+        with patch(
+            "jasna.pipeline_threads.NvidiaVideoReader",
+            side_effect=[first, recovered],
+        ) as factory:
+            with self._reader() as reader:
+                frame = reader.read_exact(40)
+        assert torch.equal(frame, torch.tensor([40]))
+        assert [call.kwargs["decode_backend"] for call in factory.call_args_list] == [
+            None,
+            "auto",
+        ]
+        assert recovered.seek_calls == [40 / 24]
+
+    def test_retries_selected_route_twice_before_succeeding(self):
+        first = _ScriptedPtsReader([_pts_batch(41)])
+        retry_one = _ScriptedPtsReader([_pts_batch(41)])
+        retry_two = _ScriptedPtsReader([_pts_batch(40)])
+        with patch(
+            "jasna.pipeline_threads.NvidiaVideoReader",
+            side_effect=[first, retry_one, retry_two],
+        ) as factory:
+            with self._reader() as reader:
+                frame = reader.read_exact(40)
+        assert torch.equal(frame, torch.tensor([40]))
+        assert [call.kwargs["decode_backend"] for call in factory.call_args_list] == [
+            None,
+            "auto",
+            "auto",
+        ]
+    def test_unrecoverable_mismatch_is_terminal_without_cpu_fallback(self):
+        first = _ScriptedPtsReader([_pts_batch(41)])
+        retry_one = _ScriptedPtsReader([_pts_batch(41)])
+        retry_two = _ScriptedPtsReader([])
+        with patch(
+            "jasna.pipeline_threads.NvidiaVideoReader",
+            side_effect=[first, retry_one, retry_two],
+        ) as factory:
+            with self._reader() as reader:
+                with pytest.raises(RuntimeError, match="could not recover secondary-reader PTS mismatch"):
+                    reader.read_exact(40)
+        assert [call.kwargs["decode_backend"] for call in factory.call_args_list] == [
+            None,
+            "auto",
+            "auto",
+        ]
+        assert "pyav-sw" not in repr(factory.call_args_list)
+
+    def test_cancellation_aborts_recovery_without_reopening(self):
+        cancel_event = threading.Event()
+        first = _ScriptedPtsReader(
+            [_pts_batch(41)],
+            on_first_batch=cancel_event.set,
+        )
+        with patch("jasna.pipeline_threads.NvidiaVideoReader", return_value=first) as factory:
+            with self._reader(cancel_event=cancel_event) as reader:
+                with pytest.raises(_PtsRecoveryCancelled, match="cancelled"):
+                    reader.read_exact(40)
+        factory.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -442,7 +603,7 @@ class TestBlendEncodeLoop:
                           encode_items=None, metadata_items=None,
                           seek_ts=None):
         frames_t = torch.randint(0, 256, (2, 3, 8, 8), dtype=torch.uint8)
-        reader = _mock_reader([(frames_t, [0, 1])])
+        reader = _mock_exact_reader(frames_t, [0, 1])
 
         blend_buffer = BlendBuffer(device=torch.device("cpu"))
         encode_queue = FrameQueue(max_frames=999)
@@ -461,7 +622,7 @@ class TestBlendEncodeLoop:
             frame_writer = _RecordingWriter()
 
         with (
-            patch("jasna.pipeline_threads.NvidiaVideoReader", return_value=reader),
+            patch("jasna.pipeline_threads._PtsAlignedFrameReader", return_value=reader),
             patch("jasna.pipeline_threads.torch.cuda.set_device"),
         ):
             blend_encode_loop(
@@ -497,15 +658,8 @@ class TestBlendEncodeLoop:
         vram_offloader.pause_stall_check.assert_called_once()
 
     def test_seek_ts_passed_to_reader(self):
-        received_seek = []
         frames_t = torch.randint(0, 256, (1, 3, 8, 8), dtype=torch.uint8)
-        reader = MagicMock()
-        reader.__enter__ = MagicMock(return_value=reader)
-        reader.__exit__ = MagicMock(return_value=False)
-        def _frames(seek_ts=None):
-            received_seek.append(seek_ts)
-            return iter([(frames_t, [0])])
-        reader.frames = _frames
+        reader = _mock_exact_reader(frames_t, [0])
 
         blend_buffer = BlendBuffer(device=torch.device("cpu"))
         blend_buffer.register_frame(0, set())
@@ -515,7 +669,10 @@ class TestBlendEncodeLoop:
         metadata_queue.put(_SENTINEL)
 
         with (
-            patch("jasna.pipeline_threads.NvidiaVideoReader", return_value=reader),
+            patch(
+                "jasna.pipeline_threads._PtsAlignedFrameReader",
+                return_value=reader,
+            ) as factory,
             patch("jasna.pipeline_threads.torch.cuda.set_device"),
         ):
             blend_encode_loop(
@@ -531,14 +688,56 @@ class TestBlendEncodeLoop:
                 seek_ts=5.0,
             )
 
-        assert received_seek == [5.0]
+        assert factory.call_args.kwargs["seek_ts"] == 5.0
+
+    def test_requests_original_frame_by_metadata_pts_not_position(self):
+        requested_pts: list[int] = []
+
+        class _ExactReader:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback) -> None:
+                return None
+
+            def read_exact(self, pts: int) -> torch.Tensor:
+                requested_pts.append(pts)
+                return torch.full((3, 8, 8), pts, dtype=torch.int64)
+
+        metadata_queue = Queue()
+        metadata_queue.put(FrameMeta(frame_idx=0, pts=100, apply_effect=False))
+        metadata_queue.put(FrameMeta(frame_idx=1, pts=300, apply_effect=False))
+        metadata_queue.put(_SENTINEL)
+        writer = _RecordingWriter()
+
+        with (
+            patch(
+                "jasna.pipeline_threads._PtsAlignedFrameReader",
+                return_value=_ExactReader(),
+            ),
+            patch("jasna.pipeline_threads.torch.cuda.set_device"),
+        ):
+            blend_encode_loop(
+                input_video="fake.mkv",
+                batch_size=2,
+                device=torch.device("cpu"),
+                metadata=_fake_metadata(),
+                blend_buffer=BlendBuffer(device=torch.device("cpu")),
+                encode_queue=FrameQueue(max_frames=8),
+                metadata_queue=metadata_queue,
+                error_holder=[],
+                frame_writer=writer,
+            )
+
+        assert requested_pts == [100, 300]
+        assert [pts for _frame, pts in writer.written] == [100, 300]
 
     def test_error_holder_propagates_in_wait_loop(self):
         blend_buffer = BlendBuffer(device=torch.device("cpu"))
         blend_buffer.register_frame(0, {99})
 
         frames_t = torch.randint(0, 256, (1, 3, 8, 8), dtype=torch.uint8)
-        reader = _mock_reader([(frames_t, [0])])
+        reader = _mock_exact_reader(frames_t, [0])
 
         encode_queue = FrameQueue(max_frames=999)
         metadata_queue = Queue(maxsize=999)
@@ -555,7 +754,7 @@ class TestBlendEncodeLoop:
         t.start()
 
         with (
-            patch("jasna.pipeline_threads.NvidiaVideoReader", return_value=reader),
+            patch("jasna.pipeline_threads._PtsAlignedFrameReader", return_value=reader),
             patch("jasna.pipeline_threads.torch.cuda.set_device"),
         ):
             blend_encode_loop(
@@ -578,7 +777,7 @@ class TestBlendEncodeLoop:
         blend_buffer.register_frame(0, {99})
 
         frames_t = torch.randint(0, 256, (1, 3, 8, 8), dtype=torch.uint8)
-        reader = _mock_reader([(frames_t, [0])])
+        reader = _mock_exact_reader(frames_t, [0])
 
         encode_queue = FrameQueue(max_frames=999)
         encode_queue.put(_SENTINEL)
@@ -589,7 +788,7 @@ class TestBlendEncodeLoop:
         writer = _RecordingWriter()
 
         with (
-            patch("jasna.pipeline_threads.NvidiaVideoReader", return_value=reader),
+            patch("jasna.pipeline_threads._PtsAlignedFrameReader", return_value=reader),
             patch("jasna.pipeline_threads.torch.cuda.set_device"),
         ):
             blend_encode_loop(
@@ -611,7 +810,7 @@ class TestBlendEncodeLoop:
         # loop simply hands the untouched source frame to blend_frame.
         original = torch.randint(0, 256, (1, 3, 8, 8), dtype=torch.uint8)
         blended_out = torch.full_like(original[0], 30)
-        reader = _mock_reader([(original, [0])])
+        reader = _mock_exact_reader(original, [0])
         blend_buffer = MagicMock()
         blend_buffer.is_frame_ready.return_value = True
         blend_buffer.blend_frame.return_value = blended_out
@@ -621,7 +820,7 @@ class TestBlendEncodeLoop:
         writer = _RecordingWriter()
 
         with (
-            patch("jasna.pipeline_threads.NvidiaVideoReader", return_value=reader),
+            patch("jasna.pipeline_threads._PtsAlignedFrameReader", return_value=reader),
             patch("jasna.pipeline_threads.torch.cuda.set_device"),
         ):
             blend_encode_loop(

--- a/tests/test_splice.py
+++ b/tests/test_splice.py
@@ -10,14 +10,20 @@ from av.video.reformatter import ColorRange, Colorspace
 from jasna.accelerator import AcceleratorVendor
 from jasna.media import VideoMetadata
 from jasna.media.splice import (
+    HevcParameterSet,
     KeyframeIndex,
     SpliceSpan,
     SmartRenderCompatibilityError,
     _analyze_packet_reordering,
+    _decoded_frame_hashes,
+    _hevc_copy_windows_match,
     _is_safe_random_access_packet,
     build_splice_plan,
     create_copy_fragment,
+    normalize_fragment,
+    probe_keyframes,
     resolve_smart_encoder_settings,
+    validate_hevc_fragment_parameter_sets,
     validate_smart_render,
 )
 from jasna.segments import SegmentRange
@@ -49,6 +55,97 @@ def _metadata(codec: str = "h264", **overrides) -> VideoMetadata:
 
 def _index(points=(0, 60, 120), end=180) -> KeyframeIndex:
     return KeyframeIndex(tuple(points), Fraction(1, 30), 0, end)
+
+
+class _Packet:
+    def __init__(
+        self,
+        *,
+        pts: int | None,
+        dts: int | None = None,
+        duration: int | None = None,
+        is_keyframe: bool = False,
+    ) -> None:
+        self.pts = pts
+        self.dts = dts
+        self.duration = duration
+        self.is_keyframe = is_keyframe
+
+    def __bytes__(self) -> bytes:
+        return b"packet"
+
+
+def test_keyframe_index_defaults_to_no_decode_delay() -> None:
+    assert _index().decode_delay_pts == 0
+
+
+def test_decoded_frame_hashes_seeks_from_nonzero_stream_start(tmp_path) -> None:
+    video = tmp_path / "offset.mkv"
+    video.write_bytes(b"fixture")
+    stream = MagicMock(start_time=21, time_base=Fraction(1, 1000))
+    container = MagicMock()
+    container.streams.video = [stream]
+    opened = MagicMock()
+    opened.__enter__.return_value = container
+    completed = MagicMock(
+        returncode=0,
+        stdout="#tb 0: 1/1000\n0, 0, 2023, 17, 123, framehash\n",
+        stderr="",
+    )
+    with (
+        patch("jasna.media.splice.av.open", return_value=opened),
+        patch("jasna.media.splice.resolve_executable", return_value="ffmpeg"),
+        patch("jasna.media.splice.subprocess.run", return_value=completed) as run,
+    ):
+        hashes = _decoded_frame_hashes(video, start=2.002, duration=1.0)
+    command = run.call_args.args[0]
+    assert command[command.index("-ss") + 1] == "2.023000000"
+    assert command[command.index("-to") + 1] == "3.023000000"
+    assert hashes == ((Fraction(2002, 1000), Fraction(17, 1000), 123, "framehash"),)
+
+
+def test_hevc_copy_windows_allow_only_boundary_and_constant_subframe_shift() -> None:
+    duration = Fraction(1001, 60_000)
+    source = tuple(
+        (Fraction(index, 60), duration, 100 + index, f"hash-{index}")
+        for index in range(4)
+    )
+    shift = Fraction(4, 1000)
+    output = tuple((frame[0] + shift, *frame[1:]) for frame in source[:-1])
+    assert _hevc_copy_windows_match(source, output)
+    changed = (*output[:-1], (*output[-1][:-1], "changed"))
+    assert not _hevc_copy_windows_match(source, changed)
+    drifting = tuple(
+        (frame[0] + shift + Fraction(index, 100), *frame[1:])
+        for index, frame in enumerate(source[:-1])
+    )
+    assert not _hevc_copy_windows_match(source, drifting)
+
+
+def test_hevc_parameter_set_comparison_preserves_fragment_rap_order(tmp_path) -> None:
+    def signature(prefix: str) -> tuple[HevcParameterSet, ...]:
+        return (
+            HevcParameterSet(32, 0, None, f"{prefix}-vps"),
+            HevcParameterSet(33, 0, 0, f"{prefix}-sps"),
+            HevcParameterSet(34, 0, 0, f"{prefix}-pps"),
+        )
+
+    config_a = signature("a")
+    config_b = signature("b")
+    fragments = [
+        (tmp_path / "copy-a.ts", "copy"),
+        (tmp_path / "render.ts", "render"),
+        (tmp_path / "copy-b.ts", "copy"),
+    ]
+    with (
+        patch(
+            "jasna.media.splice._probe_hevc_parameter_set_sequences",
+            side_effect=[(config_a,), (config_a, config_b), (config_b,)],
+        ),
+        pytest.raises(SmartRenderCompatibilityError) as rejected,
+    ):
+        validate_hevc_fragment_parameter_sets(fragments)
+    assert rejected.value.reason == "hevc_parameter_sets_incompatible"
 
 
 def test_plan_expands_to_keyframes_but_keeps_exact_effect_range() -> None:
@@ -91,6 +188,120 @@ def test_plan_rejects_range_shorter_than_timestamp_interval() -> None:
 def test_packet_reordering_detects_flat_and_hierarchical_b_frames() -> None:
     assert _analyze_packet_reordering((0, 4, 1, 2, 3, 8, 5, 6, 7)) == (3, False)
     assert _analyze_packet_reordering((0, 5, 3, 1, 2, 4, 10, 8, 6, 7, 9)) == (4, True)
+
+
+def test_probe_keyframes_uses_packet_tail_and_keyframe_decode_delay() -> None:
+    stream = MagicMock()
+    stream.codec_context.extradata = b""
+    stream.time_base = Fraction(1, 30)
+    stream.start_time = 100
+    stream.duration = 90
+    container = MagicMock()
+    container.__enter__.return_value = container
+    container.streams.video = [stream]
+    container.demux.return_value = [
+        _Packet(pts=100, dts=94, duration=3, is_keyframe=True),
+        _Packet(pts=190, dts=188, duration=0),
+    ]
+
+    with (
+        patch("jasna.media.splice.av.open", return_value=container),
+        patch("jasna.media.splice._is_safe_random_access_packet", return_value=True),
+    ):
+        index = probe_keyframes(Path("input.mp4"), _metadata())
+
+    assert index.pts == (100,)
+    assert index.end_pts == 191
+    assert index.decode_delay_pts == 6
+
+
+@pytest.mark.parametrize(
+    ("codec", "bitstream_filter", "muxer", "container_args"),
+    [
+        ("h264", "h264_mp4toannexb,dump_extra=freq=keyframe", "mpegts", ["-muxdelay", "0"]),
+        ("hevc", "hevc_mp4toannexb,dump_extra=freq=keyframe", "mpegts", ["-muxdelay", "0"]),
+        ("av1", "av1_metadata=td=insert,dump_extra=freq=keyframe", "matroska", ["-avoid_negative_ts", "make_zero"]),
+    ],
+)
+def test_normalize_fragment_preserves_default_timestamps(
+    codec: str,
+    bitstream_filter: str,
+    muxer: str,
+    container_args: list[str],
+) -> None:
+    source = Path("raw.nut")
+    destination = Path("normalized.media")
+    with (
+        patch("jasna.media.splice._fragment_pts_are_reordered") as reordered,
+        patch("jasna.media.splice._run_ffmpeg") as run_ffmpeg,
+    ):
+        normalize_fragment(source, destination, codec=codec)
+    reordered.assert_not_called()
+    assert run_ffmpeg.call_args.args[0] == [
+        "-i", str(source),
+        "-map", "0:v:0",
+        "-an",
+        "-c:v", "copy",
+        "-bsf:v", bitstream_filter,
+        *container_args,
+        "-f", muxer,
+        str(destination),
+    ]
+
+
+def test_normalize_fragment_adds_decode_delay_to_unreordered_render_output() -> None:
+    source = Path("raw.nut")
+    destination = Path("normalized.ts")
+    stream = MagicMock()
+    stream.time_base = Fraction(1, 90_000)
+    container = MagicMock()
+    container.__enter__.return_value = container
+    container.streams.video = [stream]
+    with (
+        patch("jasna.media.splice._fragment_pts_are_reordered", return_value=False),
+        patch("jasna.media.splice.av.open", return_value=container),
+        patch("jasna.media.splice._run_ffmpeg") as run_ffmpeg,
+    ):
+        normalize_fragment(
+            source,
+            destination,
+            codec="h264",
+            decode_delay=Fraction(1, 30),
+        )
+    assert run_ffmpeg.call_args.args[0] == [
+        "-i", str(source),
+        "-map", "0:v:0",
+        "-an",
+        "-c:v", "copy",
+        "-bsf:v", "h264_mp4toannexb,dump_extra=freq=keyframe,setts=pts=PTS:dts=PTS-3000",
+        "-muxdelay", "0",
+        "-output_ts_offset", "0.033333333",
+        "-avoid_negative_ts", "disabled",
+        "-f", "mpegts",
+        str(destination),
+    ]
+
+
+def test_normalize_fragment_skips_delay_for_reordered_packets() -> None:
+    source = Path("raw.nut")
+    destination = Path("normalized.ts")
+    container = MagicMock()
+    container.__enter__.return_value = container
+    container.streams.video = [MagicMock()]
+    container.demux.return_value = [
+        _Packet(pts=0), _Packet(pts=4), _Packet(pts=1), _Packet(pts=2), _Packet(pts=3),
+    ]
+    with (
+        patch("jasna.media.splice.av.open", return_value=container),
+        patch("jasna.media.splice._run_ffmpeg") as run_ffmpeg,
+    ):
+        normalize_fragment(
+            source,
+            destination,
+            codec="h264",
+            decode_delay=Fraction(1, 30),
+        )
+    assert "setts=" not in " ".join(run_ffmpeg.call_args.args[0])
 
 
 def test_smart_h264_settings_match_source_structure() -> None:

--- a/tests/test_splice_media.py
+++ b/tests/test_splice_media.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from fractions import Fraction
 import subprocess
 from pathlib import Path
 
@@ -10,13 +11,18 @@ import pytest
 from jasna.accelerator import AcceleratorVendor
 from jasna.media import get_video_meta_data
 from jasna.media.splice import (
+    SmartRenderCompatibilityError,
     SpliceSpan,
     concatenate_fragments,
     create_copy_fragment,
+    mux_fragments_final_output,
     mux_final_output,
     normalize_fragment,
+    probe_hevc_parameter_sets,
     probe_keyframes,
     resolve_smart_encoder_settings,
+    validate_hevc_copy_seams,
+    validate_hevc_fragment_parameter_sets,
 )
 from jasna.os_utils import resolve_executable, subprocess_no_window_kwargs
 
@@ -68,6 +74,92 @@ def test_h264_probe_resolves_source_compatible_smart_settings(tmp_path: Path) ->
         "bf": 3,
         "b_ref_mode": "disabled",
     }
+
+
+def test_normalize_fragment_applies_decode_delay_to_unreordered_h264(
+    tmp_path: Path,
+) -> None:
+    raw = tmp_path / "rendered.nut"
+    normalized = tmp_path / "rendered.ts"
+    _ffmpeg(
+        "-f", "lavfi", "-i", "testsrc2=size=160x96:rate=30:duration=1",
+        "-an",
+        "-c:v", "libx264",
+        "-bf", "0",
+        "-g", "30",
+        "-f", "nut",
+        str(raw),
+    )
+    normalize_fragment(
+        raw,
+        normalized,
+        codec="h264",
+        decode_delay=Fraction(1, 30),
+    )
+    with av.open(str(normalized)) as container:
+        packets = [
+            packet
+            for packet in container.demux(container.streams.video[0])
+            if packet.pts is not None and packet.dts is not None
+        ]
+    assert packets
+    assert any(packet.pts > packet.dts for packet in packets)
+
+
+def _make_hevc_source(path: Path, *, size: str = "160x96") -> None:
+    _ffmpeg(
+        "-f", "lavfi", "-i", f"testsrc2=size={size}:rate=12:duration=2",
+        "-an",
+        "-c:v", "libx265",
+        "-pix_fmt", "yuv420p10le",
+        "-x265-params", "keyint=12:min-keyint=12:scenecut=0:open-gop=0:repeat-headers=1",
+        str(path),
+    )
+
+
+def test_hevc_parameter_set_probe_reads_hvcc_and_annex_b(tmp_path: Path) -> None:
+    source = tmp_path / "source.mp4"
+    annex_b = tmp_path / "source.ts"
+    _make_hevc_source(source)
+    normalize_fragment(source, annex_b, codec="hevc")
+    hvcc_signature = probe_hevc_parameter_sets(source)
+    annex_b_signature = probe_hevc_parameter_sets(annex_b)
+    assert {item.nal_type for item in hvcc_signature} == {32, 33, 34}
+    assert hvcc_signature == annex_b_signature
+
+
+def test_hevc_parameter_set_collision_fails_closed(tmp_path: Path) -> None:
+    source = tmp_path / "source.mp4"
+    rendered = tmp_path / "rendered.mp4"
+    source_fragment = tmp_path / "source.ts"
+    rendered_fragment = tmp_path / "rendered.ts"
+    _make_hevc_source(source, size="160x96")
+    _make_hevc_source(rendered, size="176x96")
+    normalize_fragment(source, source_fragment, codec="hevc")
+    normalize_fragment(rendered, rendered_fragment, codec="hevc")
+    with pytest.raises(SmartRenderCompatibilityError) as rejected:
+        validate_hevc_fragment_parameter_sets(
+            [(source_fragment, "copy"), (rendered_fragment, "render")]
+        )
+    assert rejected.value.reason == "hevc_parameter_sets_incompatible"
+
+
+def test_hevc_copy_seam_gate_accepts_copy_and_rejects_reencode(tmp_path: Path) -> None:
+    source = tmp_path / "source.mp4"
+    reencoded = tmp_path / "reencoded.mp4"
+    _make_hevc_source(source)
+    _ffmpeg(
+        "-i", str(source),
+        "-an",
+        "-vf", "hue=s=0",
+        "-c:v", "libx265",
+        "-pix_fmt", "yuv420p10le",
+        str(reencoded),
+    )
+    validate_hevc_copy_seams(source, source, ((0.0, 1.0),))
+    with pytest.raises(SmartRenderCompatibilityError) as rejected:
+        validate_hevc_copy_seams(reencoded, source, ((0.0, 1.0),))
+    assert rejected.value.reason == "hevc_copy_seam_mismatch"
 
 
 @pytest.mark.parametrize(
@@ -148,11 +240,13 @@ def test_mixed_encoder_splice_decodes_with_exact_duration_and_audio(
     ("suffix", "expected_subtitle_codec", "expected_attachments"),
     [(".mkv", "srt", 1), (".mp4", "mov_text", 0)],
 )
+@pytest.mark.parametrize("fragment_route", [False, True])
 def test_final_mux_preserves_compatible_source_structure(
     tmp_path: Path,
     suffix: str,
     expected_subtitle_codec: str,
     expected_attachments: int,
+    fragment_route: bool,
 ) -> None:
     subtitle = tmp_path / "subtitle.srt"
     subtitle.write_text(
@@ -189,6 +283,7 @@ def test_final_mux_preserves_compatible_source_structure(
         "-map_metadata", "2",
         "-map_chapters", "2",
         "-metadata:s:v:0", "language=jpn",
+        "-disposition:v:0", "default+original",
         "-metadata:s:s:0", "language=pol",
         "-metadata:s:s:0", "title=Signs",
         "-disposition:s:0", "default+forced",
@@ -210,7 +305,16 @@ def test_final_mux_preserves_compatible_source_structure(
     )
     output = tmp_path / f"output{suffix}"
 
-    mux_final_output(assembled, source, output, codec="h264")
+    if fragment_route:
+        mux_fragments_final_output(
+            [(assembled, 2.0)],
+            source,
+            output,
+            manifest=tmp_path / "fragments.ffconcat",
+            codec="h264",
+        )
+    else:
+        mux_final_output(assembled, source, output, codec="h264")
 
     with av.open(str(output)) as container:
         assert container.metadata["title"] == "Source title"
@@ -219,6 +323,8 @@ def test_final_mux_preserves_compatible_source_structure(
             "Main",
         ]
         assert container.streams.video[0].metadata["language"] == "jpn"
+        assert container.streams.video[0].disposition.default
+        assert container.streams.video[0].disposition.original
         assert len(container.streams.audio) == 1
         assert len(container.streams.subtitles) == 1
         assert len(container.streams.attachments) == expected_attachments
@@ -240,7 +346,7 @@ def test_final_mux_preserves_compatible_source_structure(
         assert b"Opening subtitle" in subtitle_text
         if expected_attachments:
             output_attachment = container.streams.attachments[0]
-            assert output_attachment.name == "font.txt"
+            assert Path(output_attachment.name).name == "font.txt"
             assert output_attachment.mimetype == "text/plain"
             assert output_attachment.data == b"font payload"
 

--- a/tests/test_video_decoder_backends.py
+++ b/tests/test_video_decoder_backends.py
@@ -148,6 +148,42 @@ def test_unknown_backend_raises(monkeypatch) -> None:
         reader.__enter__()
 
 
+def test_reader_decode_backend_override_rejects_unknown_value(monkeypatch) -> None:
+    monkeypatch.setattr(module, "vendor_for_device", lambda _device: AcceleratorVendor.NVIDIA)
+    monkeypatch.setattr(module, "current_stream", lambda _device: None)
+    reader = module.NvidiaVideoReader(
+        "input.mp4",
+        4,
+        torch.device("cuda:0"),
+        _metadata(),
+        decode_backend="cpu-only",
+    )
+
+    with pytest.raises(ValueError, match="Unknown decode backend 'cpu-only'"):
+        reader.__enter__()
+
+
+def test_reader_decode_backend_override_takes_precedence_over_environment(monkeypatch) -> None:
+    monkeypatch.setenv(module.DECODE_BACKEND_ENV, "vali")
+    monkeypatch.setattr(module, "vendor_for_device", lambda _device: AcceleratorVendor.NVIDIA)
+    monkeypatch.setattr(module, "current_stream", lambda _device: None)
+    container = _fake_container(False)
+    monkeypatch.setattr(module.av, "open", MagicMock(return_value=container))
+    reader = module.NvidiaVideoReader(
+        "input.mp4",
+        4,
+        torch.device("cuda:0"),
+        _metadata(),
+        decode_backend="pyav-sw",
+    )
+
+    reader.__enter__()
+
+    assert reader._decode_backend == "pyav-sw"
+    assert module.av.open.call_args.kwargs == {}
+    assert container.streams.video[0].codec_context.thread_type == "AUTO"
+
+
 class _FakeVali:
     class TaskExecInfo:
         END_OF_STREAM = "END_OF_STREAM"


### PR DESCRIPTION
## Summary

- preserve packet-tail duration and decode-delay semantics across copied and rendered fragments
- align the secondary reader to exact source PTS with bounded same-backend recovery and explicit failure
- validate HEVC VPS/SPS/PPS compatibility and bounded copy-side seam windows
- mux fragment manifests directly into the final output while preserving compatible side streams

This is an independent root PR based directly on `main`.

## Validation

- `/home/latiao/vr_toolbox_jasna_linux/.venv/bin/python -m pytest -q tests/test_splice.py tests/test_splice_media.py tests/test_pipeline_run.py tests/test_pipeline_segments.py tests/test_pipeline_threads.py tests/test_video_decoder_backends.py`
- Result: `149 passed, 1 skipped`
- Module imports, compile checks, one-commit check, forbidden rocDecode/fallback scan, and `git diff --check` passed

## Scope

This PR does not change detection, Tracker, restoration, quality thresholds, B4 default, decoder vendor routing, or encoder bit depth. Unrecoverable PTS or HEVC seam mismatches fail explicitly instead of switching to hidden CPU/software fallback.

## Follow-up PRs that depend on this PR

- **Smart Render resume/workspace signature** — persists decode-delay and fragment compatibility inputs so a resumed job cannot reuse stale timestamp/seam state.
- **Durable Smart Render final output** — makes direct final mux and Stop/cancel cleanup crash-resilient after timestamp/seam correctness is established.
- **HEVC Smart Render encoder selection** — selects compatible HEVC rendered fragments after the separate encoder contract/correctness PRs land.
- **Automatic-range fallback provenance** — may fall back to full render only after the GUI persists proof that a range came from automatic scan; manually selected ranges must remain fail-closed.

This root is independent of Windows AMD decoder policy and the AMF interop core.
